### PR TITLE
Make the BSL use in Mock BPA thread safe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,7 +89,7 @@ function cmd_deps {
 }
 
 function cmd_docs {
-    cmake --build ${BUILDDIR} --target docs-api-html
+    cmake --build ${BUILDDIR} --target docs-api-html docs-api-misspelling
 }
 
 function cmd_install {

--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -82,6 +82,7 @@ deallocated
 deinit
 Deinit
 deinitialize
+deinitialized
 Deinitializes
 dereference
 dir

--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -71,6 +71,7 @@ cryptographic
 ctx
 de
 De
+deallocated
 deallocation
 Decodeable
 DecodeBase
@@ -78,7 +79,6 @@ decrypt
 DECRYPT
 decrypted
 DefaultSecuritContext's
-deallocated
 deinit
 Deinit
 deinitialize
@@ -137,6 +137,7 @@ MiMTAR
 MLib
 MLIB
 MMCS
+Mutex
 namespace
 namespaced
 NIST

--- a/mock-bpa-test/helpers/runner.py
+++ b/mock-bpa-test/helpers/runner.py
@@ -44,6 +44,7 @@ def compose_args(args: List[str]) -> List[str]:
             'valgrind',
             '--tool=memcheck',
             '--leak-check=full',
+            '--show-leak-kinds=all',
             '--suppressions=resources/memcheck.supp',
             '--gen-suppressions=all',
             '--error-exitcode=2',

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -116,7 +116,7 @@ class TestAgent(unittest.TestCase):
 
         ''' Spawn the process and wait for the startup READY message. '''
         self._agent.start()
-        self._agent.wait_for_text(r'.* <INFO> \[.+\:bpa_exec] READY$')
+        self._agent.wait_for_text(r'.* <INFO> \[.+\:MockBPA_Agent_Exec] READY$')
 
     def _encode(self, blocks: List[object]):
 

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -79,7 +79,7 @@ class TestAgent(unittest.TestCase):
 
         args = compose_args([
             'bsl-mock-bpa',
-            '-e', 'ipn:2.1',
+            '-s', 'ipn:2.1',  # security source
             '-u', 'localhost:4556', '-r', 'localhost:14556',
             '-o', 'localhost:24556', '-a', 'localhost:34556',
             '-p', policy_config,

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -371,17 +371,22 @@ int BSL_Host_GetSecSrcEID(BSL_HostEID_t *eid);
  */
 int BSL_HostEID_DecodeFromText(BSL_HostEID_t *eid, const char *text);
 
-/** Load an EID from CBOR
+/** Decode an EID from CBOR.
  *
- * @param[in,out] eid This eid
- * @param[in] CBOR decoder context
+ * @param[in,out] eid The value to decode into
+ * @param[in] decoder CBOR decoder context
  * @return 0 on success
  */
 int BSL_HostEID_DecodeFromCBOR(BSL_HostEID_t *eid, void *decoder);
 
-/** Opaque pointer to BPA-specific Endpoint ID Pattern storage.
- * Ownership of the object is kept by the BPA, and these are only references.
+/** Encode a EID into CBOR.
+ *
+ * @param[in] eid The value to encode
+ * @param[in] encoder CBOR encoder context
+ * @return Zero if successful.
  */
+int BSL_HostEID_EncodeToCBOR(const BSL_HostEID_t *eid, void *encoder);
+
 /** Static initializer for an invalid ::BSL_HostEIDPattern_t.
  * Even after this, BSL_HostEIDPattern_Init() must be used to get into a valid state.
  */
@@ -402,14 +407,6 @@ int BSL_HostEIDPattern_Init(BSL_HostEIDPattern_t *pat);
  * @param[in,out] pat The object to de-initialize.
  */
 void BSL_HostEIDPattern_Deinit(BSL_HostEIDPattern_t *pat);
-
-/**
- * Encode a EID into a CBOR sequence
- * @param[in] eid
- * @param[in] user_data
- * @return Zero if successful.
- */
-int BSL_HostEID_EncodeToCBOR(const BSL_HostEID_t *eid, void *user_data);
 
 /** Decode an EID Pattern from its text form.
  *

--- a/src/BPSecLib_Public.h
+++ b/src/BPSecLib_Public.h
@@ -245,8 +245,8 @@ typedef struct
     /// User data pointer for callbacks
     void *user_data;
 
-    /// @brief Host BPA function to get its current EID
-    int (*get_host_eid_fn)(const void *user_data, BSL_HostEID_t *result);
+    /// @brief Host BPA function to get its security source EID
+    int (*get_sec_src_eid_fn)(void *user_data, BSL_HostEID_t *result);
 
     /// @brief Host BPA function to initialize/allocate an EID type.
     int (*eid_init)(void *user_data, BSL_HostEID_t *result);

--- a/src/BPSecLib_Public.h
+++ b/src/BPSecLib_Public.h
@@ -256,7 +256,7 @@ typedef struct
 
 /** Set the BPA descriptor (callbacks) for this process.
  *
- * @warning This function is not thread safe and should be set before any
+ * @warning This function is not thread safe and should be used before any
  * ::BSL_LibCtx_t is initialized or other BSL interfaces used.
  *
  * @param desc The descriptor to use for future BPA functions.
@@ -270,6 +270,13 @@ int BSL_HostDescriptors_Set(BSL_HostDescriptors_t desc);
  * @param[out] desc The descriptor to copy into.
  */
 void BSL_HostDescriptors_Get(BSL_HostDescriptors_t *desc);
+
+/** Reset the host descriptors to their default, unusable state.
+ *
+ * @warning This function is not thread safe and should be used after any
+ * ::BSL_LibCtx_t is deinitialized.
+ */
+void BSL_HostDescriptors_Clear(void);
 
 /** @brief Initialize the BPSecLib (BSL) library context.
  *

--- a/src/backend/HostInterface.c
+++ b/src/backend/HostInterface.c
@@ -121,6 +121,11 @@ void BSL_HostDescriptors_Get(BSL_HostDescriptors_t *desc)
     *desc = HostDescriptorTable;
 }
 
+void BSL_HostDescriptors_Clear(void)
+{
+    HostDescriptorTable = (BSL_HostDescriptors_t) { 0 };
+}
+
 int BSL_HostEID_Init(BSL_HostEID_t *eid)
 {
     CHK_ARG_NONNULL(eid);

--- a/src/backend/HostInterface.c
+++ b/src/backend/HostInterface.c
@@ -32,7 +32,7 @@ static BSL_HostDescriptors_t HostDescriptorTable = { 0 };
 int BSL_HostDescriptors_Set(BSL_HostDescriptors_t desc)
 {
     CHK_PRECONDITION(desc.eid_init);
-    CHK_PRECONDITION(desc.get_host_eid_fn);
+    CHK_PRECONDITION(desc.get_sec_src_eid_fn);
     CHK_PRECONDITION(desc.eid_deinit);
     CHK_PRECONDITION(desc.bundle_metadata_fn);
     CHK_PRECONDITION(desc.block_metadata_fn);
@@ -161,8 +161,8 @@ void BSL_HostEID_Deinit(BSL_HostEID_t *eid)
 int BSL_Host_GetSecSrcEID(BSL_HostEID_t *eid)
 {
     CHK_ARG_NONNULL(eid);
-    CHK_PRECONDITION(HostDescriptorTable.get_host_eid_fn != NULL);
-    return HostDescriptorTable.get_host_eid_fn(HostDescriptorTable.user_data, eid);
+    CHK_PRECONDITION(HostDescriptorTable.get_sec_src_eid_fn != NULL);
+    return HostDescriptorTable.get_sec_src_eid_fn(HostDescriptorTable.user_data, eid);
 }
 
 int BSL_HostEID_EncodeToCBOR(const BSL_HostEID_t *eid, void *encoder)

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -98,7 +98,6 @@ int BSL_API_RegisterPolicyProvider(BSL_LibCtx_t *lib, uint64_t pp_id, BSL_Policy
     CHK_ARG_NONNULL(lib);
     CHK_ARG_EXPR(desc.query_fn != NULL);
     CHK_ARG_EXPR(desc.finalize_fn != NULL);
-    CHK_ARG_EXPR(desc.deinit_fn != NULL);
 
     BSL_PolicyDict_set_at(lib->policy_reg, pp_id, desc);
     return BSL_SUCCESS;

--- a/src/mock_bpa/CMakeLists.txt
+++ b/src/mock_bpa/CMakeLists.txt
@@ -26,6 +26,7 @@ target_compile_options(bsl_mock_bpa PRIVATE -Wshadow -Wpointer-arith -Wstrict-pr
 target_sources(
   bsl_mock_bpa PUBLIC 
   ${CMAKE_CURRENT_SOURCE_DIR}/agent.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/bundle.h
   ${CMAKE_CURRENT_SOURCE_DIR}/crc.h
   ${CMAKE_CURRENT_SOURCE_DIR}/eid.h
   ${CMAKE_CURRENT_SOURCE_DIR}/eidpat.h
@@ -41,6 +42,7 @@ target_sources(
 target_sources(
   bsl_mock_bpa PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/agent.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/bundle.c
   ${CMAKE_CURRENT_SOURCE_DIR}/crc.c
   ${CMAKE_CURRENT_SOURCE_DIR}/eid.c
   ${CMAKE_CURRENT_SOURCE_DIR}/eidpat.c

--- a/src/mock_bpa/MockBPA.h
+++ b/src/mock_bpa/MockBPA.h
@@ -27,5 +27,6 @@
 #include "decode.h"
 #include "agent.h"
 #include "eidpat.h"
+#include "agent.h"
 
 #endif //_BSL_MockBPA_MockBPA_H_

--- a/src/mock_bpa/MockBPA.h
+++ b/src/mock_bpa/MockBPA.h
@@ -25,7 +25,6 @@
 #include "crc.h"
 #include "encode.h"
 #include "decode.h"
-#include "agent.h"
 #include "eidpat.h"
 #include "agent.h"
 

--- a/src/mock_bpa/agent.c
+++ b/src/mock_bpa/agent.c
@@ -482,14 +482,13 @@ static void *MockBPA_Agent_work_over_rx(void *arg)
         BSL_LOG_INFO("over_rx item");
         mock_bpa_decode(&item);
 
-        if (MockBPA_process(agent->bsl_appin, BSL_POLICYLOCATION_APPIN, item.bundle_ref.data))
+        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
+        if (MockBPA_process(agent->bsl_appin, BSL_POLICYLOCATION_APPIN, bundle))
         {
             BSL_LOG_ERR("failed security processing");
             mock_bpa_ctr_deinit(&item);
             continue;
         }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
         if (!bundle->retain)
         {
             BSL_LOG_ERR("bundle was marked to delete by BSL");
@@ -527,14 +526,13 @@ static void *MockBPA_Agent_work_under_rx(void *arg)
             continue;
         }
 
-        if (MockBPA_process(agent->bsl_clin, BSL_POLICYLOCATION_CLIN, item.bundle_ref.data))
+        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
+        if (MockBPA_process(agent->bsl_clin, BSL_POLICYLOCATION_CLIN, bundle))
         {
             BSL_LOG_ERR("failed security processing");
             mock_bpa_ctr_deinit(&item);
             continue;
         }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
         if (!bundle->retain)
         {
             BSL_LOG_ERR("bundle was marked to delete by BSL");
@@ -565,14 +563,13 @@ static void *MockBPA_Agent_work_deliver(void *arg)
         }
         BSL_LOG_INFO("deliver item");
 
-        if (MockBPA_process(agent->bsl_appout, BSL_POLICYLOCATION_APPOUT, item.bundle_ref.data))
+        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
+        if (MockBPA_process(agent->bsl_appout, BSL_POLICYLOCATION_APPOUT, bundle))
         {
             BSL_LOG_ERR("failed security processing");
             mock_bpa_ctr_deinit(&item);
             continue;
         }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
         if (!bundle->retain)
         {
             BSL_LOG_ERR("bundle was marked to delete by BSL");
@@ -611,14 +608,13 @@ static void *MockBPA_Agent_work_forward(void *arg)
         }
         BSL_LOG_INFO("forward item");
 
-        if (MockBPA_process(agent->bsl_clout, BSL_POLICYLOCATION_CLOUT, item.bundle_ref.data))
+        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
+        if (MockBPA_process(agent->bsl_clout, BSL_POLICYLOCATION_CLOUT, bundle))
         {
             BSL_LOG_ERR("failed security processing");
             mock_bpa_ctr_deinit(&item);
             continue;
         }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
         if (!bundle->retain)
         {
             BSL_LOG_ERR("bundle was marked to delete by BSL");

--- a/src/mock_bpa/agent.h
+++ b/src/mock_bpa/agent.h
@@ -167,7 +167,7 @@ typedef struct MockBPA_Agent_s
     BSL_LibCtx_t *bsl_clin;
     /// BSL context for ::BSL_POLICYLOCATION_CLOUT
     BSL_LibCtx_t *bsl_clout;
-    /// Mutex for aggregating telemtry on all above ::BSL_LibCtx_t instances
+    /// Mutex for aggregating telemetry on all above ::BSL_LibCtx_t instances
     pthread_mutex_t tlm_mutex;
 
     /// Configuration for local app-facing address

--- a/src/mock_bpa/agent.h
+++ b/src/mock_bpa/agent.h
@@ -36,8 +36,6 @@
 
 #include <m-atomic.h>
 #include <m-buffer.h>
-#include <m-deque.h>
-#include <m-bptree.h>
 #include <m-string.h>
 
 #include <arpa/inet.h>
@@ -47,71 +45,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-typedef struct MockBPA_BundleTimestamp_s
-{
-    uint64_t bundle_creation_time;
-    uint64_t seq_num;
-} MockBPA_BundleTimestamp_t;
-
-typedef struct MockBPA_PrimaryBlock_s
-{
-    uint64_t                  version;
-    uint64_t                  flags;
-    uint64_t                  crc_type;
-    BSL_HostEID_t             dest_eid;
-    BSL_HostEID_t             src_node_id;
-    BSL_HostEID_t             report_to_eid;
-    MockBPA_BundleTimestamp_t timestamp;
-    uint64_t                  lifetime;
-    uint64_t                  frag_offset;
-    uint64_t                  adu_length;
-
-    /// Encoded form owned by this struct
-    BSL_Data_t encoded;
-} MockBPA_PrimaryBlock_t;
-
-typedef struct MockBPA_CanonicalBlock_s
-{
-    uint64_t blk_type;
-    uint64_t blk_num;
-    uint64_t flags;
-    uint64_t crc_type;
-
-    /// Pointer to memory managed by the BPA
-    void *btsd;
-    /// Known length of the #btsd
-    size_t btsd_len;
-} MockBPA_CanonicalBlock_t;
-
-/** @struct MockBPA_BlockList_t
- * An ordered list of ::MockBPA_CanonicalBlock_t storage
- * with fast size access.
- * BTSD is not managed by this list, but by the BPA itself.
- */
-/** @struct MockBPA_BlockByNum_t
- * A lookup from unique block number to ::MockBPA_CanonicalBlock_t pointer.
- */
-/// @cond Doxygen_Suppress
-M_DEQUE_DEF(MockBPA_BlockList, MockBPA_CanonicalBlock_t, M_POD_OPLIST)
-M_BPTREE_DEF2(MockBPA_BlockByNum, 4, uint64_t, M_BASIC_OPLIST, MockBPA_CanonicalBlock_t *, M_PTR_OPLIST)
-/// @endcond
-
-typedef struct MockBPA_Bundle_s
-{
-    uint64_t               id;
-    bool                   retain;
-    MockBPA_PrimaryBlock_t primary_block;
-
-    /// Storage for blocks in this bundle
-    MockBPA_BlockList_t blocks;
-    /// Lookup table by block number
-    MockBPA_BlockByNum_t blocks_num;
-
-} MockBPA_Bundle_t;
-
-int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle);
-int MockBPA_Bundle_Deinit(MockBPA_Bundle_t *bundle);
 
 int MockBPA_GetBundleMetadata(const BSL_BundleRef_t *bundle_ref, BSL_PrimaryBlock_t *result_primary_block);
 int MockBPA_GetBlockNums(const BSL_BundleRef_t *bundle_ref, size_t block_id_array_capacity,

--- a/src/mock_bpa/bundle.c
+++ b/src/mock_bpa/bundle.c
@@ -1,0 +1,37 @@
+#include "bundle.h"
+
+int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle)
+{
+    ASSERT_ARG_NONNULL(bundle);
+    memset(bundle, 0, sizeof(*bundle));
+
+    bundle->retain = true;
+
+    MockBPA_BlockList_init(bundle->blocks);
+    MockBPA_BlockByNum_init(bundle->blocks_num);
+
+    return 0;
+}
+
+int MockBPA_Bundle_Deinit(MockBPA_Bundle_t *bundle)
+{
+    ASSERT_ARG_NONNULL(bundle);
+    BSL_HostEID_Deinit(&bundle->primary_block.src_node_id);
+    BSL_HostEID_Deinit(&bundle->primary_block.dest_eid);
+    BSL_HostEID_Deinit(&bundle->primary_block.report_to_eid);
+    BSL_Data_Deinit(&bundle->primary_block.encoded);
+
+    MockBPA_BlockByNum_clear(bundle->blocks_num);
+
+    MockBPA_BlockList_it_t bit;
+    for (MockBPA_BlockList_it(bit, bundle->blocks); !MockBPA_BlockList_end_p(bit); MockBPA_BlockList_next(bit))
+    {
+        MockBPA_CanonicalBlock_t *blk = MockBPA_BlockList_ref(bit);
+        BSL_LOG_DEBUG("freeing block number %" PRIu64, blk->blk_num);
+        BSL_FREE(blk->btsd);
+    }
+    MockBPA_BlockList_clear(bundle->blocks);
+
+    memset(bundle, 0, sizeof(*bundle));
+    return 0;
+}

--- a/src/mock_bpa/bundle.c
+++ b/src/mock_bpa/bundle.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
 #include "bundle.h"
 
 int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle)

--- a/src/mock_bpa/bundle.h
+++ b/src/mock_bpa/bundle.h
@@ -106,12 +106,13 @@ typedef struct MockBPA_Bundle_s
 } MockBPA_Bundle_t;
 
 /** Initialize an empty not-really-valid bundle.
- *
+ * @param[out] bundle The struct.
  */
 int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle);
 
 /** Deinitialize any bundle storage.
- * This includes deallocating BTSD.
+ * This includes freeing any BTSD.
+ * @param[out] bundle The struct.
  */
 int MockBPA_Bundle_Deinit(MockBPA_Bundle_t *bundle);
 

--- a/src/mock_bpa/bundle.h
+++ b/src/mock_bpa/bundle.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
+
+/** @file
+ * Declarations for Bundle storage.
+ * @ingroup mock_bpa
+ */
+#ifndef MOCK_BPA_BUNDLE_H_
+#define MOCK_BPA_BUNDLE_H_
+
+#include "eid.h"
+
+#include <m-deque.h>
+#include <m-bptree.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Timestamp according to Section 4.2.7 of RFC 9171 @cite rfc9171
+typedef struct
+{
+    uint64_t bundle_creation_time;
+    uint64_t seq_num;
+} MockBPA_CreationTimestamp_t;
+
+/** Structure of the primary block according to
+ * Section 4.3.1 of RFC 9171 @cite rfc9171.
+ */
+typedef struct
+{
+    uint64_t                    version;
+    uint64_t                    flags;
+    uint64_t                    crc_type;
+    BSL_HostEID_t               dest_eid;
+    BSL_HostEID_t               src_node_id;
+    BSL_HostEID_t               report_to_eid;
+    MockBPA_CreationTimestamp_t timestamp;
+    uint64_t                    lifetime;
+    uint64_t                    frag_offset;
+    uint64_t                    adu_length;
+
+    /// Encoded form owned by this struct
+    BSL_Data_t encoded;
+} MockBPA_PrimaryBlock_t;
+
+/** Structure of each canonical block according to
+ * Section 4.3.2 of RFC 9171 @cite rfc9171.
+ */
+typedef struct
+{
+    uint64_t blk_type;
+    uint64_t blk_num;
+    uint64_t flags;
+    uint64_t crc_type;
+
+    /// Pointer to memory managed by the BPA
+    void *btsd;
+    /// Known length of the #btsd
+    size_t btsd_len;
+} MockBPA_CanonicalBlock_t;
+
+/** @struct MockBPA_BlockList_t
+ * An ordered list of ::MockBPA_CanonicalBlock_t storage
+ * with fast size access.
+ * BTSD is not managed by this list, but by the BPA itself.
+ */
+/** @struct MockBPA_BlockByNum_t
+ * A lookup from unique block number to ::MockBPA_CanonicalBlock_t pointer.
+ */
+/// @cond Doxygen_Suppress
+M_DEQUE_DEF(MockBPA_BlockList, MockBPA_CanonicalBlock_t, M_POD_OPLIST)
+M_BPTREE_DEF2(MockBPA_BlockByNum, 4, uint64_t, M_BASIC_OPLIST, MockBPA_CanonicalBlock_t *, M_PTR_OPLIST)
+/// @endcond
+
+typedef struct MockBPA_Bundle_s
+{
+    uint64_t               id;
+    bool                   retain;
+    MockBPA_PrimaryBlock_t primary_block;
+
+    /// Storage for blocks in this bundle
+    MockBPA_BlockList_t blocks;
+    /// Lookup table by block number
+    MockBPA_BlockByNum_t blocks_num;
+
+} MockBPA_Bundle_t;
+
+/** Initialize an empty not-really-valid bundle.
+ *
+ */
+int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle);
+
+/** Deinitialize any bundle storage.
+ * This includes deallocating BTSD.
+ */
+int MockBPA_Bundle_Deinit(MockBPA_Bundle_t *bundle);
+
+#ifdef __cplusplus
+} // extern C
+#endif
+
+#endif /* MOCK_BPA_BUNDLE_H_ */

--- a/src/mock_bpa/ctr.h
+++ b/src/mock_bpa/ctr.h
@@ -22,10 +22,11 @@
 #ifndef BSL_MOCK_BPA_CTR_H_
 #define BSL_MOCK_BPA_CTR_H_
 
-#include <m-core.h>
-
+#include "bundle.h"
 #include <BPSecLib_Private.h>
 #include <BPSecLib_Public.h>
+
+#include <m-core.h>
 
 /// A container for encoded and decoded bundle data
 typedef struct

--- a/src/mock_bpa/ctr.h
+++ b/src/mock_bpa/ctr.h
@@ -19,14 +19,13 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#ifndef TEST_BPA_MOCK_BPA_CTR_H_
-#define TEST_BPA_MOCK_BPA_CTR_H_
+#ifndef BSL_MOCK_BPA_CTR_H_
+#define BSL_MOCK_BPA_CTR_H_
 
 #include <m-core.h>
 
 #include <BPSecLib_Private.h>
 #include <BPSecLib_Public.h>
-#include "agent.h"
 
 /// A container for encoded and decoded bundle data
 typedef struct
@@ -51,4 +50,4 @@ int mock_bpa_encode(mock_bpa_ctr_t *ctr);
 #define M_OPL_mock_bpa_ctr_t() \
     (INIT(API_2(mock_bpa_ctr_init)), INIT_MOVE(API_6(mock_bpa_ctr_init_move)), CLEAR(API_2(mock_bpa_ctr_deinit)))
 
-#endif /* TEST_BPA_MOCK_BPA_CTR_H_ */
+#endif /* BSL_MOCK_BPA_CTR_H_ */

--- a/src/mock_bpa/decode.h
+++ b/src/mock_bpa/decode.h
@@ -27,9 +27,8 @@
 #ifndef BSL_MOCK_BPA_DECODE_H_
 #define BSL_MOCK_BPA_DECODE_H_
 
-#include "agent.h"
 #include "eid.h"
-#include <BPSecLib_Private.h>
+#include "bundle.h"
 #include <qcbor/qcbor_decode.h>
 
 #ifdef __cplusplus

--- a/src/mock_bpa/eid.c
+++ b/src/mock_bpa/eid.c
@@ -33,13 +33,6 @@
 #include <stdio.h>
 #include <sys/types.h>
 
-int MockBPA_GetEid(const void *user_data, BSL_HostEID_t *result_eid)
-{
-    const char *local_ipn = getenv("BSL_TEST_LOCAL_IPN_EID");
-    int         x         = mock_bpa_eid_from_text(result_eid, local_ipn, (void *)user_data);
-    return (0 == x) ? 0 : -1;
-}
-
 void bsl_mock_eid_init(bsl_mock_eid_t *eid)
 {
     CHKVOID(eid);

--- a/src/mock_bpa/eid.h
+++ b/src/mock_bpa/eid.h
@@ -35,8 +35,6 @@
 extern "C" {
 #endif
 
-int MockBPA_GetEid(const void *user_data, BSL_HostEID_t *result_eid);
-
 /// Scheme-specific part for IPN scheme
 typedef struct
 {

--- a/src/mock_bpa/encode.h
+++ b/src/mock_bpa/encode.h
@@ -28,7 +28,7 @@
 #define BSL_MOCK_BPA_ENCODE_H_
 
 #include "eid.h"
-#include "agent.h"
+#include "bundle.h"
 #include <qcbor/qcbor_encode.h>
 
 #ifdef __cplusplus

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -235,6 +235,7 @@ int main(int argc, char **argv)
     MockBPA_Agent_Deinit(&agent);
     BSL_HostEID_Deinit(&sec_eid);
     BSL_HostEID_Deinit(&app_eid);
+
     BSL_HostDescriptors_Clear();
     BSL_CryptoDeinit();
     BSL_closelog();

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -169,22 +169,30 @@ int main(int argc, char **argv)
                     }
                     break;
                 case 'p':
+                {
                     // TODO better way to handle this
-                    mock_bpa_handle_policy_config(optarg, agent.policy_appin, &policy_registry);
-                    mock_bpa_handle_policy_config(optarg, agent.policy_appout, &policy_registry);
-                    mock_bpa_handle_policy_config(optarg, agent.policy_clin, &policy_registry);
-                    mock_bpa_handle_policy_config(optarg, agent.policy_clout, &policy_registry);
+                    int anyerr = 0;
+                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.policy_appin, &policy_registry));
+                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.policy_appout, &policy_registry));
+                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.policy_clin, &policy_registry));
+                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.policy_clout, &policy_registry));
+                    if (anyerr)
+                    {
+                        retval = 1;
+                    }
 
                     // TODO JSON parsing
                     // // mock_bpa_handle_policy_config_from_json("src/mock_bpa/policy_provider_test.json",
                     // policy_callbacks.user_data);
 
                     break;
+                }
                 case 'k':
                     if (mock_bpa_key_registry_init(optarg))
                         retval = 1;
                     break;
                 case 'h':
+                    // fall-through to default
                 default:
                     show_usage(argv[0]);
                     retval = 1;

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -23,12 +23,8 @@
  * This is the main entry for a mock BPA daemon that communicates through
  * unix domain sockets.
  */
-#include <arpa/inet.h>
 #include <errno.h>
-#include <m-atomic.h>
-#include <m-buffer.h>
 #include <netdb.h>
-#include <poll.h>
 #include <signal.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -40,39 +36,13 @@
 #include <CryptoInterface.h>
 
 #include "agent.h"
-#include "ctr.h"
 #include "policy_config.h"
-#include "policy_registry.h"
-
-static atomic_bool stop_state;
-
-#define DATA_QUEUE_SIZE 100
-
-BUFFER_DEF(data_queue, mock_bpa_ctr_t, DATA_QUEUE_SIZE,
-           BUFFER_QUEUE | BUFFER_THREAD_SAFE | BUFFER_PUSH_INIT_POP_MOVE | BUFFER_BLOCKING)
-
-static data_queue_t over_rx;
-static data_queue_t over_tx;
-static data_queue_t under_rx;
-static data_queue_t under_tx;
-static data_queue_t deliver;
-static data_queue_t forward;
-
-static pthread_t thr_over_rx, thr_under_rx, thr_deliver, thr_forward;
-
-// Library context
-static BSL_LibCtx_t *bsl;
 
 // Configuration
-static BSL_HostEID_t              app_eid;
-static struct sockaddr_in         over_addr   = { .sin_family = 0 };
-static struct sockaddr_in         app_addr    = { .sin_family = 0 };
-static struct sockaddr_in         under_addr  = { .sin_family = 0 };
-static struct sockaddr_in         router_addr = { .sin_family = 0 };
-static int                        tx_notify_r, tx_notify_w;
-static BSL_HostEID_t              sec_eid;
-static bool                       policy_configured = false;
-static mock_bpa_policy_registry_t policy_registry;
+static BSL_HostEID_t app_eid;
+static BSL_HostEID_t sec_eid;
+/// Agent for this process
+static MockBPA_Agent_t agent;
 
 static int ingest_netaddr(struct sockaddr_in *addr, const char *arg)
 {
@@ -115,503 +85,10 @@ static int ingest_netaddr(struct sockaddr_in *addr, const char *arg)
     return 0;
 }
 
-static int bind_udp(int *sock, const struct sockaddr_in *addr)
+static void sig_stop(int signum)
 {
-    *sock = socket(addr->sin_family, SOCK_DGRAM, IPPROTO_UDP);
-    if (*sock < 0)
-    {
-        BSL_LOG_ERR("Failed to open UDP socket");
-        return 2;
-    }
-    {
-        char nodebuf[INET_ADDRSTRLEN];
-        inet_ntop(addr->sin_family, &addr->sin_addr, nodebuf, sizeof(nodebuf));
-        BSL_LOG_DEBUG("Binding UDP socket to [%s]:%d", nodebuf, ntohs(addr->sin_port));
-
-        int res = bind(*sock, (struct sockaddr *)addr, sizeof(*addr));
-        if (res)
-        {
-            close(*sock);
-            BSL_LOG_ERR("Failed to bind UDP socket, errno %d", errno);
-            return 3;
-        }
-    }
-
-    return 0;
-}
-
-static int mock_bpa_process(BSL_PolicyLocation_e loc, MockBPA_Bundle_t *bundle)
-{
-    (void)loc;
-    (void)bundle;
-    BSL_LOG_INFO("Mock BPA: Invoking mock_bpa_process");
-    BSL_SecurityActionSet_t   *malloced_action_set   = BSL_CALLOC(1, BSL_SecurityActionSet_Sizeof());
-    BSL_SecurityResponseSet_t *malloced_response_set = BSL_CALLOC(1, BSL_SecurityResponseSet_Sizeof());
-    int                        returncode            = -1;
-
-    BSL_BundleRef_t bundle_ref = { 0 };
-    bundle_ref.data            = bundle;
-    BSL_LOG_INFO("Mock BPA: Calling BSL_API_QuerySecurity");
-    returncode = BSL_API_QuerySecurity(bsl, malloced_action_set, &bundle_ref, loc);
-    if (returncode != 0)
-    {
-        BSL_LOG_ERR("Failed to query security: code=%d", returncode);
-        goto cleanup;
-    }
-
-    BSL_LOG_INFO("Mock BPA: Calling BSL_API_ApplySecurity");
-    returncode = BSL_API_ApplySecurity(bsl, malloced_response_set, &bundle_ref, malloced_action_set);
-    if (returncode < 0)
-    {
-        BSL_LOG_ERR("Failed to apply security: code=%d", returncode);
-        goto cleanup;
-    }
-
-    BSL_LOG_INFO("Mock BPA: mock_bpa_process SUCCESS (code=0)");
-
-cleanup:
-    BSL_SecurityActionSet_Deinit(malloced_action_set);
-    BSL_FREE(malloced_action_set);
-    BSL_FREE(malloced_response_set);
-    return returncode;
-}
-
-static void sig_stop(int signum _U_)
-{
-    atomic_store(&stop_state, true);
     BSL_LOG_INFO("signal received %d", signum);
-
-    uint8_t buf    = 0;
-    int     nbytes = write(tx_notify_w, &buf, sizeof(buf));
-    if (nbytes < 0)
-    {
-        BSL_LOG_ERR("Failed to write: %ld", nbytes);
-    }
-}
-
-static void *work_over_rx(void *arg _U_)
-{
-    BSL_LOG_INFO("work_over_rx started");
-    while (true)
-    {
-        mock_bpa_ctr_t item;
-        data_queue_pop(&item, over_rx);
-        if (item.encoded.len == 0)
-        {
-            mock_bpa_ctr_deinit(&item);
-            break;
-        }
-        BSL_LOG_INFO("over_rx item");
-        mock_bpa_decode(&item);
-
-        if (mock_bpa_process(BSL_POLICYLOCATION_APPIN, item.bundle_ref.data))
-        {
-            BSL_LOG_ERR("work_over_rx failed security processing");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
-        if (!bundle->retain)
-        {
-            BSL_LOG_ERR("bundle was marked to delete by BSL");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        // loopback
-        data_queue_push(deliver, item);
-    }
-    BSL_LOG_INFO("work_over_rx stopped");
-
-    return NULL;
-}
-
-static void *work_under_rx(void *arg _U_)
-{
-    BSL_LOG_INFO("work_under_rx started");
-    while (true)
-    {
-        mock_bpa_ctr_t item;
-        data_queue_pop(&item, under_rx);
-        if (item.encoded.len == 0)
-        {
-            mock_bpa_ctr_deinit(&item);
-            break;
-        }
-
-        BSL_LOG_INFO("under_rx item");
-        if (mock_bpa_decode(&item))
-        {
-            BSL_LOG_ERR("work_under_rx failed to decode bundle");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        if (mock_bpa_process(BSL_POLICYLOCATION_CLIN, item.bundle_ref.data))
-        {
-            BSL_LOG_ERR("work_under_rx failed security processing");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
-        if (!bundle->retain)
-        {
-            BSL_LOG_ERR("bundle was marked to delete by BSL");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        // loopback
-        data_queue_push(forward, item);
-    }
-    BSL_LOG_INFO("work_under_rx stopped");
-
-    return NULL;
-}
-
-static void *work_deliver(void *arg _U_)
-{
-    BSL_LOG_INFO("work_deliver started");
-    while (true)
-    {
-        mock_bpa_ctr_t item;
-        data_queue_pop(&item, deliver);
-        if (item.encoded.len == 0)
-        {
-            mock_bpa_ctr_deinit(&item);
-            break;
-        }
-        BSL_LOG_INFO("deliver item");
-
-        if (mock_bpa_process(BSL_POLICYLOCATION_APPOUT, item.bundle_ref.data))
-        {
-            BSL_LOG_ERR("work_deliver failed security processing");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
-        if (!bundle->retain)
-        {
-            BSL_LOG_ERR("bundle was marked to delete by BSL");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        mock_bpa_encode(&item);
-        data_queue_push(over_tx, item);
-        {
-            uint8_t buf    = 0;
-            int     nbytes = write(tx_notify_w, &buf, sizeof(buf));
-            if (nbytes < 0)
-            {
-                BSL_LOG_ERR("Failed to write: %ld", nbytes);
-            }
-        }
-    }
-    BSL_LOG_INFO("work_deliver stopped");
-
-    return NULL;
-}
-
-static void *work_forward(void *arg _U_)
-{
-    BSL_LOG_INFO("work_forward started");
-    while (true)
-    {
-        mock_bpa_ctr_t item;
-        data_queue_pop(&item, forward);
-        if (item.encoded.len == 0)
-        {
-            mock_bpa_ctr_deinit(&item);
-            break;
-        }
-        BSL_LOG_INFO("forward item");
-
-        if (mock_bpa_process(BSL_POLICYLOCATION_CLOUT, item.bundle_ref.data))
-        {
-            BSL_LOG_ERR("work_forward failed security processing");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        MockBPA_Bundle_t *bundle = item.bundle_ref.data;
-        if (!bundle->retain)
-        {
-            BSL_LOG_ERR("bundle was marked to delete by BSL");
-            mock_bpa_ctr_deinit(&item);
-            continue;
-        }
-
-        mock_bpa_encode(&item);
-        data_queue_push(under_tx, item);
-        {
-            uint8_t buf    = 0;
-            int     nbytes = write(tx_notify_w, &buf, sizeof(uint8_t));
-            if (nbytes < 0)
-            {
-                BSL_LOG_ERR("Failed to write, got %ld", nbytes);
-            }
-        }
-    }
-    BSL_LOG_INFO("work_forward stopped");
-
-    return NULL;
-}
-
-static int bpa_init(void)
-{
-    {
-        struct sigaction stopper = {
-            .sa_handler = sig_stop,
-        };
-        sigaction(SIGINT, &stopper, NULL);
-        sigaction(SIGTERM, &stopper, NULL);
-    }
-
-    data_queue_init(over_rx, DATA_QUEUE_SIZE);
-    data_queue_init(over_tx, DATA_QUEUE_SIZE);
-    data_queue_init(under_rx, DATA_QUEUE_SIZE);
-    data_queue_init(under_tx, DATA_QUEUE_SIZE);
-    data_queue_init(deliver, DATA_QUEUE_SIZE);
-    data_queue_init(forward, DATA_QUEUE_SIZE);
-
-    {
-        // event socket for waking the I/O thread
-        int fds[2];
-        if (pipe(fds) != 0)
-        {
-            return 3;
-        }
-        tx_notify_r = fds[0];
-        tx_notify_w = fds[1];
-    }
-
-    if (pthread_create(&thr_under_rx, NULL, work_under_rx, NULL))
-    {
-        return 2;
-    }
-    if (pthread_create(&thr_over_rx, NULL, work_over_rx, NULL))
-    {
-        return 2;
-    }
-    if (pthread_create(&thr_deliver, NULL, work_deliver, NULL))
-    {
-        return 2;
-    }
-    if (pthread_create(&thr_forward, NULL, work_forward, NULL))
-    {
-        return 2;
-    }
-    return 0;
-}
-
-static int bpa_exec(void)
-{
-    int retval = 0;
-
-    int over_sock, under_sock;
-    if (bind_udp(&over_sock, &over_addr))
-    {
-        return 3;
-    }
-    if (bind_udp(&under_sock, &under_addr))
-    {
-        return 3;
-    }
-
-    struct pollfd pfds[] = {
-        { .fd = tx_notify_r, .events = POLLIN },
-        { .fd = under_sock },
-        { .fd = over_sock },
-    };
-    struct pollfd *const tx_notify_pfd = pfds;
-    struct pollfd *const under_pfd     = pfds + 1;
-    struct pollfd *const over_pfd      = pfds + 2;
-
-    BSL_LOG_INFO("READY");
-
-    while (!atomic_load(&stop_state))
-    {
-        under_pfd->events = POLLIN;
-        if (!data_queue_empty_p(under_tx))
-        {
-            under_pfd->events |= POLLOUT;
-        }
-
-        over_pfd->events = POLLIN;
-        if (!data_queue_empty_p(over_tx))
-        {
-            over_pfd->events |= POLLOUT;
-        }
-
-        int res = poll(pfds, sizeof(pfds) / sizeof(struct pollfd), -1);
-        if (res < 0)
-        {
-            BSL_LOG_ERR("poll failed with errno: %d", errno);
-            if (errno != EINTR)
-            {
-                retval = 4;
-            }
-            break;
-        }
-
-        if (tx_notify_pfd->revents & POLLIN)
-        {
-            // no actual data, just clear the pipe
-            uint8_t buf;
-            int     nbytes = read(tx_notify_r, &buf, sizeof(uint8_t));
-            if (nbytes < 0)
-            {
-                BSL_LOG_ERR("Cannot read: %ld", nbytes);
-            }
-        }
-
-        if (over_pfd->revents & POLLIN)
-        {
-            uint8_t      buf[65536];
-            struct iovec iov = {
-                .iov_base = buf,
-                .iov_len  = sizeof(buf),
-            };
-            struct msghdr msg = {
-                .msg_iovlen = 1,
-                .msg_iov    = &iov,
-            };
-            ssize_t got = recvmsg(over_sock, &msg, 0);
-            if (got > 0)
-            {
-                BSL_LOG_DEBUG("over_sock recv %zd", got);
-                mock_bpa_ctr_t item;
-                mock_bpa_ctr_init(&item);
-                BSL_Data_AppendFrom(&item.encoded, got, buf);
-
-                data_queue_push(over_rx, item);
-            }
-        }
-        if (over_pfd->revents & POLLOUT)
-        {
-            mock_bpa_ctr_t item;
-            data_queue_pop(&item, over_tx);
-
-            BSL_LOG_DEBUG("over_sock send %zd", item.encoded.len);
-            struct iovec iov = {
-                .iov_base = item.encoded.ptr,
-                .iov_len  = item.encoded.len,
-            };
-            struct msghdr msg = {
-                .msg_name    = &app_addr,
-                .msg_namelen = sizeof(app_addr),
-                .msg_iovlen  = 1,
-                .msg_iov     = &iov,
-            };
-            ssize_t got = sendmsg(over_sock, &msg, 0);
-            if (got != (ssize_t)item.encoded.len)
-            {
-                BSL_LOG_ERR("over_sock failed to send all %zd bytes, only %zd sent: %d", item.encoded.len, got, errno);
-            }
-            mock_bpa_ctr_deinit(&item);
-        }
-
-        if (under_pfd->revents & POLLIN)
-        {
-            uint8_t      buf[65536];
-            struct iovec iov = {
-                .iov_base = buf,
-                .iov_len  = sizeof(buf),
-            };
-            struct msghdr msg = {
-                .msg_iovlen = 1,
-                .msg_iov    = &iov,
-            };
-            ssize_t got = recvmsg(under_sock, &msg, 0);
-            if (got > 0)
-            {
-                BSL_LOG_DEBUG("under_sock recv %zd", got);
-                mock_bpa_ctr_t item;
-                mock_bpa_ctr_init(&item);
-                BSL_Data_AppendFrom(&item.encoded, got, buf);
-
-                data_queue_push(under_rx, item);
-            }
-        }
-        if (under_pfd->revents & POLLOUT)
-        {
-            mock_bpa_ctr_t item;
-            data_queue_pop(&item, under_tx);
-
-            BSL_LOG_DEBUG("under_sock send %zd", item.encoded.len);
-            struct iovec iov = {
-                .iov_base = item.encoded.ptr,
-                .iov_len  = item.encoded.len,
-            };
-            struct msghdr msg = {
-                .msg_name    = &router_addr,
-                .msg_namelen = sizeof(router_addr),
-                .msg_iovlen  = 1,
-                .msg_iov     = &iov,
-            };
-            ssize_t got = sendmsg(under_sock, &msg, 0);
-            if (got != (ssize_t)item.encoded.len)
-            {
-                BSL_LOG_ERR("under_sock failed to send all %zd bytes, only %zd sent", item.encoded.len, got);
-            }
-            mock_bpa_ctr_deinit(&item);
-        }
-    }
-
-    close(over_sock);
-    close(under_sock);
-    return retval;
-}
-
-static void bpa_cleanup(void)
-{
-    BSL_LOG_INFO("cleaning up");
-    mock_bpa_ctr_t item;
-
-    // join RX workers first
-    mock_bpa_ctr_init(&item);
-    data_queue_push(under_rx, item);
-    mock_bpa_ctr_init(&item);
-    data_queue_push(over_rx, item);
-    if (pthread_join(thr_under_rx, NULL))
-    {
-        BSL_LOG_ERR("Failed to join the work_under_rx");
-    }
-    if (pthread_join(thr_over_rx, NULL))
-    {
-        BSL_LOG_ERR("Failed to join the work_over_rx");
-    }
-
-    // then delivery/forward workers after RX are all flushed
-    mock_bpa_ctr_init(&item);
-    data_queue_push(forward, item);
-    mock_bpa_ctr_init(&item);
-    data_queue_push(deliver, item);
-    if (pthread_join(thr_forward, NULL))
-    {
-        BSL_LOG_ERR("Failed to join the work_forward");
-    }
-    if (pthread_join(thr_deliver, NULL))
-    {
-        BSL_LOG_ERR("Failed to join the work_deliver");
-    }
-
-    close(tx_notify_r);
-    close(tx_notify_w);
-    data_queue_clear(over_rx);
-    data_queue_clear(over_tx);
-    data_queue_clear(under_rx);
-    data_queue_clear(under_tx);
-    data_queue_clear(deliver);
-    data_queue_clear(forward);
-
-    BSL_HostEID_Deinit(&sec_eid);
-    BSL_HostEID_Deinit(&app_eid);
-    ASSERT_PROPERTY(BSL_API_DeinitLib(bsl) == 0);
+    MockBPA_Agent_Stop(&agent);
 }
 
 static void show_usage(const char *argv0)
@@ -625,48 +102,30 @@ static void show_usage(const char *argv0)
             argv0);
 }
 
-#include <security_context/DefaultSecContext.h>
-#include <policy_provider/SamplePolicyProvider.h>
-
 int main(int argc, char **argv)
 {
     BSL_openlog();
     int retval = 0;
-
-    atomic_init(&stop_state, false);
-
-    if (bsl_mock_bpa_agent_init())
-    {
-        BSL_LOG_ERR("Failed to initialize mock BPA");
-        retval = 2;
-    }
-
-    // TODO XXX FIX BEFORE MERGE!!
-    bsl = BSL_CALLOC(1, BSL_LibCtx_Sizeof());
-    if (BSL_API_InitLib(bsl))
-    {
-        BSL_LOG_ERR("Failed to initialize BSL");
-        retval = 2;
-    }
-
-    BSL_PolicyDesc_t policy_callbacks = { .deinit_fn   = BSLP_Deinit,
-                                          .query_fn    = BSLP_QueryPolicy,
-                                          .finalize_fn = BSLP_FinalizePolicy,
-                                          .user_data   = BSL_CALLOC(1, sizeof(BSLP_PolicyProvider_t)) };
-    ASSERT_PROPERTY(BSL_SUCCESS == BSL_API_RegisterPolicyProvider(bsl, 1, policy_callbacks));
+    int res;
 
     BSL_CryptoInit();
-
-    BSL_SecCtxDesc_t bib_sec_desc;
-    bib_sec_desc.execute  = BSLX_BIB_Execute;
-    bib_sec_desc.validate = BSLX_BIB_Validate;
-    ASSERT_PROPERTY(0 == BSL_API_RegisterSecurityContext(bsl, 1, bib_sec_desc));
-
-    BSL_SecCtxDesc_t bcb_sec_desc;
-    bcb_sec_desc.execute  = BSLX_BCB_Execute;
-    bcb_sec_desc.validate = BSLX_BCB_Validate;
-    ASSERT_PROPERTY(0 == BSL_API_RegisterSecurityContext(bsl, 2, bcb_sec_desc));
-
+    if ((res = MockBPA_Agent_Init(&agent)))
+    {
+        BSL_LOG_ERR("Failed to initialize mock BPA, error %d", res);
+        retval = 2;
+    }
+    {
+        struct sigaction stopper = {
+            .sa_handler = sig_stop,
+        };
+        sigaction(SIGINT, &stopper, NULL);
+        sigaction(SIGTERM, &stopper, NULL);
+    }
+    // always run these steps
+    if (BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(&agent)))
+    {
+        retval = 2;
+    }
     BSL_HostEID_Init(&app_eid);
     BSL_HostEID_Init(&sec_eid);
 
@@ -678,16 +137,16 @@ int main(int argc, char **argv)
             switch (opt)
             {
                 case 'o':
-                    ingest_netaddr(&over_addr, optarg);
+                    ingest_netaddr(&agent.over_addr, optarg);
                     break;
                 case 'a':
-                    ingest_netaddr(&app_addr, optarg);
+                    ingest_netaddr(&agent.app_addr, optarg);
                     break;
                 case 'u':
-                    ingest_netaddr(&under_addr, optarg);
+                    ingest_netaddr(&agent.under_addr, optarg);
                     break;
                 case 'r':
-                    ingest_netaddr(&router_addr, optarg);
+                    ingest_netaddr(&agent.router_addr, optarg);
                     break;
                 case 'e':
                     if (BSL_HostEID_DecodeFromText(&app_eid, optarg))
@@ -707,14 +166,12 @@ int main(int argc, char **argv)
                     break;
                 case 'h':
                 case 'p':
-                    mock_bpa_policy_registry_init(&policy_registry);
-                    mock_bpa_handle_policy_config(optarg, policy_callbacks.user_data, &policy_registry);
+                    mock_bpa_handle_policy_config(optarg, agent.policy_callbacks.user_data, &agent.policy_registry);
 
                     // TODO JSON parsing
                     // // mock_bpa_handle_policy_config_from_json("src/mock_bpa/policy_provider_test.json",
                     // policy_callbacks.user_data);
 
-                    policy_configured = true;
                     break;
                 case 'k':
                     if (mock_bpa_key_registry_init(optarg))
@@ -726,25 +183,25 @@ int main(int argc, char **argv)
                     break;
             }
         }
-        if (!retval && (over_addr.sin_family != AF_INET))
+        if (!retval && (agent.over_addr.sin_family != AF_INET))
         {
             BSL_LOG_ERR("Missing over-socket address\n");
             show_usage(argv[0]);
             retval = 1;
         }
-        if (!retval && (app_addr.sin_family != AF_INET))
+        if (!retval && (agent.app_addr.sin_family != AF_INET))
         {
             BSL_LOG_ERR("Missing application address\n");
             show_usage(argv[0]);
             retval = 1;
         }
-        if (!retval && (under_addr.sin_family != AF_INET))
+        if (!retval && (agent.under_addr.sin_family != AF_INET))
         {
             BSL_LOG_ERR("Missing under-socket address\n");
             show_usage(argv[0]);
             retval = 1;
         }
-        if (!retval && (router_addr.sin_family != AF_INET))
+        if (!retval && (agent.router_addr.sin_family != AF_INET))
         {
             BSL_LOG_ERR("Missing router address\n");
             show_usage(argv[0]);
@@ -754,27 +211,23 @@ int main(int argc, char **argv)
 
     if (!retval)
     {
-        retval = bpa_init();
+        retval = MockBPA_Agent_Start(&agent);
     }
     if (!retval)
     {
-        retval = bpa_exec();
-    }
-
-    if (policy_configured)
-    {
-        mock_bpa_policy_registry_deinit(&policy_registry);
-        policy_configured = false;
+        retval = MockBPA_Agent_Exec(&agent);
     }
 
     if (retval != 1)
     {
-        bpa_cleanup();
+        MockBPA_Agent_Join(&agent);
     }
 
+    MockBPA_Agent_Deinit(&agent);
+    BSL_HostEID_Deinit(&sec_eid);
+    BSL_HostEID_Deinit(&app_eid);
+    BSL_HostDescriptors_Clear();
     BSL_CryptoDeinit();
-    bsl_mock_bpa_agent_deinit();
     BSL_closelog();
-    BSL_FREE(bsl);
     return retval;
 }

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -129,6 +129,10 @@ int main(int argc, char **argv)
     BSL_HostEID_Init(&app_eid);
     BSL_HostEID_Init(&sec_eid);
 
+    /// Definitions of policy for all BSL instances
+    mock_bpa_policy_registry_t policy_registry;
+    mock_bpa_policy_registry_init(&policy_registry);
+
     if (!retval)
     {
         int opt;
@@ -164,9 +168,12 @@ int main(int argc, char **argv)
                         retval = 1;
                     }
                     break;
-                case 'h':
                 case 'p':
-                    mock_bpa_handle_policy_config(optarg, agent.policy_callbacks.user_data, &agent.policy_registry);
+                    // TODO better way to handle this
+                    mock_bpa_handle_policy_config(optarg, agent.policy_appin, &policy_registry);
+                    mock_bpa_handle_policy_config(optarg, agent.policy_appout, &policy_registry);
+                    mock_bpa_handle_policy_config(optarg, agent.policy_clin, &policy_registry);
+                    mock_bpa_handle_policy_config(optarg, agent.policy_clout, &policy_registry);
 
                     // TODO JSON parsing
                     // // mock_bpa_handle_policy_config_from_json("src/mock_bpa/policy_provider_test.json",
@@ -177,6 +184,7 @@ int main(int argc, char **argv)
                     if (mock_bpa_key_registry_init(optarg))
                         retval = 1;
                     break;
+                case 'h':
                 default:
                     show_usage(argv[0]);
                     retval = 1;
@@ -223,6 +231,7 @@ int main(int argc, char **argv)
         MockBPA_Agent_Join(&agent);
     }
 
+    mock_bpa_policy_registry_deinit(&policy_registry);
     MockBPA_Agent_Deinit(&agent);
     BSL_HostEID_Deinit(&sec_eid);
     BSL_HostEID_Deinit(&app_eid);

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -158,8 +158,6 @@ int main(int argc, char **argv)
                         BSL_LOG_ERR("Failed to decode app EID: %s", optarg);
                         retval = 1;
                     }
-                    BSL_LOG_INFO("SETTING IPN EID: %s", optarg);
-                    setenv("BSL_TEST_LOCAL_IPN_EID", optarg, 1);
                     break;
                 case 's':
                     if (BSL_HostEID_DecodeFromText(&sec_eid, optarg))
@@ -167,6 +165,7 @@ int main(int argc, char **argv)
                         BSL_LOG_ERR("Failed to decode BPSec EID: %s", optarg);
                         retval = 1;
                     }
+                    setenv("BSL_TEST_LOCAL_IPN_EID", optarg, 1);
                     break;
                 case 'p':
                 {

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -553,7 +553,7 @@ int mock_bpa_handle_policy_config(const char *policies, BSLP_PolicyProvider_t *p
 {
     // Split up and register each policy
     const char *curs = policies;
-    char *pend;
+    char       *pend;
     while (true)
     {
         mock_bpa_policy_params_t *params = mock_bpa_policy_registry_get(reg);

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -549,30 +549,41 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     BSLP_PolicyRule_AddParam(rule_all_in, params->param_test_key);
 }
 
-void mock_bpa_handle_policy_config(char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg)
+int mock_bpa_handle_policy_config(const char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg)
 {
-
-    char *pt;
-
     // Split up and register each policy
-    pt = strtok(policies, ",");
-    while (pt != NULL)
+    const char *curs = policies;
+    char *pend;
+    while (true)
     {
-
         mock_bpa_policy_params_t *params = mock_bpa_policy_registry_get(reg);
+        if (!params)
+        {
+            BSL_LOG_CRIT("POLICY COUNT EXCEEDED, NOT REGISTERING FURTHER");
+            return -1;
+        }
 
-        if (params != NULL)
+        uint32_t val = strtoul(curs, &pend, 0);
+        if (pend == curs)
         {
-            mock_bpa_register_policy(strtoul(pt, NULL, 0), policy, params);
+            BSL_LOG_ERR("Failed to decode policy integer at: %s", curs);
         }
-        else
+        curs = pend;
+        mock_bpa_register_policy(val, policy, params);
+
+        if (*curs == '\0')
         {
-            BSL_LOG_ERR("\nPOLICY COUNT EXCEEDED, NOT REGISTERING FURTHER\n");
+            break;
         }
-        pt = strtok(NULL, ",");
+        else if (*curs != ',')
+        {
+            BSL_LOG_ERR("Failed to decode policy list (expecting comma) at: %s", curs);
+        }
+        curs += 1;
     }
 
-    BSL_LOG_DEBUG("Successfully created policy registry of size: %d\n", mock_bpa_policy_registry_size(reg));
+    BSL_LOG_DEBUG("Successfully created policy registry of size: %d", mock_bpa_policy_registry_size(reg));
+    return 0;
 }
 
 int mock_bpa_key_registry_init(const char *pp_cfg_file_path)

--- a/src/mock_bpa/policy_config.h
+++ b/src/mock_bpa/policy_config.h
@@ -74,7 +74,7 @@ extern "C" {
  */
 typedef uint32_t bsl_mock_policy_configuration_t;
 
-void mock_bpa_handle_policy_config(char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg);
+int mock_bpa_handle_policy_config(const char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg);
 
 void mock_bpa_handle_policy_config_from_json(const char *pp_cfg_file_path, BSLP_PolicyProvider_t *policy);
 

--- a/src/mock_bpa/policy_registry.c
+++ b/src/mock_bpa/policy_registry.c
@@ -36,7 +36,7 @@ void mock_bpa_policy_registry_init(mock_bpa_policy_registry_t *registry)
     registry->registry_count = 0;
 }
 
-int mock_bpa_policy_registry_size(mock_bpa_policy_registry_t *registry)
+int mock_bpa_policy_registry_size(const mock_bpa_policy_registry_t *registry)
 {
     return registry->registry_count;
 }

--- a/src/mock_bpa/policy_registry.h
+++ b/src/mock_bpa/policy_registry.h
@@ -47,7 +47,7 @@ typedef struct mock_bpa_policy_registry
 
 void mock_bpa_policy_registry_init(mock_bpa_policy_registry_t *registry);
 
-int mock_bpa_policy_registry_size(mock_bpa_policy_registry_t *registry);
+int mock_bpa_policy_registry_size(const mock_bpa_policy_registry_t *registry);
 
 mock_bpa_policy_params_t *mock_bpa_policy_registry_get(mock_bpa_policy_registry_t *registry);
 

--- a/test/fuzz_dynamic_asb_cbor.cpp
+++ b/test/fuzz_dynamic_asb_cbor.cpp
@@ -36,13 +36,9 @@ extern "C" int LLVMFuzzerInitialize(int *argc _U_, char ***argv _U_)
 {
     BSL_openlog();
     BSL_LogSetLeastSeverity(LOG_CRIT);
-    bsl_mock_bpa_agent_init();
+    BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL));
     return 0;
 }
-/* No cleanup:
-    bsl_mock_bpa_agent_deinit();
-    BSL_closelog();
-*/
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/test/fuzz_dynamic_asb_cbor.cpp
+++ b/test/fuzz_dynamic_asb_cbor.cpp
@@ -19,7 +19,7 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <BPSecLib_Private.h>
+#include <mock_bpa/MockBPA.h>
 #include "bsl_test_utils.h"
 #include <cinttypes>
 

--- a/test/fuzz_mock_bpa_bpv7_cbor.cpp
+++ b/test/fuzz_mock_bpa_bpv7_cbor.cpp
@@ -36,13 +36,9 @@ extern "C" int LLVMFuzzerInitialize(int *argc _U_, char ***argv _U_)
 {
     BSL_openlog();
     BSL_LogSetLeastSeverity(LOG_CRIT);
-    bsl_mock_bpa_agent_init();
+    BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL));
     return 0;
 }
-/* No cleanup:
-    bsl_mock_bpa_agent_deinit();
-    BSL_closelog();
-*/
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/test/fuzz_mock_bpa_eid_cbor.cpp
+++ b/test/fuzz_mock_bpa_eid_cbor.cpp
@@ -35,13 +35,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 extern "C" int LLVMFuzzerInitialize(int *argc _U_, char ***argv _U_)
 {
     BSL_openlog();
-    bsl_mock_bpa_agent_init();
+    BSL_LogSetLeastSeverity(LOG_CRIT);
+    BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL));
     return 0;
 }
-/* No cleanup:
-    bsl_mock_bpa_agent_deinit();
-    BSL_closelog();
-*/
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/test/fuzz_mock_bpa_eid_uri.cpp
+++ b/test/fuzz_mock_bpa_eid_uri.cpp
@@ -37,13 +37,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 extern "C" int LLVMFuzzerInitialize(int *argc _U_, char ***argv _U_)
 {
     BSL_openlog();
-    bsl_mock_bpa_agent_init();
+    BSL_LogSetLeastSeverity(LOG_CRIT);
+    BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL));
     return 0;
 }
-/* No cleanup:
-    bsl_mock_bpa_agent_deinit();
-    BSL_closelog();
-*/
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/test/fuzz_mock_bpa_eidpat_text.cpp
+++ b/test/fuzz_mock_bpa_eidpat_text.cpp
@@ -37,13 +37,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
 extern "C" int LLVMFuzzerInitialize(int *argc _U_, char ***argv _U_)
 {
     BSL_openlog();
-    bsl_mock_bpa_agent_init();
+    BSL_LogSetLeastSeverity(LOG_CRIT);
+    BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL));
     return 0;
 }
-/* No cleanup:
-    bsl_mock_bpa_agent_deinit();
-    BSL_closelog();
-*/
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -46,7 +46,7 @@ void setUp(void)
 {
     BSL_openlog();
     memset(&LocalTestCtx, 0, sizeof(LocalTestCtx));
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
     setenv("BSL_TEST_LOCAL_IPN_EID", "ipn:2.1", 1);
     TEST_ASSERT_EQUAL(0, BSL_API_InitLib(&LocalTestCtx.bsl));
 
@@ -65,7 +65,7 @@ void tearDown(void)
 {
     mock_bpa_ctr_deinit(&LocalTestCtx.mock_bpa_ctr);
     TEST_ASSERT_EQUAL(0, BSL_API_DeinitLib(&LocalTestCtx.bsl));
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
 }
 

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -47,12 +47,12 @@ static BSL_TestContext_t LocalTestCtx;
 void suiteSetUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -52,12 +52,12 @@ static BSL_TestContext_t LocalTestCtx;
 void suiteSetUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -51,12 +51,12 @@ static void printencoded(const uint8_t *pEncoded, size_t nLen)
 void suiteSetUp(void)
 {
     BSL_openlog();
-    TEST_ASSERT_EQUAL_INT(0, bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }

--- a/test/test_MockBPA_EID.c
+++ b/test/test_MockBPA_EID.c
@@ -30,12 +30,12 @@
 void suiteSetUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -27,6 +27,7 @@
 #include <backend/SecurityResultSet.h>
 #include <policy_provider/SamplePolicyProvider.h>
 #include <security_context/rfc9173.h>
+#include <mock_bpa/agent.h>
 
 #include "bsl_test_utils.h"
 
@@ -36,12 +37,12 @@ static BSL_SecurityActionSet_t action_set   = { 0 };
 void suiteSetUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -41,7 +41,7 @@ static BSL_TestContext_t LocalTestCtx;
 void setUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
     setenv("BSL_TEST_LOCAL_IPN_EID", "ipn:2.1", 1);
     memset(&LocalTestCtx, 0, sizeof(LocalTestCtx));
     TEST_ASSERT_EQUAL(0, BSL_API_InitLib(&LocalTestCtx.bsl));
@@ -53,7 +53,7 @@ void tearDown(void)
     mock_bpa_ctr_deinit(&LocalTestCtx.mock_bpa_ctr);
     // BSL_BundleCtx_Deinit(LocalTestCtx.bundle);
     TEST_ASSERT_EQUAL(0, BSL_API_DeinitLib(&LocalTestCtx.bsl));
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
 }
 

--- a/test/test_SecurityTypes.c
+++ b/test/test_SecurityTypes.c
@@ -37,12 +37,12 @@
 void setUp(void)
 {
     BSL_openlog();
-    assert(0 == bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 void tearDown(void)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
 }
 

--- a/test/test_mock_bpa_ctr.c
+++ b/test/test_mock_bpa_ctr.c
@@ -23,16 +23,17 @@
 #include <unity.h>
 #include "bsl_test_utils.h"
 #include <mock_bpa/ctr.h>
+#include <mock_bpa/agent.h>
 
 void suiteSetUp(void)
 {
     BSL_openlog();
-    TEST_ASSERT_EQUAL_INT(0, bsl_mock_bpa_agent_init());
+    TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
 }
 
 int suiteTearDown(int failures)
 {
-    bsl_mock_bpa_agent_deinit();
+    BSL_HostDescriptors_Clear();
     BSL_closelog();
     return failures;
 }


### PR DESCRIPTION
Reworked the mock BPA agent state to use its own state struct, and keeping one BSL context for each interaction point.

Closes #83 