### PR TITLE
Separate spellcheck failure from docs build in CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,6 +58,11 @@ jobs:
           -DBUILD_DOCS_API=ON
       - name: Build
         run: ./build.sh --target docs-api-html docs-api-pdf docs-api-misspelling
+      - name: Misspelling
+        env:
+          MISSPELLING_TXT: 'build/default/docs/api/misspelling.txt'
+        # success means file is present and empty
+        run: test -f "${MISSPELLING_TXT}" -a ! -s "${MISSPELLING_TXT}" || (cat "${MISSPELLING_TXT}"; exit 1)
       - name: Install
         run: ./build.sh install --component docs-api
       - name: Compress

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -20,8 +20,6 @@ the prime contract 80NM0018D0004 between the Caltech and NASA under
 subcontract 1700763.
 ]]
 
-include(GNUInstallDirs)
-
 find_package(Doxygen REQUIRED)
 
 find_program(XMLSTARLET_EXECUTABLE xmlstarlet)
@@ -97,10 +95,6 @@ if(XMLSTARLET_EXECUTABLE AND ASPELL_EXECUTABLE)
     add_custom_target(
         docs-api-misspelling
         DEPENDS "${MISSPELLING_TXT}"
-        COMMAND cat "${MISSPELLING_TXT}"
-        # success means file is present and empty
-        COMMAND test -f "${MISSPELLING_TXT}" -a ! -s "${MISSPELLING_TXT}"
-        COMMENT "Checking ${MISSPELLING_TXT}"
     )
 endif(XMLSTARLET_EXECUTABLE AND ASPELL_EXECUTABLE)
 


### PR DESCRIPTION
This makes misspelling failures easier to understand.