### PR TITLE
Security Actions & Security Operation Handling

### DIFF
--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -160,6 +160,8 @@ RTEMS
 ruleset
 sc
 SCs
+SecurityAction
+SecurityActionSet
 SHA
 sipos
 speciality

--- a/mock-bpa-test/requirements_tests.py
+++ b/mock-bpa-test/requirements_tests.py
@@ -45,7 +45,7 @@ class _RequirementsCases(_TestSet):
                 [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
                 [1, 1, 0, 0, bytes.fromhex('526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
-            policy_config='0x186,0x187',
+            policy_config='0x1A6,0x1A7',
             is_implemented=True,
             is_working=True,
             expect_success=True,

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1113,6 +1113,8 @@ int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_
  */
 bool BSL_SecurityActionSet_IsConsistent(const BSL_SecurityActionSet_t *self);
 
+size_t BSL_SecurityActionSet_CountOperations(const BSL_SecurityActionSet_t *self);
+
 /** Count number of security operations present in this policy action set.
  *
  * @param[in] self This action set.

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -857,6 +857,20 @@ bool BSL_SecOper_IsRoleAcceptor(const BSL_SecOper_t *self);
  */
 bool BSL_SecOper_IsBIB(const BSL_SecOper_t *self);
 
+/**
+ * Retrieve the conclusion state of a security operation
+ * @param[in] self The security operation
+ * @return the conclusion state
+ */
+BSL_SecOper_ConclusionState_e BSL_SecOper_GetConclusion(const BSL_SecOper_t *self);
+
+/**
+ * Set the security operation conclusion state
+ * @param[in,out] self security operation to change conclusion state of
+ * @param[in] new_conclusion new conclusion to set to
+ */
+void BSL_SecOper_SetConclusion(BSL_SecOper_t *self, BSL_SecOper_ConclusionState_e new_conclusion);
+
 /// Forward declaration of this struct
 typedef struct BSL_AbsSecBlock_s BSL_AbsSecBlock_t;
 
@@ -1041,6 +1055,33 @@ const BSL_SecParam_t *BSL_SecOutcome_GetParamAt(const BSL_SecOutcome_t *self, si
 /// @return
 bool BSL_SecOutcome_IsInAbsSecBlock(const BSL_SecOutcome_t *self, const BSL_AbsSecBlock_t *abs_sec_block);
 
+size_t BSL_SecurityAction_Sizeof(void);
+
+bool BSL_SecurityAction_IsConsistent(const BSL_SecurityAction_t *self);
+
+void BSL_SecurityAction_Init(BSL_SecurityAction_t *self);
+
+void BSL_SecurityAction_Deinit(BSL_SecurityAction_t *self);
+
+int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *sec_oper);
+
+size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self);
+
+const BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index);
+
+/** @brief Increment a security failure for this action set
+ *
+ * @param[in,out] self Pointer to this security action set.
+ */
+void BSL_SecurityAction_IncrError(BSL_SecurityAction_t *self);
+
+/** @brief Returns count of failures after processing this action
+ *
+ * @param[in] self Pointer to this security action.
+ * @return Count of errors.
+ */
+size_t BSL_SecurityAction_CountErrors(const BSL_SecurityAction_t *self);
+
 /// @brief Returns size of the struct, helpful for dynamic allocation.
 /// @return Size of the struct
 size_t BSL_SecurityActionSet_Sizeof(void);
@@ -1051,19 +1092,6 @@ size_t BSL_SecurityActionSet_Sizeof(void);
  */
 void BSL_SecurityActionSet_Init(BSL_SecurityActionSet_t *self);
 
-/** @brief Increment a security failure for this action set
- *
- * @param[in,out] self Pointer to this security action set.
- */
-void BSL_SecurityActionSet_IncrError(BSL_SecurityActionSet_t *self);
-
-/** @brief Returns count of failures after processing this action set
- *
- * @param[in] self Pointer to this security action set.
- * @return Count of errors.
- */
-size_t BSL_SecurityActionSet_CountErrors(const BSL_SecurityActionSet_t *self);
-
 /** Zeroize, clear, and release itself and any owned resources.
  *
  * @param[in,out] self This action set.
@@ -1073,10 +1101,10 @@ void BSL_SecurityActionSet_Deinit(BSL_SecurityActionSet_t *self);
 /** @brief Append a security operation to the security action set
  *
  * @param[in,out] self This security action set.
- * @param[in] sec_oper Security operation to include.
+ * @param[in] action Action to include.
  * @return 0 on success, negative on error
  */
-int BSL_SecurityActionSet_AppendSecOper(BSL_SecurityActionSet_t *self, const BSL_SecOper_t *sec_oper);
+int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_SecurityAction_t *action);
 
 /** Return true if internal sanity and consistency checks pass
  *
@@ -1088,24 +1116,24 @@ bool BSL_SecurityActionSet_IsConsistent(const BSL_SecurityActionSet_t *self);
 /** Count number of security operations present in this policy action set.
  *
  * @param[in] self This action set.
- * @return Number of operations, 0 indicates no policy matched.
+ * @return Number of actions, 0 indicates no policy matched.
  */
-size_t BSL_SecurityActionSet_CountSecOpers(const BSL_SecurityActionSet_t *self);
+size_t BSL_SecurityActionSet_CountActions(const BSL_SecurityActionSet_t *self);
 
 /** Returns the Security Operation at the given index.
  *
  * @param[in] self This action set
  * @param[in] index index
- * @return pointer to security operation at given index, asserting false if not in bound
+ * @return pointer to action at given index, asserting false if not in bound
  */
-const BSL_SecOper_t *BSL_SecurityActionSet_GetSecOperAtIndex(const BSL_SecurityActionSet_t *self, size_t index);
+const BSL_SecurityAction_t *BSL_SecurityActionSet_GetActionAtIndex(const BSL_SecurityActionSet_t *self, size_t index);
 
-/** Get the error code after querying (inspecting) policy actions. Non-zero indicates error
+/** @brief Returns count of failures after processing this action set
  *
- * @param[in] self this action set
- * @return Anomaly on non-zero
+ * @param[in] self Pointer to this security action set.
+ * @return Count of errors.
  */
-int BSL_SecurityActionSet_GetErrCode(const BSL_SecurityActionSet_t *self);
+size_t BSL_SecurityActionSet_CountErrors(const BSL_SecurityActionSet_t *self);
 
 /// @brief Returns size of this struct type
 size_t BSL_SecurityResponseSet_Sizeof(void);

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1067,7 +1067,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
 
 size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self);
 
-const BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index);
+BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index);
 
 /** @brief Increment a security failure for this action set
  *

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1055,18 +1055,44 @@ const BSL_SecParam_t *BSL_SecOutcome_GetParamAt(const BSL_SecOutcome_t *self, si
 /// @return
 bool BSL_SecOutcome_IsInAbsSecBlock(const BSL_SecOutcome_t *self, const BSL_AbsSecBlock_t *abs_sec_block);
 
+/**
+ * @return size of security operation
+ */
 size_t BSL_SecurityAction_Sizeof(void);
 
+/**
+ * @return true if security action @param self is consistent
+ */
 bool BSL_SecurityAction_IsConsistent(const BSL_SecurityAction_t *self);
 
+/**
+ * Initialize security action
+ * @param self security action
+ */
 void BSL_SecurityAction_Init(BSL_SecurityAction_t *self);
 
+/**
+ * De-initialize security action
+ * @param self security action
+ */
 void BSL_SecurityAction_Deinit(BSL_SecurityAction_t *self);
 
+/**
+ * Add security operation to security action, with deterministic ordering
+ * @param self action to add security operation to
+ * @param sec_oper new security operation to add
+ * @return 0 if successful
+ */
 int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *sec_oper);
 
+/**
+ * @return number of security operation in the @param self action
+ */
 size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self);
 
+/**
+ * @return the security operation at @param index index in @param self security action
+ */
 BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index);
 
 /** @brief Increment a security failure for this action set
@@ -1113,6 +1139,9 @@ int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_
  */
 bool BSL_SecurityActionSet_IsConsistent(const BSL_SecurityActionSet_t *self);
 
+/**
+ * @return the total number of operations within each of the actions of @param self action set
+ */
 size_t BSL_SecurityActionSet_CountOperations(const BSL_SecurityActionSet_t *self);
 
 /** Count number of security operations present in this policy action set.

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1046,6 +1046,11 @@ void BSL_SecOutcome_AppendParam(BSL_SecOutcome_t *self, const BSL_SecParam_t *pa
  */
 size_t BSL_SecOutcome_CountParams(const BSL_SecOutcome_t *self);
 
+/** Get the security parameter from the security outcome at the provided index
+ * @param[in] self security outcome
+ * @param[in] index index to retrieve security parameter from
+ * @return Security parameter
+ */
 const BSL_SecParam_t *BSL_SecOutcome_GetParamAt(const BSL_SecOutcome_t *self, size_t index);
 
 /// @brief Returns true if this (the parameters and results) is contained within the given ASK
@@ -1079,19 +1084,24 @@ void BSL_SecurityAction_Deinit(BSL_SecurityAction_t *self);
 
 /**
  * Add security operation to security action, with deterministic ordering
- * @param self action to add security operation to
- * @param sec_oper new security operation to add
+ * @param[in,out] self action to add security operation to
+ * @param[in] sec_oper new security operation to add
  * @return 0 if successful
  */
 int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *sec_oper);
 
+/** Order the Security operations such that execution will be successful
+ * @param[in, out] self action to sort
+ */
+int BSL_SecurityAction_OrderSecOps(BSL_SecurityAction_t *self);
+
 /**
- * @return number of security operation in the @param self action
+ * @return number of security operation in the @param[in] self action
  */
 size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self);
 
 /**
- * @return the security operation at @param index index in @param self security action
+ * @return the security operation at @param[in] index index in @param[in] self security action
  */
 BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index);
 

--- a/src/BPSecLib_Public.h
+++ b/src/BPSecLib_Public.h
@@ -52,7 +52,8 @@ typedef struct BSL_SecurityResponseSet_s BSL_SecurityResponseSet_t;
 /// @brief Forward declaration of ::BSL_SecurityActionSet_s, which contains actions for BSL to process the Bundle.
 typedef struct BSL_SecurityActionSet_s BSL_SecurityActionSet_t;
 
-/// @brief Forward declaration of ::BSL_SecurityAction_s, which contains security operations for BSL to process the Bundle.
+/// @brief Forward declaration of ::BSL_SecurityAction_s, which contains security operations for BSL to process the
+/// Bundle.
 typedef struct BSL_SecurityAction_s BSL_SecurityAction_t;
 
 /// @brief Forward-declaration for structure containing callbacks to a security context.

--- a/src/BPSecLib_Public.h
+++ b/src/BPSecLib_Public.h
@@ -49,9 +49,10 @@ typedef struct BSL_LibCtx_s BSL_LibCtx_t;
 /// process the Bundle.
 typedef struct BSL_SecurityResponseSet_s BSL_SecurityResponseSet_t;
 
-/// @brief Forward declaration of ::BSL_SecurityActionSet_s, which contains information for BSL to process the Bundle.
+/// @brief Forward declaration of ::BSL_SecurityActionSet_s, which contains actions for BSL to process the Bundle.
 typedef struct BSL_SecurityActionSet_s BSL_SecurityActionSet_t;
 
+/// @brief Forward declaration of ::BSL_SecurityAction_s, which contains security operations for BSL to process the Bundle.
 typedef struct BSL_SecurityAction_s BSL_SecurityAction_t;
 
 /// @brief Forward-declaration for structure containing callbacks to a security context.

--- a/src/BPSecLib_Public.h
+++ b/src/BPSecLib_Public.h
@@ -52,6 +52,8 @@ typedef struct BSL_SecurityResponseSet_s BSL_SecurityResponseSet_t;
 /// @brief Forward declaration of ::BSL_SecurityActionSet_s, which contains information for BSL to process the Bundle.
 typedef struct BSL_SecurityActionSet_s BSL_SecurityActionSet_t;
 
+typedef struct BSL_SecurityAction_s BSL_SecurityAction_t;
+
 /// @brief Forward-declaration for structure containing callbacks to a security context.
 typedef struct BSL_SecCtxDesc_s BSL_SecCtxDesc_t;
 
@@ -76,6 +78,21 @@ typedef enum
     /// @brief Bundle egress to CLA
     BSL_POLICYLOCATION_CLOUT
 } BSL_PolicyLocation_e;
+
+/**
+ * @brief Indicates the conclusion state of a security operation
+ */
+typedef enum
+{
+    /// @brief Security operation is still pending action
+    BSL_SECOP_CONCLUSION_PENDING = 1,
+    /// @brief Security operation has concluded and succeeded
+    BSL_SECOP_CONCLUSION_SUCCESS,
+    /// @brief Security operation is invalid
+    BSL_SECOP_CONCLUSION_INVALID,
+    /// @brief Security operation has concluded and failed
+    BSL_SECOP_CONCLUSION_FAILURE
+} BSL_SecOper_ConclusionState_e;
 
 /** Block CRC types.
  * Defined in Section 4.2.1 of RFC 9171 @cite rfc9171.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,7 @@ set(BSL_DYNAMIC_C
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecOutcome.c
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecParam.c
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecResult.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecurityAction.c
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecurityActionSet.c
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecurityContext.c
   ${CMAKE_CURRENT_SOURCE_DIR}/backend/SecurityResultSet.c

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -133,10 +133,9 @@ int BSL_API_QuerySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *outp
         for (BSL_SecActionList_it(act_it, output_action_set->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
         {
             BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-            BSL_SecOperList_it_t secop_it;
-            for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
+            for (size_t j = 0; j < BSL_SecurityAction_CountSecOpers(act); j ++)
             {
-                BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
+                BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, j);
                 if (block.type_code != sec_oper->_service_type)
                 {
                     continue;
@@ -203,10 +202,9 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
     for (BSL_SecActionList_it(act_it, policy_actions->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
     {
         BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-        BSL_SecOperList_it_t secop_it;
-        for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
+        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i ++)
         {
-            BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
+            BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, i);
 
             BSL_SecOper_ConclusionState_e conclusion = BSL_SecOper_GetConclusion(sec_oper);
 

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -130,10 +130,11 @@ int BSL_API_QuerySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *outp
             continue;
         }
         BSL_SecActionList_it_t act_it;
-        for (BSL_SecActionList_it(act_it, output_action_set->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
+        for (BSL_SecActionList_it(act_it, output_action_set->actions); !BSL_SecActionList_end_p(act_it);
+             BSL_SecActionList_next(act_it))
         {
             BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-            for (size_t j = 0; j < BSL_SecurityAction_CountSecOpers(act); j ++)
+            for (size_t j = 0; j < BSL_SecurityAction_CountSecOpers(act); j++)
             {
                 BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, j);
                 if (block.type_code != sec_oper->_service_type)
@@ -199,10 +200,11 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
     bool must_drop = false;
 
     BSL_SecActionList_it_t act_it;
-    for (BSL_SecActionList_it(act_it, policy_actions->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
+    for (BSL_SecActionList_it(act_it, policy_actions->actions); !BSL_SecActionList_end_p(act_it);
+         BSL_SecActionList_next(act_it))
     {
         BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i ++)
+        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i++)
         {
             BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, i);
 
@@ -235,7 +237,8 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
                 }
                 case BSL_POLICYACTION_DROP_BUNDLE:
                 {
-                    BSL_LOG_WARNING("Deleting bundle due to block target num %lu security failure", sec_oper->target_block_num);
+                    BSL_LOG_WARNING("Deleting bundle due to block target num %lu security failure",
+                                    sec_oper->target_block_num);
                     must_drop = true;
                     break;
                 }

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -129,30 +129,36 @@ int BSL_API_QuerySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *outp
             BSL_LOG_WARNING("Failed to get block number %lu", blocks_array[i]);
             continue;
         }
-        for (size_t sec_op_index = 0; sec_op_index < output_action_set->sec_operations_count; sec_op_index++)
+        BSL_SecActionList_it_t act_it;
+        for (BSL_SecActionList_it(act_it, output_action_set->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
         {
-            BSL_SecOper_t *sec_oper = &output_action_set->sec_operations[sec_op_index];
-            if (block.type_code != sec_oper->_service_type)
+            BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
+            BSL_SecOperList_it_t secop_it;
+            for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
             {
-                continue;
-            }
-            // Now set it's sec_block
-            BSL_AbsSecBlock_t *abs_sec_block = calloc(1, BSL_AbsSecBlock_Sizeof());
-            BSL_Data_t         block_btsd    = { 0 };
-            BSL_Data_InitView(&block_btsd, block.btsd_len, block.btsd);
-            if (BSL_AbsSecBlock_DecodeFromCBOR(abs_sec_block, block_btsd) == 0)
-            {
-                if (BSL_AbsSecBlock_ContainsTarget(abs_sec_block, sec_oper->target_block_num))
+                BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
+                if (block.type_code != sec_oper->_service_type)
                 {
-                    sec_oper->sec_block_num = block.block_num;
+                    continue;
                 }
+                // Now set it's sec_block
+                BSL_AbsSecBlock_t *abs_sec_block = calloc(1, BSL_AbsSecBlock_Sizeof());
+                BSL_Data_t         block_btsd    = { 0 };
+                BSL_Data_InitView(&block_btsd, block.btsd_len, block.btsd);
+                if (BSL_AbsSecBlock_DecodeFromCBOR(abs_sec_block, block_btsd) == 0)
+                {
+                    if (BSL_AbsSecBlock_ContainsTarget(abs_sec_block, sec_oper->target_block_num))
+                    {
+                        sec_oper->sec_block_num = block.block_num;
+                    }
+                }
+                else
+                {
+                    BSL_LOG_WARNING("Failed to parse ASB from BTSD");
+                }
+                BSL_AbsSecBlock_Deinit(abs_sec_block);
+                free(abs_sec_block);
             }
-            else
-            {
-                BSL_LOG_WARNING("Failed to parse ASB from BTSD");
-            }
-            BSL_AbsSecBlock_Deinit(abs_sec_block);
-            free(abs_sec_block);
         }
     }
 
@@ -188,60 +194,64 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
         return BSL_ERR_HOST_CALLBACK_FAILED;
     }
 
-    // There should be as many responses as there were sec operations
-    ASSERT_PROPERTY(response_output->total_operations == policy_actions->sec_operations_count);
-
     int finalize_status = BSL_PolicyRegistry_FinalizeActions(bsl, policy_actions, bundle, response_output);
     BSL_LOG_INFO("Completed finalize: status=%d", finalize_status);
 
     bool must_drop = false;
-    for (size_t oper_index = 0; oper_index < policy_actions->sec_operations_count; oper_index++)
+
+    BSL_SecActionList_it_t act_it;
+    for (BSL_SecActionList_it(act_it, policy_actions->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
     {
-        // First, get the error code for the security operation ()
-        int                block_err_code  = response_output->results[oper_index];
-        BSL_PolicyAction_e err_action_code = policy_actions->sec_operations[oper_index].failure_code;
-
-        // When the operation was a success, there's nothing further to do.
-        if (block_err_code == BSL_SUCCESS)
+        BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
+        BSL_SecOperList_it_t secop_it;
+        for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
         {
-            BSL_LOG_DEBUG("Security operation [%lu] success, target block num = %lu", oper_index,
-                          policy_actions->sec_operations[oper_index].target_block_num);
-            continue;
-        }
+            BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
 
-        // Now handle a specific error
-        switch (err_action_code)
-        {
-            case BSL_POLICYACTION_NOTHING:
+            BSL_SecOper_ConclusionState_e conclusion = BSL_SecOper_GetConclusion(sec_oper);
+
+            // When the operation was a success, there's nothing further to do.
+            if (conclusion == BSL_SECOP_CONCLUSION_SUCCESS)
             {
-                // Do nothing, per policy (Indicate in telemetry.)
-                BSL_LOG_WARNING("Instructed to do nothing for failed security operation");
+                BSL_LOG_DEBUG("Security operation success, target block num = %lu", sec_oper->target_block_num);
+                continue;
+            }
+
+            BSL_PolicyAction_e err_action_code = sec_oper->failure_code;
+
+            // Now handle a specific error
+            switch (err_action_code)
+            {
+                case BSL_POLICYACTION_NOTHING:
+                {
+                    // Do nothing, per policy (Indicate in telemetry.)
+                    BSL_LOG_WARNING("Instructed to do nothing for failed security operation");
+                    break;
+                }
+                case BSL_POLICYACTION_DROP_BLOCK:
+                {
+                    // Drop the failed target block, but otherwise continue
+                    BSL_LOG_WARNING("***** Dropping block over which security operation failed *******");
+                    BSL_BundleCtx_RemoveBlock(bundle, sec_oper->target_block_num);
+                    break;
+                }
+                case BSL_POLICYACTION_DROP_BUNDLE:
+                {
+                    BSL_LOG_WARNING("Deleting bundle due to block target num %lu security failure", sec_oper->target_block_num);
+                    must_drop = true;
+                    break;
+                }
+                case BSL_POLICYACTION_UNDEFINED:
+                default:
+                {
+                    BSL_LOG_ERR("Unhandled policy action: %lu", err_action_code);
+                }
+            }
+
+            if (must_drop)
+            {
                 break;
             }
-            case BSL_POLICYACTION_DROP_BLOCK:
-            {
-                // Drop the failed target block, but otherwise continue
-                BSL_LOG_WARNING("***** Dropping block over which security operation failed *******");
-                BSL_BundleCtx_RemoveBlock(bundle, policy_actions->sec_operations[oper_index].target_block_num);
-                break;
-            }
-            case BSL_POLICYACTION_DROP_BUNDLE:
-            {
-                BSL_LOG_WARNING("Deleting bundle due to block target num %lu security failure",
-                                policy_actions->sec_operations[oper_index].target_block_num);
-                must_drop = true;
-                break;
-            }
-            case BSL_POLICYACTION_UNDEFINED:
-            default:
-            {
-                BSL_LOG_ERR("Unhandled policy action: %lu", err_action_code);
-            }
-        }
-
-        if (must_drop)
-        {
-            break;
         }
     }
 

--- a/src/backend/SecOperation.c
+++ b/src/backend/SecOperation.c
@@ -47,6 +47,8 @@ void BSL_SecOper_Init(BSL_SecOper_t *self, uint64_t context_id, uint64_t target_
     self->_role            = sec_role;
     self->conclusion       = BSL_SECOP_CONCLUSION_PENDING;
 
+    M_ILIST_INIT_FIELD(BSL_SecOperList, *self);
+
     ASSERT_POSTCONDITION(BSL_SecOper_IsConsistent(self));
 }
 

--- a/src/backend/SecOperation.c
+++ b/src/backend/SecOperation.c
@@ -47,8 +47,6 @@ void BSL_SecOper_Init(BSL_SecOper_t *self, uint64_t context_id, uint64_t target_
     self->_role            = sec_role;
     self->conclusion       = BSL_SECOP_CONCLUSION_PENDING;
 
-    M_ILIST_INIT_FIELD(BSL_SecOperList, *self);
-
     ASSERT_POSTCONDITION(BSL_SecOper_IsConsistent(self));
 }
 

--- a/src/backend/SecOperation.c
+++ b/src/backend/SecOperation.c
@@ -98,8 +98,6 @@ uint64_t BSL_SecOper_GetSecurityBlockNum(const BSL_SecOper_t *self)
 
 uint64_t BSL_SecOper_GetTargetBlockNum(const BSL_SecOper_t *self)
 {
-    BSL_LOG_INFO("GET TARGET BLOCK NUM (SEC_OPER %lu) %d", self, self->target_block_num);
-
     ASSERT_PRECONDITION(BSL_SecOper_IsConsistent(self));
 
     return self->target_block_num;

--- a/src/backend/SecOperation.h
+++ b/src/backend/SecOperation.h
@@ -49,15 +49,13 @@ struct BSL_SecOper_s
     /// @brief Code for handing what to do to the block or bundle if security processing fails.
     BSL_PolicyAction_e failure_code;
 
+    /// @brief Conclusion state of security operation processing
+    BSL_SecOper_ConclusionState_e conclusion;
+
     /// @brief Private enumeration indicating the role (e.g., acceptor vs verifier)
     BSL_SecRole_e       _role;
     BSL_SecBlockType_e  _service_type;
     BSLB_SecParamList_t _param_list;
 };
-
-// NOLINTBEGIN
-/// @todo - replace with forward declaration. Use new policy structure.
-LIST_DEF(BSLB_SecOperList, BSL_SecOper_t, M_POD_OPLIST)
-// NOLINTEND
 
 #endif /* BSLB_SECOPERATIONS_H_ */

--- a/src/backend/SecOperation.h
+++ b/src/backend/SecOperation.h
@@ -28,11 +28,7 @@
 #define BSLB_SECOPERATIONS_H_
 
 #include <stdint.h>
-
-#include <m-i-list.h>
-
 #include <BPSecLib_Private.h>
-
 #include "SecParam.h"
 
 struct BSL_SecOper_s
@@ -56,8 +52,6 @@ struct BSL_SecOper_s
     BSL_SecRole_e       _role;
     BSL_SecBlockType_e  _service_type;
     BSLB_SecParamList_t _param_list;
-
-    ILIST_INTERFACE (BSL_SecOperList, struct BSL_SecOper_s);
 };
 
 #endif /* BSLB_SECOPERATIONS_H_ */

--- a/src/backend/SecOperation.h
+++ b/src/backend/SecOperation.h
@@ -29,7 +29,7 @@
 
 #include <stdint.h>
 
-#include <m-list.h>
+#include <m-i-list.h>
 
 #include <BPSecLib_Private.h>
 
@@ -56,6 +56,8 @@ struct BSL_SecOper_s
     BSL_SecRole_e       _role;
     BSL_SecBlockType_e  _service_type;
     BSLB_SecParamList_t _param_list;
+
+    ILIST_INTERFACE (BSL_SecOperList, struct BSL_SecOper_s);
 };
 
 #endif /* BSLB_SECOPERATIONS_H_ */

--- a/src/backend/SecParam.c
+++ b/src/backend/SecParam.c
@@ -107,7 +107,7 @@ bool BSL_SecParam_IsConsistent(const BSL_SecParam_t *self)
 {
     CHK_AS_BOOL(self != NULL);
     CHK_AS_BOOL(self->param_id > 0);
-    CHK_AS_BOOL(self->_type > BSL_SECPARAM_TYPE_UNKNOWN && self->_type <= BSL_SECPARAM_TYPE_BYTESTR);
+    CHK_AS_BOOL(self->_type > BSL_SECPARAM_TYPE_UNKNOWN && self->_type <= BSL_SECPARAM_TYPE_STR);
 
     if (self->_type == BSL_SECPARAM_TYPE_INT64)
     {

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -71,6 +71,13 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
         {
             // SOURCE BIB or ACCEPT BCB should come first
             // true if ACC BIB or SRC BCB
+
+            // Both BIBs or BCBs
+            if (!(BSL_SecOper_IsBIB(sec_oper) ^ BSL_SecOper_IsBIB(comp)))
+            {
+                BSL_SecOper_SetConclusion(sec_oper, BSL_SECOP_CONCLUSION_INVALID);
+            }
+
             if (BSL_SecOper_IsBIB(sec_oper) ^ BSL_SecOper_IsRoleSource(sec_oper))
             {
                 BSL_SecOperList_push_at(self->sec_op_list, i + 1, *sec_oper);

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -1,0 +1,79 @@
+#include "SecurityAction.h"
+
+size_t BSL_SecurityAction_Sizeof(void)
+{
+    return sizeof(BSL_SecurityAction_t);
+}
+
+bool BSL_SecurityAction_IsConsistent(const BSL_SecurityAction_t *self)
+{
+    (void) self;
+    return true;
+}
+
+void BSL_SecurityAction_Init(BSL_SecurityAction_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+
+    BSL_SecOperList_init(self->sec_op_list);
+    self->sec_op_list_length = 0;
+    self->err_ct = 0;
+}
+
+void BSL_SecurityAction_Deinit(BSL_SecurityAction_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+
+    BSL_SecOperList_clear(self->sec_op_list);
+}
+
+void BSL_SecurityAction_IncrError(BSL_SecurityAction_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+    self->err_ct++;
+}
+
+size_t BSL_SecurityAction_CountErrors(const BSL_SecurityAction_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+    return self->err_ct;
+}
+
+int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *sec_oper)
+{
+    ASSERT_ARG_NONNULL(self);
+
+    BSL_SecOperList_it_t it;
+    for (BSL_SecOperList_it(it, self->sec_op_list); !BSL_SecOperList_end_p(it); BSL_SecOperList_next(it))
+    {
+        if (BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)) == BSL_SecOper_GetTargetBlockNum(sec_oper))
+        {
+            if (!(BSL_SecOper_IsBIB(BSL_SecOperList_cref(it)) ^ BSL_SecOper_IsBIB(sec_oper)))
+            {
+                BSL_SecOper_SetConclusion(sec_oper, BSL_SECOP_CONCLUSION_INVALID);
+            }
+            BSL_SecOperList_insert(self->sec_op_list, it, *sec_oper);
+            self->sec_op_list_length ++;
+            return BSL_SUCCESS;
+        }
+    }
+
+    // Target not shared, order doesn't matter
+
+    BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);
+    self->sec_op_list_length ++;
+
+    return BSL_SUCCESS;
+}
+
+size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+    return self->sec_op_list_length;
+}
+
+const BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index)
+{
+    ASSERT_ARG_NONNULL(self);
+    return BSL_SecOperList_cget(self->sec_op_list, index);
+}

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -44,8 +44,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
     ASSERT_ARG_NONNULL(self);
 
     BSL_SecOperList_it_t it;
-    BSL_SecOperList_it_t it2;
-    bool first_it = true;
+
     for (BSL_SecOperList_it(it, self->sec_op_list); !BSL_SecOperList_end_p(it); BSL_SecOperList_next(it))
     {
         // New sec block shares target with another sec block
@@ -57,18 +56,15 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
                 // It seems the m*lib docs is incorrect here -
                 // it states that an uninitialized it2 = insert at front, but it was causing errors
                 // So, let's use a simple bool and check
-                if (first_it)
-                {
-                    BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);
-                }
-                else
-                {
-                    BSL_SecOperList_insert(self->sec_op_list, it2, *sec_oper);
-                }
+
+                // TODO BEFORE
+                BSL_SecOperList_previous(it);
+                BSL_SecOperList_push_after(BSL_SecOperList_ref(it), sec_oper);
+                BSL_SecOperList_next(it);
             }
             else
             {
-                BSL_SecOperList_insert(self->sec_op_list, it, *sec_oper);
+                BSL_SecOperList_push_after(BSL_SecOperList_ref(it), sec_oper);
             }
 
             if (!(BSL_SecOper_IsBIB(BSL_SecOperList_cref(it)) ^ BSL_SecOper_IsBIB(sec_oper)))
@@ -83,32 +79,24 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
         // New sec block is the target of another sec block
         if (BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)) == BSL_SecOper_GetSecurityBlockNum(sec_oper))
         {
-            if (first_it)
-            {
-                BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);
-            }
-            else
-            {
-                BSL_SecOperList_insert(self->sec_op_list, it2, *sec_oper);
-            }
+            BSL_SecOperList_previous(it);
+            BSL_SecOperList_push_after(BSL_SecOperList_ref(it), sec_oper);
+            BSL_SecOperList_next(it);
             self->sec_op_list_length ++;
             return BSL_SUCCESS;
         }
 
-        if (first_it)
+        // New sec block targets a block already in list
+        if (BSL_SecOper_GetTargetBlockNum(sec_oper) == BSL_SecOper_GetSecurityBlockNum(BSL_SecOperList_cref(it)))
         {
-            BSL_SecOperList_it(it2, self->sec_op_list);
-            first_it = false;
-        }
-        else
-        {
-            BSL_SecOperList_next(it2);
+            BSL_SecOperList_push_after(BSL_SecOperList_ref(it), sec_oper);
+            self->sec_op_list_length ++;
+            return BSL_SUCCESS;
         }
     }
 
     // Target not shared, order doesn't matter
-
-    BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);
+    BSL_SecOperList_push_back(self->sec_op_list, sec_oper);
     self->sec_op_list_length ++;
 
     return BSL_SUCCESS;
@@ -123,5 +111,14 @@ size_t BSL_SecurityAction_CountSecOpers(const BSL_SecurityAction_t *self)
 BSL_SecOper_t *BSL_SecurityAction_GetSecOperAtIndex(const BSL_SecurityAction_t *self, size_t index)
 {
     ASSERT_ARG_NONNULL(self);
-    return BSL_SecOperList_get(self->sec_op_list, index);
+    ASSERT_ARG_NONNULL(self->sec_op_list);
+    size_t n = 0;
+    for M_EACH(item, self->sec_op_list, ILIST_OPLIST(BSL_SecOperList)) {
+        if (n == index)
+        {
+            return item;
+        }
+        n++;
+    }
+    return NULL;
 }

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
 #include "SecurityAction.h"
 
 size_t BSL_SecurityAction_Sizeof(void)
@@ -7,7 +28,7 @@ size_t BSL_SecurityAction_Sizeof(void)
 
 bool BSL_SecurityAction_IsConsistent(const BSL_SecurityAction_t *self)
 {
-    (void) self;
+    (void)self;
     return true;
 }
 
@@ -43,7 +64,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
     ASSERT_ARG_NONNULL(self);
     ASSERT_ARG_NONNULL(self->sec_op_list);
     size_t i;
-    for (i = 0 ; i < BSL_SecOperList_size(self->sec_op_list); i ++)
+    for (i = 0; i < BSL_SecOperList_size(self->sec_op_list); i++)
     {
         BSL_SecOper_t *comp = BSL_SecOperList_get(self->sec_op_list, i);
         if (BSL_SecOper_GetTargetBlockNum(comp) == BSL_SecOper_GetTargetBlockNum(sec_oper))
@@ -52,7 +73,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
             // true if ACC BIB or SRC BCB
             if (BSL_SecOper_IsBIB(sec_oper) ^ BSL_SecOper_IsRoleSource(sec_oper))
             {
-                BSL_SecOperList_push_at(self->sec_op_list, i+1, *sec_oper);
+                BSL_SecOperList_push_at(self->sec_op_list, i + 1, *sec_oper);
             }
             else
             {
@@ -71,7 +92,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
         // new security operation targets security operation in list
         if (BSL_SecOper_GetTargetBlockNum(sec_oper) == BSL_SecOper_GetSecurityBlockNum(comp))
         {
-            BSL_SecOperList_push_at(self->sec_op_list, i+1, *sec_oper);
+            BSL_SecOperList_push_at(self->sec_op_list, i + 1, *sec_oper);
             break;
         }
 
@@ -84,7 +105,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
             }
             else
             {
-                BSL_SecOperList_push_at(self->sec_op_list, i+1, *sec_oper);
+                BSL_SecOperList_push_at(self->sec_op_list, i + 1, *sec_oper);
             }
             break;
         }
@@ -94,7 +115,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
     {
         BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);
     }
-    
+
     return BSL_SUCCESS;
 }
 

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -52,8 +52,10 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
             {
                 BSL_SecOper_SetConclusion(sec_oper, BSL_SECOP_CONCLUSION_INVALID);
             }
+            BSL_LOG_INFO("Inserting secop (tgt=%d) (ctx=%d) AFTER same target", sec_oper->target_block_num, sec_oper->context_id);
             BSL_SecOperList_insert(self->sec_op_list, it, *sec_oper);
             self->sec_op_list_length ++;
+            BSL_LOG_INFO("len struct %lu, len mlib %lu", self->sec_op_list_length, BSL_SecOperList_size(self->sec_op_list));
             return BSL_SUCCESS;
         }
     }

--- a/src/backend/SecurityAction.c
+++ b/src/backend/SecurityAction.c
@@ -43,8 +43,6 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
 {
     ASSERT_ARG_NONNULL(self);
 
-    BSL_LOG_INFO("APPENDING SECOP: %lu ; tgt=%d; sc=%d", sec_oper, BSL_SecOper_GetTargetBlockNum(sec_oper), BSL_SecOper_GetSecurityBlockNum(sec_oper));
-
     BSL_SecOperList_it_t it;
     BSL_SecOperList_it_t it2;
     bool first_it = true;
@@ -55,9 +53,7 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
         {
             bool before = !(BSL_SecOper_IsBIB(sec_oper) ^ BSL_SecOper_IsRoleSource(sec_oper));
             if (before)
-            {
-                BSL_LOG_INFO("INSERTING NEW SEC OP BEFORE (tgt=%d)", BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)));
-                
+            {                
                 // It seems the m*lib docs is incorrect here -
                 // it states that an uninitialized it2 = insert at front, but it was causing errors
                 // So, let's use a simple bool and check
@@ -72,7 +68,6 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
             }
             else
             {
-                BSL_LOG_INFO("INSERTING NEW SEC OP AFTER (tgt=%d)", BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)));
                 BSL_SecOperList_insert(self->sec_op_list, it, *sec_oper);
             }
 
@@ -88,7 +83,6 @@ int BSL_SecurityAction_AppendSecOper(BSL_SecurityAction_t *self, BSL_SecOper_t *
         // New sec block is the target of another sec block
         if (BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)) == BSL_SecOper_GetSecurityBlockNum(sec_oper))
         {
-            BSL_LOG_INFO("NEW SEC OP IS TGT, INSERTING AFTER (ptr=%lu)(tgt=%d)", sec_oper, BSL_SecOper_GetTargetBlockNum(BSL_SecOperList_cref(it)));
             if (first_it)
             {
                 BSL_SecOperList_push_back(self->sec_op_list, *sec_oper);

--- a/src/backend/SecurityAction.h
+++ b/src/backend/SecurityAction.h
@@ -1,0 +1,14 @@
+#include "m-list.h"
+#include <BPSecLib_Private.h>
+#include "SecOperation.h"
+
+// NOLINTBEGIN
+LIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
+// NOLINTEND
+
+struct BSL_SecurityAction_s
+{
+    BSL_SecOperList_t sec_op_list;
+    size_t sec_op_list_length;
+    size_t err_ct;
+};

--- a/src/backend/SecurityAction.h
+++ b/src/backend/SecurityAction.h
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
 #include <m-array.h>
 #include <BPSecLib_Private.h>
 #include "SecOperation.h"
@@ -9,5 +30,5 @@ ARRAY_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(B
 struct BSL_SecurityAction_s
 {
     BSL_SecOperList_t sec_op_list;
-    size_t err_ct;
+    size_t            err_ct;
 };

--- a/src/backend/SecurityAction.h
+++ b/src/backend/SecurityAction.h
@@ -1,9 +1,10 @@
-#include "m-list.h"
+#include "m-i-list.h"
 #include <BPSecLib_Private.h>
 #include "SecOperation.h"
 
 // NOLINTBEGIN
-LIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
+// LIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
+ILIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
 // NOLINTEND
 
 struct BSL_SecurityAction_s

--- a/src/backend/SecurityAction.h
+++ b/src/backend/SecurityAction.h
@@ -1,15 +1,13 @@
-#include "m-i-list.h"
+#include <m-array.h>
 #include <BPSecLib_Private.h>
 #include "SecOperation.h"
 
 // NOLINTBEGIN
-// LIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
-ILIST_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
+ARRAY_DEF(BSL_SecOperList, BSL_SecOper_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecOper_Deinit))))
 // NOLINTEND
 
 struct BSL_SecurityAction_s
 {
     BSL_SecOperList_t sec_op_list;
-    size_t sec_op_list_length;
     size_t err_ct;
 };

--- a/src/backend/SecurityActionSet.c
+++ b/src/backend/SecurityActionSet.c
@@ -50,6 +50,7 @@ void BSL_SecurityActionSet_Deinit(BSL_SecurityActionSet_t *self)
     BSL_SecActionList_clear(self->actions);
     self->err_count = 0;
     self->action_count = 0;
+    self->operation_count = 0;
 }
 
 int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_SecurityAction_t *action)
@@ -58,6 +59,7 @@ int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_
     BSL_SecActionList_push_back(self->actions, *action);
     self->err_count += action->err_ct;
     self->action_count++;
+    self->operation_count += action->sec_op_list_length;
 
     return BSL_SUCCESS;
 }
@@ -66,6 +68,12 @@ size_t BSL_SecurityActionSet_CountActions(const BSL_SecurityActionSet_t *self)
 {
     ASSERT_ARG_NONNULL(self);
     return self->action_count;
+}
+
+size_t BSL_SecurityActionSet_CountOperations(const BSL_SecurityActionSet_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+    return self->operation_count;
 }
 
 const BSL_SecurityAction_t *BSL_SecurityActionSet_GetActionAtIndex(const BSL_SecurityActionSet_t *self, size_t index)

--- a/src/backend/SecurityActionSet.c
+++ b/src/backend/SecurityActionSet.c
@@ -27,7 +27,7 @@
 
 bool BSL_SecurityActionSet_IsConsistent(const BSL_SecurityActionSet_t *self)
 {
-    (void) self;
+    (void)self;
     return true;
 }
 
@@ -41,15 +41,15 @@ void BSL_SecurityActionSet_Init(BSL_SecurityActionSet_t *self)
     ASSERT_ARG_NONNULL(self);
     BSL_SecActionList_init(self->actions);
     self->action_count = 0;
-    self->err_count = 0;
+    self->err_count    = 0;
 }
 
 void BSL_SecurityActionSet_Deinit(BSL_SecurityActionSet_t *self)
 {
     ASSERT_ARG_NONNULL(self);
     BSL_SecActionList_clear(self->actions);
-    self->err_count = 0;
-    self->action_count = 0;
+    self->err_count       = 0;
+    self->action_count    = 0;
     self->operation_count = 0;
 }
 

--- a/src/backend/SecurityActionSet.c
+++ b/src/backend/SecurityActionSet.c
@@ -59,7 +59,7 @@ int BSL_SecurityActionSet_AppendAction(BSL_SecurityActionSet_t *self, const BSL_
     BSL_SecActionList_push_back(self->actions, *action);
     self->err_count += action->err_ct;
     self->action_count++;
-    self->operation_count += action->sec_op_list_length;
+    self->operation_count += BSL_SecurityAction_CountSecOpers(action);
 
     return BSL_SUCCESS;
 }

--- a/src/backend/SecurityActionSet.h
+++ b/src/backend/SecurityActionSet.h
@@ -27,22 +27,17 @@
 #define BSLB_SECACTIONSET_H_
 
 #include <BPSecLib_Private.h>
+#include "SecurityAction.h"
 
-#include "SecOperation.h"
-
-#define BSL_SECURITYACTIONSET_MAX_OPS (10)
+LIST_DEF(BSL_SecActionList, BSL_SecurityAction_t, M_OPEXTEND(M_POD_OPLIST, CLEAR(API_2(BSL_SecurityAction_Deinit))))
 
 /// @brief Contains the populated security operations for this bundle.
 /// @note This is intended to be a write-once, read-only struct
 struct BSL_SecurityActionSet_s
 {
-    BSL_SecOper_t sec_operations[BSL_SECURITYACTIONSET_MAX_OPS]; ///< Fixed array of security operations (for simpler
-                                                                 ///< mem management)
-    size_t   sec_operations_count;                               ///< Count of sec_operations
-    uint64_t new_block_ids[BSL_SECURITYACTIONSET_MAX_OPS];       ///< Array for IDs of blocks to be created
-    uint64_t new_block_types[BSL_SECURITYACTIONSET_MAX_OPS]; ///< Array for block type codes of blocks to be created.
-    size_t   arrays_capacity;                                ///< Capacity of sec_operations
-    int      err_code;                                       ///< General error code
+    BSL_SecActionList_t actions;
+    size_t action_count;
+    size_t err_count;
 };
 
 #endif /* BSLB_SECACTIONSET_H_ */

--- a/src/backend/SecurityActionSet.h
+++ b/src/backend/SecurityActionSet.h
@@ -38,6 +38,7 @@ struct BSL_SecurityActionSet_s
     BSL_SecActionList_t actions;
     size_t action_count;
     size_t err_count;
+    size_t operation_count;
 };
 
 #endif /* BSLB_SECACTIONSET_H_ */

--- a/src/backend/SecurityActionSet.h
+++ b/src/backend/SecurityActionSet.h
@@ -36,9 +36,9 @@ LIST_DEF(BSL_SecActionList, BSL_SecurityAction_t, M_OPEXTEND(M_POD_OPLIST, CLEAR
 struct BSL_SecurityActionSet_s
 {
     BSL_SecActionList_t actions;
-    size_t action_count;
-    size_t err_count;
-    size_t operation_count;
+    size_t              action_count;
+    size_t              err_count;
+    size_t              operation_count;
 };
 
 #endif /* BSLB_SECACTIONSET_H_ */

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -467,7 +467,7 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
     CHK_PRECONDITION(BSL_SecurityActionSet_IsConsistent(action_set));
     // NOLINTEND
 
-    BSL_SecurityResponseSet_Init(output_response, BSL_SecurityActionSet_CountActions(action_set), 0);
+    BSL_SecurityResponseSet_Init(output_response, BSL_SecurityActionSet_CountOperations(action_set), 0);
     /**
      * Notes:
      *  - It should evaluate every security operation, even if earlier ones failed.
@@ -485,11 +485,13 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
         BSL_SecOperList_it_t secop_it;
         for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
         {
+            memset(outcome, 0, BSL_SecOutcome_Sizeof());
+
             BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
             const BSL_SecCtxDesc_t *sec_ctx = BSL_SecCtxDict_cget(lib->sc_reg, sec_oper->context_id);
             ASSERT_PROPERTY(sec_ctx != NULL);
 
-            memset(outcome, 0, BSL_SecOutcome_Sizeof());
+            BSL_SecOutcome_Init(outcome, sec_oper, 100000);
 
             BSL_LOG_INFO("SC ABOUT TO ENTER CTX (SEC_OPER %lu) (ACTION %lu)", sec_oper, act);
 

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -477,15 +477,16 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
     BSL_SecOutcome_t *outcome    = calloc(BSL_SecOutcome_Sizeof(), 1);
 
     BSL_SecActionList_it_t act_it;
-    for (BSL_SecActionList_it(act_it, action_set->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
+    for (BSL_SecActionList_it(act_it, action_set->actions); !BSL_SecActionList_end_p(act_it);
+         BSL_SecActionList_next(act_it))
     {
         BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i ++)
+        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i++)
         {
             memset(outcome, 0, BSL_SecOutcome_Sizeof());
 
-            BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, i);
-            const BSL_SecCtxDesc_t *sec_ctx = BSL_SecCtxDict_cget(lib->sc_reg, sec_oper->context_id);
+            BSL_SecOper_t          *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, i);
+            const BSL_SecCtxDesc_t *sec_ctx  = BSL_SecCtxDict_cget(lib->sc_reg, sec_oper->context_id);
             ASSERT_PROPERTY(sec_ctx != NULL);
 
             BSL_SecOutcome_Init(outcome, sec_oper, 100000);
@@ -494,8 +495,8 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
             if (BSL_SecOper_IsBIB(sec_oper))
             {
                 errcode = BSL_SecOper_IsRoleSource(sec_oper) == true
-                            ? BSL_ExecBIBSource(sec_ctx->execute, lib, bundle, sec_oper, outcome)
-                            : BSL_ExecBIBAccept(sec_ctx->execute, lib, bundle, sec_oper, outcome);
+                              ? BSL_ExecBIBSource(sec_ctx->execute, lib, bundle, sec_oper, outcome)
+                              : BSL_ExecBIBAccept(sec_ctx->execute, lib, bundle, sec_oper, outcome);
             }
             else
             {

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -480,12 +480,11 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
     for (BSL_SecActionList_it(act_it, action_set->actions); !BSL_SecActionList_end_p(act_it); BSL_SecActionList_next(act_it))
     {
         BSL_SecurityAction_t *act = BSL_SecActionList_ref(act_it);
-        BSL_SecOperList_it_t secop_it;
-        for (BSL_SecOperList_it(secop_it, act->sec_op_list); !BSL_SecOperList_end_p(secop_it); BSL_SecOperList_next(secop_it))
+        for (size_t i = 0; i < BSL_SecurityAction_CountSecOpers(act); i ++)
         {
             memset(outcome, 0, BSL_SecOutcome_Sizeof());
 
-            BSL_SecOper_t *sec_oper = BSL_SecOperList_ref(secop_it);
+            BSL_SecOper_t *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(act, i);
             const BSL_SecCtxDesc_t *sec_ctx = BSL_SecCtxDict_cget(lib->sc_reg, sec_oper->context_id);
             ASSERT_PROPERTY(sec_ctx != NULL);
 

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -354,8 +354,6 @@ static int BSL_ExecBCBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
 {
     (void)lib;
 
-    BSL_LOG_INFO("SC BACKEND SOURCE (SEC_OPER %lu) (OUTCOME %lu)", sec_oper, outcome);
-
     CHK_ARG_NONNULL(sec_context_fn);
     CHK_ARG_NONNULL(bundle);
     CHK_ARG_NONNULL(sec_oper);
@@ -492,8 +490,6 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
             ASSERT_PROPERTY(sec_ctx != NULL);
 
             BSL_SecOutcome_Init(outcome, sec_oper, 100000);
-
-            BSL_LOG_INFO("SC ABOUT TO ENTER CTX (SEC_OPER %lu) (ACTION %lu)", sec_oper, act);
 
             int errcode = -1;
             if (BSL_SecOper_IsBIB(sec_oper))

--- a/src/backend/SecurityResultSet.h
+++ b/src/backend/SecurityResultSet.h
@@ -35,7 +35,7 @@
 /// @note This struct is still in-concept
 struct BSL_SecurityResponseSet_s
 {
-    /// @brief This maps to the BSL_SecurityActionSet_s::sec_operations,
+    /// @brief This maps to the Security Action sec_op_list,
     ///        and contains the result code of that security operation.
     int                results[BSL_SECURITYRESPONSESET_ARRAYLEN];
     char               err_msg[BSL_SECURITYRESPONSESET_STRLEN];

--- a/src/security_context/BCB_AES_GCM.c
+++ b/src/security_context/BCB_AES_GCM.c
@@ -563,8 +563,6 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const BSL
 {
     (void)lib;
 
-    BSL_LOG_INFO("SC BCB SOURCE (SEC_OPER %lu) (OUTCOME %lu)", sec_oper, sec_outcome);
-
     CHK_ARG_NONNULL(bundle);
     CHK_ARG_NONNULL(sec_oper);
     CHK_ARG_NONNULL(sec_outcome);

--- a/src/security_context/BCB_AES_GCM.c
+++ b/src/security_context/BCB_AES_GCM.c
@@ -562,6 +562,9 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const BSL
                      BSL_SecOutcome_t *sec_outcome)
 {
     (void)lib;
+
+    BSL_LOG_INFO("SC BCB SOURCE (SEC_OPER %lu) (OUTCOME %lu)", sec_oper, sec_outcome);
+
     CHK_ARG_NONNULL(bundle);
     CHK_ARG_NONNULL(sec_oper);
     CHK_ARG_NONNULL(sec_outcome);

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -89,6 +89,7 @@ BSL_SecurityActionSet_t *BSL_TestUtils_InitMallocBIBActionSet(BIBTestContext *bi
     BSL_SecurityAction_Init(act);
     BSL_SecurityAction_AppendSecOper(act, &bib_context->sec_oper);
     BSL_SecurityActionSet_AppendAction(action_set, act);
+    free(act);
     return action_set;
 }
 

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -88,6 +88,7 @@ BSL_SecurityActionSet_t *BSL_TestUtils_InitMallocBIBActionSet(BIBTestContext *bi
     BSL_SecurityAction_t *act = calloc(sizeof(BSL_SecurityAction_t), 1);
     BSL_SecurityAction_Init(act);
     BSL_SecurityAction_AppendSecOper(act, &bib_context->sec_oper);
+    //BSL_SecurityAction_OrderSecOps(act);
     BSL_SecurityActionSet_AppendAction(action_set, act);
     free(act);
     return action_set;

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -84,11 +84,11 @@ void BSL_TestUtils_InitBCB_Appendix2(BCBTestContext *context, BSL_SecRole_e role
 BSL_SecurityActionSet_t *BSL_TestUtils_InitMallocBIBActionSet(BIBTestContext *bib_context)
 {
     BSL_SecurityActionSet_t *action_set = calloc(sizeof(BSL_SecurityActionSet_t), 1);
-    BSL_SecurityActionSet_Init(action_set);    
+    BSL_SecurityActionSet_Init(action_set);
     BSL_SecurityAction_t *act = calloc(sizeof(BSL_SecurityAction_t), 1);
     BSL_SecurityAction_Init(act);
     BSL_SecurityAction_AppendSecOper(act, &bib_context->sec_oper);
-    //BSL_SecurityAction_OrderSecOps(act);
+    // BSL_SecurityAction_OrderSecOps(act);
     BSL_SecurityActionSet_AppendAction(action_set, act);
     free(act);
     return action_set;

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -84,11 +84,11 @@ void BSL_TestUtils_InitBCB_Appendix2(BCBTestContext *context, BSL_SecRole_e role
 BSL_SecurityActionSet_t *BSL_TestUtils_InitMallocBIBActionSet(BIBTestContext *bib_context)
 {
     BSL_SecurityActionSet_t *action_set = calloc(sizeof(BSL_SecurityActionSet_t), 1);
-    // Populate a PolicyActionSet with one action, of the appendix A1 BIB
-    action_set->arrays_capacity      = sizeof(action_set->sec_operations) / sizeof(BSL_SecOper_t);
-    action_set->sec_operations_count = 1;
-    BSL_SecOper_t *bib_oper          = &action_set->sec_operations[0];
-    *bib_oper                        = bib_context->sec_oper;
+    BSL_SecurityActionSet_Init(action_set);    
+    BSL_SecurityAction_t *act = calloc(sizeof(BSL_SecurityAction_t), 1);
+    BSL_SecurityAction_Init(act);
+    BSL_SecurityAction_AppendSecOper(act, &bib_context->sec_oper);
+    BSL_SecurityActionSet_AppendAction(action_set, act);
     return action_set;
 }
 

--- a/test/bsl_test_utils.h
+++ b/test/bsl_test_utils.h
@@ -29,6 +29,7 @@
 #include <backend/SecParam.h>
 #include <backend/SecResult.h>
 #include <backend/SecurityActionSet.h>
+//#include <backend/SecurityAction.h>
 
 #include <mock_bpa/mock_bpa_ctr.h>
 

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -83,8 +83,11 @@ void test_PolicyProvider_InspectEmptyRuleset(void)
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
-    TEST_ASSERT_EQUAL(0, BSL_SecurityActionSet_CountSecOpers(&action_set));
-    TEST_ASSERT_EQUAL(0, BSL_SecurityActionSet_GetErrCode(&action_set));
+    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_CountActions(&action_set));
+    const BSL_SecurityAction_t *act = BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0);
+    TEST_ASSERT_EQUAL(0, BSL_SecurityAction_CountSecOpers(act));
+
+    BSL_SecurityActionSet_Deinit(&action_set);
 }
 
 /**
@@ -116,8 +119,10 @@ void test_PolicyProvider_InspectSingleBIBRuleset(void)
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
-    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_CountSecOpers(&action_set));
-    TEST_ASSERT_EQUAL(0, BSL_SecurityActionSet_GetErrCode(&action_set));
+    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_CountActions(&action_set));
+    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
+
+    BSL_SecurityActionSet_Deinit(&action_set);
 }
 
 /**
@@ -147,9 +152,9 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
-    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_CountSecOpers(&action_set));
-    TEST_ASSERT_EQUAL(0, BSL_SecurityActionSet_GetErrCode(&action_set));
-    TEST_ASSERT_EQUAL(3, BSL_SecOper_CountParams(BSL_SecurityActionSet_GetSecOperAtIndex(&action_set, 0)));
+    const BSL_SecurityAction_t *act = BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0);
+    TEST_ASSERT_EQUAL(1, BSL_SecurityAction_CountSecOpers(act));
+    TEST_ASSERT_EQUAL(3, BSL_SecOper_CountParams(BSL_SecurityAction_GetSecOperAtIndex(act, 0)));
 
     BSL_SecurityActionSet_Deinit(&action_set);
 }

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -120,7 +120,7 @@ void test_PolicyProvider_InspectSingleBIBRuleset(void)
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
     TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_CountActions(&action_set));
-    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
+    TEST_ASSERT_EQUAL(1, BSL_SecurityAction_CountSecOpers(BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)));
 
     BSL_SecurityActionSet_Deinit(&action_set);
 }

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -294,7 +294,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
 
-    //BSL_SecurityAction_OrderSecOps(malloced_action);
+    // BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -371,7 +371,7 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
 
-    //BSL_SecurityAction_OrderSecOps(malloced_action);
+    // BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -465,7 +465,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_payload);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
 
-    //BSL_SecurityAction_OrderSecOps(malloced_action);
+    // BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -545,7 +545,7 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
 
-    //BSL_SecurityAction_OrderSecOps(malloced_action);
+    // BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -86,7 +86,7 @@ void tearDown(void)
  *  - Common repeated patterns are in the process of being factored out
  *  - All values are drawn from RFC9173 Appendix A.
  */
-void ntest_SecurityContext_BIB_Source(void)
+void test_SecurityContext_BIB_Source(void)
 {
     TEST_ASSERT_EQUAL(
         0, BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_original));
@@ -130,7 +130,7 @@ void ntest_SecurityContext_BIB_Source(void)
  *  - Common repeated patterns are in the process of being factored out
  *  - All values are drawn from RFC9173 Appendix A.
  */
-void ntest_SecurityContext_BIB_Verifier(void)
+void test_SecurityContext_BIB_Verifier(void)
 {
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -169,7 +169,7 @@ void ntest_SecurityContext_BIB_Verifier(void)
  * Notes:
  *  - Check more than return code, look deeper into outcome.
  */
-void ntest_SecurityContext_BIB_Verifier_Failure(void)
+void test_SecurityContext_BIB_Verifier_Failure(void)
 {
     // TODO(bvb) Note that this is basically identical to above except different key, they should be consolidated
     TEST_ASSERT_EQUAL(0,
@@ -208,7 +208,7 @@ void ntest_SecurityContext_BIB_Verifier_Failure(void)
  *  - Check that the BIB result was removed from the bundle (by making sure the encoding matches bundle in A1.1)
  *
  */
-void ntest_SecurityContext_BIB_Acceptor(void)
+void test_SecurityContext_BIB_Acceptor(void)
 {
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -250,7 +250,7 @@ cleanup:
 }
 
 // See RFC: https://www.rfc-editor.org/rfc/rfc9173.html#name-example-3-security-blocks-f
-void ntest_RFC9173_AppendixA_Example3_Acceptor(void)
+void test_RFC9173_AppendixA_Example3_Acceptor(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     const char *final_bundle = ("9f88070000820282010282028202018202820201820018281a000f4240850b0300"
@@ -310,7 +310,7 @@ void ntest_RFC9173_AppendixA_Example3_Acceptor(void)
     free(malloced_responseset);
 }
 
-void ntest_RFC9173_AppendixA_Example3_Source(void)
+void test_RFC9173_AppendixA_Example3_Source(void)
 {
     // See: https://www.rfc-editor.org/rfc/rfc9173.html#appendix-A.3.1
     const char *plain_bundle = ("9f88070000820282010282028202018202820201820018281a000f424085070200"
@@ -487,9 +487,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     free(malloced_responseset);
 }
 
-// This is currently failing the BCB targets the BIB, but the BIB BTSD hasn't been filled yet. 
-// so, there is nothing to encrypt
-void ntest_RFC9173_AppendixA_Example4_Source(void)
+void test_RFC9173_AppendixA_Example4_Source(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     const char *original_bundle = ("9f88070000820282010282028202018202820201820018281a000f424085010100"

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -287,9 +287,14 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
 
     BSL_SecurityActionSet_t *malloced_actionset = calloc(1, BSL_SecurityActionSet_Sizeof());
     BSL_SecurityActionSet_Init(malloced_actionset);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_primary);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_ext_block);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_oper);
+
+    BSL_SecurityAction_t *malloced_action = calloc(1, BSL_SecurityAction_Sizeof());
+    BSL_SecurityAction_Init(malloced_action);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_primary);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
+
+    BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
 
@@ -300,6 +305,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     BSL_SecurityResponseSet_Deinit(malloced_responseset);
     BSL_SecurityActionSet_Deinit(malloced_actionset);
 
+    free(malloced_action);
     free(malloced_actionset);
     free(malloced_responseset);
 }
@@ -357,9 +363,14 @@ void test_RFC9173_AppendixA_Example3_Source(void)
 
     BSL_SecurityActionSet_t *malloced_actionset = calloc(1, BSL_SecurityActionSet_Sizeof());
     BSL_SecurityActionSet_Init(malloced_actionset);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_primary);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_ext_block);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_oper);
+
+    BSL_SecurityAction_t *malloced_action = calloc(1, BSL_SecurityAction_Sizeof());
+    BSL_SecurityAction_Init(malloced_action);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_primary);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
+
+    BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
 
@@ -378,6 +389,7 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BSL_SecurityResponseSet_Deinit(malloced_responseset);
     BSL_SecurityActionSet_Deinit(malloced_actionset);
 
+    free(malloced_action);
     free(malloced_actionset);
     free(malloced_responseset);
 }
@@ -444,9 +456,14 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
 
     BSL_SecurityActionSet_t *malloced_actionset = calloc(1, BSL_SecurityActionSet_Sizeof());
     BSL_SecurityActionSet_Init(malloced_actionset);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_op_tgt_payload);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_op_tgt_bib);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_payload);
+
+    BSL_SecurityAction_t *malloced_action = calloc(1, BSL_SecurityAction_Sizeof());
+    BSL_SecurityAction_Init(malloced_action);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_payload);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
+
+    BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
 
@@ -465,6 +482,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     BSL_SecurityResponseSet_Deinit(malloced_responseset);
     BSL_SecurityActionSet_Deinit(malloced_actionset);
 
+    free(malloced_action);
     free(malloced_actionset);
     free(malloced_responseset);
 }
@@ -517,9 +535,14 @@ void test_RFC9173_AppendixA_Example4_Source(void)
 
     BSL_SecurityActionSet_t *malloced_actionset = calloc(1, BSL_SecurityActionSet_Sizeof());
     BSL_SecurityActionSet_Init(malloced_actionset);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_op_tgt_payload);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bcb_op_tgt_bib);
-    BSL_SecurityActionSet_AppendSecOper(malloced_actionset, &bib_oper_payload);
+
+    BSL_SecurityAction_t *malloced_action = calloc(1, BSL_SecurityAction_Sizeof());
+    BSL_SecurityAction_Init(malloced_action);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_payload);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
+
+    BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
 
@@ -534,6 +557,7 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BSL_SecurityResponseSet_Deinit(malloced_responseset);
     BSL_SecurityActionSet_Deinit(malloced_actionset);
 
+    free(malloced_action);
     free(malloced_actionset);
     free(malloced_responseset);
 }

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -294,6 +294,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
 
+    //BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -370,6 +371,7 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_ext_block);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_oper);
 
+    //BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -463,6 +465,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_payload);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
 
+    //BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
@@ -542,6 +545,7 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
 
+    //BSL_SecurityAction_OrderSecOps(malloced_action);
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -86,7 +86,7 @@ void tearDown(void)
  *  - Common repeated patterns are in the process of being factored out
  *  - All values are drawn from RFC9173 Appendix A.
  */
-void test_SecurityContext_BIB_Source(void)
+void ntest_SecurityContext_BIB_Source(void)
 {
     TEST_ASSERT_EQUAL(
         0, BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_original));
@@ -130,7 +130,7 @@ void test_SecurityContext_BIB_Source(void)
  *  - Common repeated patterns are in the process of being factored out
  *  - All values are drawn from RFC9173 Appendix A.
  */
-void test_SecurityContext_BIB_Verifier(void)
+void ntest_SecurityContext_BIB_Verifier(void)
 {
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -169,7 +169,7 @@ void test_SecurityContext_BIB_Verifier(void)
  * Notes:
  *  - Check more than return code, look deeper into outcome.
  */
-void test_SecurityContext_BIB_Verifier_Failure(void)
+void ntest_SecurityContext_BIB_Verifier_Failure(void)
 {
     // TODO(bvb) Note that this is basically identical to above except different key, they should be consolidated
     TEST_ASSERT_EQUAL(0,
@@ -208,7 +208,7 @@ void test_SecurityContext_BIB_Verifier_Failure(void)
  *  - Check that the BIB result was removed from the bundle (by making sure the encoding matches bundle in A1.1)
  *
  */
-void test_SecurityContext_BIB_Acceptor(void)
+void ntest_SecurityContext_BIB_Acceptor(void)
 {
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -250,7 +250,7 @@ cleanup:
 }
 
 // See RFC: https://www.rfc-editor.org/rfc/rfc9173.html#name-example-3-security-blocks-f
-void test_RFC9173_AppendixA_Example3_Acceptor(void)
+void ntest_RFC9173_AppendixA_Example3_Acceptor(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     const char *final_bundle = ("9f88070000820282010282028202018202820201820018281a000f4240850b0300"
@@ -310,7 +310,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     free(malloced_responseset);
 }
 
-void test_RFC9173_AppendixA_Example3_Source(void)
+void ntest_RFC9173_AppendixA_Example3_Source(void)
 {
     // See: https://www.rfc-editor.org/rfc/rfc9173.html#appendix-A.3.1
     const char *plain_bundle = ("9f88070000820282010282028202018202820201820018281a000f424085070200"
@@ -394,7 +394,7 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     free(malloced_responseset);
 }
 
-void test_RFC9173_AppendixA_Example4_Acceptor(void)
+void ntest_RFC9173_AppendixA_Example4_Acceptor(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     // See: https://www.rfc-editor.org/rfc/rfc9173.html#appendix-A.4.5

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -394,7 +394,7 @@ void ntest_RFC9173_AppendixA_Example3_Source(void)
     free(malloced_responseset);
 }
 
-void ntest_RFC9173_AppendixA_Example4_Acceptor(void)
+void test_RFC9173_AppendixA_Example4_Acceptor(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     // See: https://www.rfc-editor.org/rfc/rfc9173.html#appendix-A.4.5
@@ -459,9 +459,9 @@ void ntest_RFC9173_AppendixA_Example4_Acceptor(void)
 
     BSL_SecurityAction_t *malloced_action = calloc(1, BSL_SecurityAction_Sizeof());
     BSL_SecurityAction_Init(malloced_action);
+    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_payload);
     BSL_SecurityAction_AppendSecOper(malloced_action, &bcb_op_tgt_bib);
-    BSL_SecurityAction_AppendSecOper(malloced_action, &bib_oper_payload);
 
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
@@ -487,7 +487,9 @@ void ntest_RFC9173_AppendixA_Example4_Acceptor(void)
     free(malloced_responseset);
 }
 
-void test_RFC9173_AppendixA_Example4_Source(void)
+// This is currently failing the BCB targets the BIB, but the BIB BTSD hasn't been filled yet. 
+// so, there is nothing to encrypt
+void ntest_RFC9173_AppendixA_Example4_Source(void)
 {
     BSL_Crypto_SetRngGenerator(rfc9173_byte_gen_fn_a4);
     const char *original_bundle = ("9f88070000820282010282028202018202820201820018281a000f424085010100"

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -206,7 +206,6 @@ void test_API_RemoveFailedBlock(void)
     TEST_ASSERT_EQUAL(1, action_set.action_count);
     TEST_ASSERT_EQUAL(1, BSL_SecurityAction_CountSecOpers(BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)));
 
-
     // We know that we should expect one failure in the result.
     BSL_SecurityResponseSet_t response_set = { 0 };
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -149,7 +149,8 @@ void test_SourceSimpleBIB(void)
 
         TEST_ASSERT_EQUAL(0, query_result);
         // We know that it contains one operation (Add a BIB block to payload)
-        TEST_ASSERT_EQUAL(1, action_set.sec_operations_count);
+        TEST_ASSERT_EQUAL(1, action_set.action_count);
+        TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
     }
 
     {
@@ -202,7 +203,9 @@ void test_API_RemoveFailedBlock(void)
                                              BSL_POLICYLOCATION_CLIN);
 
     TEST_ASSERT_EQUAL(0, query_result);
-    TEST_ASSERT_EQUAL(1, action_set.sec_operations_count);
+    TEST_ASSERT_EQUAL(1, action_set.action_count);
+    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
+
 
     // We know that we should expect one failure in the result.
     BSL_SecurityResponseSet_t response_set = { 0 };

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -150,7 +150,7 @@ void test_SourceSimpleBIB(void)
         TEST_ASSERT_EQUAL(0, query_result);
         // We know that it contains one operation (Add a BIB block to payload)
         TEST_ASSERT_EQUAL(1, action_set.action_count);
-        TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
+        TEST_ASSERT_EQUAL(1, BSL_SecurityAction_CountSecOpers(BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)));
     }
 
     {
@@ -204,7 +204,7 @@ void test_API_RemoveFailedBlock(void)
 
     TEST_ASSERT_EQUAL(0, query_result);
     TEST_ASSERT_EQUAL(1, action_set.action_count);
-    TEST_ASSERT_EQUAL(1, BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)->sec_op_list_length);
+    TEST_ASSERT_EQUAL(1, BSL_SecurityAction_CountSecOpers(BSL_SecurityActionSet_GetActionAtIndex(&action_set, 0)));
 
 
     // We know that we should expect one failure in the result.


### PR DESCRIPTION
## Notable Changes

### Creates singular `Action` structure, containing _ordered_ list of SecOps. `ActionSet`s now contain (not-necessarily ordered) list of `Action`s.
- New SecOps added to an `Action` have their parameters checked to determine order - for example, if a new SecOp(tgt=payload, ctx=BIB, role=ACCEPT), it should be added after SecOp(tgt=payload, ctx=BCB, role=ACCEPT).
- ActionSets now use an M*lib struct to hold actions to remove hard limit on capacity
### Adds conclusions to SecOps
Copied from other open PR for clarity