### PR TITLE
Remove Fixed-length arrays in Security Response Set

### DIFF
--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1155,7 +1155,7 @@ size_t BSL_SecurityResponseSet_Sizeof(void);
  * @todo This is still undefined.
  *
  */
-void BSL_SecurityResponseSet_Init(BSL_SecurityResponseSet_t *self, size_t noperations, size_t nfailed);
+void BSL_SecurityResponseSet_Init(BSL_SecurityResponseSet_t *self);
 
 /** Zeroize itself and release any owned resources
  *
@@ -1174,6 +1174,13 @@ bool BSL_SecurityResponseSet_IsConsistent(const BSL_SecurityResponseSet_t *self)
  * @param[in] self This response set.
  */
 size_t BSL_SecurityResponseSet_CountResponses(const BSL_SecurityResponseSet_t *self);
+
+/** Append a result code to the security response set
+ * @param[in,out] self the response set to append result to
+ * @param[in] result the result code to append
+ * @param[in] err_act the on-error policy action associated with the response
+ */
+void BSL_SecurityResponseSet_AppendResult(BSL_SecurityResponseSet_t *self, int64_t result, BSL_PolicyAction_e err_act);
 
 /** Queries the policy provider for any security operations to take on the bundle.
  *

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -212,6 +212,8 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
     CHK_ARG_NONNULL(bundle);
     CHK_ARG_NONNULL(policy_actions);
 
+    BSL_SecurityResponseSet_Init(response_output);
+
     int exec_code = BSL_SecCtx_ExecutePolicyActionSet((BSL_LibCtx_t *)bsl, response_output, bundle, policy_actions);
     if (exec_code < BSL_SUCCESS)
     {
@@ -274,6 +276,8 @@ int BSL_API_ApplySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityResponseSet_t *re
             }
         }
     }
+
+    BSL_SecurityResponseSet_Deinit(response_output);
 
     // TODO CHK_POSTCONDITION
     return BSL_SUCCESS;

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -472,7 +472,6 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
     CHK_PRECONDITION(BSL_SecurityActionSet_IsConsistent(action_set));
     // NOLINTEND
 
-    BSL_SecurityResponseSet_Init(output_response, BSL_SecurityActionSet_CountOperations(action_set), 0);
     /**
      * Notes:
      *  - It should evaluate every security operation, even if earlier ones failed.
@@ -518,13 +517,15 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
 
             BSL_SecOutcome_Deinit(outcome);
 
-            if (errcode != 0)
+            if (errcode != BSL_SUCCESS)
             {
                 BSL_LOG_ERR("Security Op failed: %d", errcode);
                 BSL_SecOper_SetConclusion(sec_oper, BSL_SECOP_CONCLUSION_FAILURE);
+                BSL_SecurityResponseSet_AppendResult(output_response, errcode, sec_oper->failure_code);
                 break; // stop processing secops if there is a failure
             }
             BSL_SecOper_SetConclusion(sec_oper, BSL_SECOP_CONCLUSION_SUCCESS);
+            BSL_SecurityResponseSet_AppendResult(output_response, errcode, sec_oper->failure_code);
         }
     }
     BSL_FREE(outcome);

--- a/src/backend/SecurityResultSet.c
+++ b/src/backend/SecurityResultSet.c
@@ -33,22 +33,23 @@ size_t BSL_SecurityResponseSet_Sizeof(void)
 bool BSL_SecurityResponseSet_IsConsistent(const BSL_SecurityResponseSet_t *self)
 {
     CHK_AS_BOOL(self != NULL);
-    CHK_AS_BOOL(self->err_msg[sizeof(self->err_msg) - 1] == '\0');
-    CHK_AS_BOOL(strlen(self->err_msg) < sizeof(self->err_msg));
+    ASSERT_PROPERTY(self->total_operations == BSL_SecResultSet_ResultCodes_size(self->results));
+    ASSERT_PROPERTY(self->total_operations == BSL_SecResultSet_ErrorActionCodes_size(self->err_action_codes));
     return true;
 }
 
-void BSL_SecurityResponseSet_Init(BSL_SecurityResponseSet_t *self, size_t noperations, size_t nfailed)
+void BSL_SecurityResponseSet_Init(BSL_SecurityResponseSet_t *self)
 {
     ASSERT_ARG_NONNULL(self);
-    self->failure_count    = nfailed;
-    self->total_operations = noperations;
-    self->err_code         = (nfailed == 0 && noperations > 1) ? 0 : 1;
+    BSL_SecResultSet_ResultCodes_init(self->results);
+    BSL_SecResultSet_ErrorActionCodes_init(self->err_action_codes);
 }
 
 void BSL_SecurityResponseSet_Deinit(BSL_SecurityResponseSet_t *self)
 {
     ASSERT_PRECONDITION(BSL_SecurityResponseSet_IsConsistent(self));
+    BSL_SecResultSet_ResultCodes_clear(self->results);
+    BSL_SecResultSet_ErrorActionCodes_clear(self->err_action_codes);
     memset(self, 0, sizeof(*self));
 }
 
@@ -56,4 +57,12 @@ size_t BSL_SecurityResponseSet_CountResponses(const BSL_SecurityResponseSet_t *s
 {
     ASSERT_PRECONDITION(BSL_SecurityResponseSet_IsConsistent(self));
     return self->total_operations;
+}
+
+void BSL_SecurityResponseSet_AppendResult(BSL_SecurityResponseSet_t *self, int64_t result, BSL_PolicyAction_e err_act)
+{
+    ASSERT_ARG_NONNULL(self);
+    BSL_SecResultSet_ResultCodes_push_back(self->results, result);
+    BSL_SecResultSet_ErrorActionCodes_push_back(self->err_action_codes, err_act);
+    self->total_operations++;
 }

--- a/src/backend/SecurityResultSet.h
+++ b/src/backend/SecurityResultSet.h
@@ -28,8 +28,14 @@
 
 #include <BPSecLib_Private.h>
 
-#define BSL_SECURITYRESPONSESET_ARRAYLEN (10)
-#define BSL_SECURITYRESPONSESET_STRLEN   (256)
+#include <m-array.h>
+
+// NOLINTBEGIN
+/// @cond Doxygen_Suppress
+M_ARRAY_DEF(BSL_SecResultSet_ResultCodes, int64_t, M_POD_OPLIST)
+M_ARRAY_DEF(BSL_SecResultSet_ErrorActionCodes, BSL_PolicyAction_e, M_POD_OPLIST)
+/// @endcond
+// NOLINTEND
 
 /// @brief Contains the results and outcomes after performing the security operations.
 /// @note This struct is still in-concept
@@ -37,12 +43,10 @@ struct BSL_SecurityResponseSet_s
 {
     /// @brief This maps to the Security Action sec_op_list,
     ///        and contains the result code of that security operation.
-    int                results[BSL_SECURITYRESPONSESET_ARRAYLEN];
-    char               err_msg[BSL_SECURITYRESPONSESET_STRLEN];
-    BSL_PolicyAction_e err_action_codes[BSL_SECURITYRESPONSESET_ARRAYLEN];
-    int                err_code;
-    size_t             total_operations;
-    size_t             failure_count;
+    BSL_SecResultSet_ResultCodes_t      results;
+    BSL_SecResultSet_ErrorActionCodes_t err_action_codes;
+    size_t                              total_operations;
+    size_t                              failure_count;
 };
 
 #endif /* BSLB_SECURITYRESULTSET_H_ */

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -405,6 +405,7 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BSL_SecurityActionSet_AppendAction(malloced_actionset, malloced_action);
 
     BSL_SecurityResponseSet_t *malloced_responseset = BSL_TestUtils_MallocEmptyPolicyResponse();
+    BSL_SecurityResponseSet_Init(malloced_responseset);
 
     const int exec_result = BSL_SecCtx_ExecutePolicyActionSet(&LocalTestCtx.bsl, malloced_responseset,
                                                               &mock_bpa_ctr->bundle_ref, malloced_actionset);
@@ -418,6 +419,8 @@ void test_RFC9173_AppendixA_Example3_Source(void)
 
     const size_t response_count = BSL_SecurityResponseSet_CountResponses(malloced_responseset);
     TEST_ASSERT_EQUAL(3, response_count);
+
+    BSL_SecurityResponseSet_Deinit(malloced_responseset);
 
     BSL_SecurityAction_Deinit(malloced_action);
     BSL_FREE(malloced_action);


### PR DESCRIPTION
Work towards #18 

As an aside: the response set struct is barely utilized within BSL, an enhancement could be to remove it altogether.