### PR TITLE
Have doxygen extract and show all source files

### DIFF
--- a/docs/api/Doxyfile.in
+++ b/docs/api/Doxyfile.in
@@ -492,7 +492,7 @@ NUM_PROC_THREADS       = 1
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.


### PR DESCRIPTION
This shows all the file names in the tree but does not inline the file contents.