### PR TITLE
Enforce the block count limit when decoding

### DIFF
--- a/cmake/Findlibfuzzer.cmake
+++ b/cmake/Findlibfuzzer.cmake
@@ -6,7 +6,7 @@
 
 if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang"
    OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  message(FATAL "Can only fuzz with clang compiler")
+  message(FATAL_ERROR "Can only fuzz with clang compiler")
 endif()
 
 # Options for all compilation units


### PR DESCRIPTION
Without this the Mock BPA will crash when it receives a PDU with more blocks than the limit allows.

Related to #24 but doesn't fix, only enforces the existing limit.