### PR TITLE
Refactor policy provider API and implementation

### DIFF
--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1321,10 +1321,10 @@ typedef void (*BSL_PolicyDeinit_f)(void *user_data);
 /// @brief Descriptor of opaque data and callbacks for Policy Provider.
 struct BSL_PolicyDesc_s
 {
-    void                *user_data;
+    void                *user_data;   ///< Reference to policy provider -specific data
     BSL_PolicyInspect_f  query_fn;    ///< Function pointer to query policy
     BSL_PolicyFinalize_f finalize_fn; ///< Function pointer to finalize policy
-    BSL_PolicyDeinit_f   deinit_fn;   ///< Function to deinit the policy provider at termination of BSL.
+    BSL_PolicyDeinit_f   deinit_fn;   ///< Function to deinit the policy provider at termination of BSL context
 };
 
 /** Call the underlying security context to perform the given action

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -1307,12 +1307,12 @@ int BSL_PolicyRegistry_FinalizeActions(const BSL_LibCtx_t *bsl, const BSL_Securi
                                        const BSL_BundleRef_t *bundle, const BSL_SecurityResponseSet_t *response_output);
 
 /// @brief Callback interface to query policy provider to populate the action set
-typedef int (*BSL_PolicyInspect_f)(const void *user_data, BSL_SecurityActionSet_t *output_action_set,
+typedef int (*BSL_PolicyInspect_f)(void *user_data, BSL_SecurityActionSet_t *output_action_set,
                                    const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location);
 
 /// @brief Callback interface to finalize policy provider over the action set. Finalize should ignore actions from
 /// different policy providers
-typedef int (*BSL_PolicyFinalize_f)(const void *user_data, const BSL_SecurityActionSet_t *output_action_set,
+typedef int (*BSL_PolicyFinalize_f)(void *user_data, const BSL_SecurityActionSet_t *output_action_set,
                                     const BSL_BundleRef_t *bundle, const BSL_SecurityResponseSet_t *response_output);
 
 /// @brief Callback interface for policy provider to shut down and release any resources

--- a/src/mock_bpa/agent.c
+++ b/src/mock_bpa/agent.c
@@ -472,11 +472,11 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent, BSLP_PolicyProvider_t **policy)
     }
     // TODO find a better way to deal with this
 
-    *policy = BSLP_PolicyProvider_Init(1);
-    agent->appin.policy = *policy;
+    *policy              = BSLP_PolicyProvider_Init(1);
+    agent->appin.policy  = *policy;
     agent->appout.policy = *policy;
-    agent->clin.policy = *policy;
-    agent->clout.policy = *policy;
+    agent->clin.policy   = *policy;
+    agent->clout.policy  = *policy;
 
     {
         BSL_PolicyDesc_t policy_callbacks = (BSL_PolicyDesc_t) { .deinit_fn   = BSLP_Deinit,

--- a/src/mock_bpa/agent.c
+++ b/src/mock_bpa/agent.c
@@ -414,7 +414,7 @@ BSL_HostDescriptors_t MockBPA_Agent_Descriptors(MockBPA_Agent_t *agent)
     return bpa;
 }
 
-int MockBPA_Agent_Init(MockBPA_Agent_t *agent)
+int MockBPA_Agent_Init(MockBPA_Agent_t *agent, BSLP_PolicyProvider_t **policy)
 {
     int retval = 0;
 
@@ -471,9 +471,14 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent)
         ASSERT_PROPERTY(0 == BSL_API_RegisterSecurityContext(ctx->bsl, 2, bcb_sec_desc));
     }
     // TODO find a better way to deal with this
+
+    *policy = BSLP_PolicyProvider_Init(1);
+    agent->appin.policy = *policy;
+    agent->appout.policy = *policy;
+    agent->clin.policy = *policy;
+    agent->clout.policy = *policy;
+
     {
-        agent->appin.policy               = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
-        agent->appin.policy->pp_id        = 1;
         BSL_PolicyDesc_t policy_callbacks = (BSL_PolicyDesc_t) { .deinit_fn   = BSLP_Deinit,
                                                                  .query_fn    = BSLP_QueryPolicy,
                                                                  .finalize_fn = BSLP_FinalizePolicy,
@@ -481,8 +486,6 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent)
         ASSERT_PROPERTY(BSL_SUCCESS == BSL_API_RegisterPolicyProvider(agent->appin.bsl, 1, policy_callbacks));
     }
     {
-        agent->appout.policy              = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
-        agent->appout.policy->pp_id       = 1;
         BSL_PolicyDesc_t policy_callbacks = (BSL_PolicyDesc_t) { .deinit_fn   = BSLP_Deinit,
                                                                  .query_fn    = BSLP_QueryPolicy,
                                                                  .finalize_fn = BSLP_FinalizePolicy,
@@ -490,8 +493,6 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent)
         ASSERT_PROPERTY(BSL_SUCCESS == BSL_API_RegisterPolicyProvider(agent->appout.bsl, 1, policy_callbacks));
     }
     {
-        agent->clin.policy                = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
-        agent->clin.policy->pp_id         = 1;
         BSL_PolicyDesc_t policy_callbacks = (BSL_PolicyDesc_t) { .deinit_fn   = BSLP_Deinit,
                                                                  .query_fn    = BSLP_QueryPolicy,
                                                                  .finalize_fn = BSLP_FinalizePolicy,
@@ -499,8 +500,6 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent)
         ASSERT_PROPERTY(BSL_SUCCESS == BSL_API_RegisterPolicyProvider(agent->clin.bsl, 1, policy_callbacks));
     }
     {
-        agent->clout.policy               = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
-        agent->clout.policy->pp_id        = 1;
         BSL_PolicyDesc_t policy_callbacks = (BSL_PolicyDesc_t) { .deinit_fn   = BSLP_Deinit,
                                                                  .query_fn    = BSLP_QueryPolicy,
                                                                  .finalize_fn = BSLP_FinalizePolicy,

--- a/src/mock_bpa/agent.h
+++ b/src/mock_bpa/agent.h
@@ -149,7 +149,7 @@ BSL_HostDescriptors_t MockBPA_Agent_Descriptors(MockBPA_Agent_t *agent);
  * @param[out] agent The agent to initialize.
  * @return Zero if successful.
  */
-int MockBPA_Agent_Init(MockBPA_Agent_t *agent);
+int MockBPA_Agent_Init(MockBPA_Agent_t *agent, BSLP_PolicyProvider_t **policy);
 
 /** Clean up the mock BPA for the current process.
  *

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -44,6 +44,7 @@ static BSL_HostEID_t app_eid;
 static BSL_HostEID_t sec_eid;
 /// Agent for this process
 static MockBPA_Agent_t agent;
+static BSLP_PolicyProvider_t *policy;
 
 static int ingest_netaddr(struct sockaddr_in *addr, const char *arg)
 {
@@ -108,13 +109,15 @@ int main(int argc, char **argv)
     int retval = 0;
     int res;
 
+    BSL_LOG_INFO("HELLO, MOCK BPA");
+
     if (BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(&agent)))
     {
         return 2;
     }
     mock_bpa_LogOpen();
     BSL_CryptoInit();
-    if ((res = MockBPA_Agent_Init(&agent)))
+    if ((res = MockBPA_Agent_Init(&agent, &policy)))
     {
         BSL_LOG_ERR("Failed to initialize mock BPA, error %d", res);
         retval = 2;
@@ -171,30 +174,12 @@ int main(int argc, char **argv)
                     break;
                 case 'p':
                 {
-                    // TODO better way to handle this
-                    int anyerr = 0;
-                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.appin.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.appout.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.clin.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_handle_policy_config(optarg, agent.clout.policy, &policy_registry));
-                    if (anyerr)
-                    {
-                        retval = 1;
-                    }
-
+                    retval = !!(mock_bpa_handle_policy_config(optarg, policy, &policy_registry));
                     break;
                 }
                 case 'j':
                 {
-                    int anyerr = 0;
-                    anyerr += abs(mock_bpa_register_policy_from_json(optarg, agent.appin.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_register_policy_from_json(optarg, agent.appout.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_register_policy_from_json(optarg, agent.clin.policy, &policy_registry));
-                    anyerr += abs(mock_bpa_register_policy_from_json(optarg, agent.clout.policy, &policy_registry));
-                    if (anyerr)
-                    {
-                        retval = 1;
-                    }
+                    retval = !!(mock_bpa_register_policy_from_json(optarg, policy, &policy_registry));
                     break;
                 }
                 case 'k':
@@ -250,6 +235,7 @@ int main(int argc, char **argv)
     }
 
     mock_bpa_policy_registry_deinit(&policy_registry);
+    BSLP_PolicyProvider_Deinit(policy);
     MockBPA_Agent_Deinit(&agent);
     BSL_HostEID_Deinit(&sec_eid);
     BSL_HostEID_Deinit(&app_eid);

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -43,7 +43,7 @@
 static BSL_HostEID_t app_eid;
 static BSL_HostEID_t sec_eid;
 /// Agent for this process
-static MockBPA_Agent_t agent;
+static MockBPA_Agent_t        agent;
 static BSLP_PolicyProvider_t *policy;
 
 static int ingest_netaddr(struct sockaddr_in *addr, const char *arg)

--- a/src/mock_bpa/mock_bpa.c
+++ b/src/mock_bpa/mock_bpa.c
@@ -109,8 +109,6 @@ int main(int argc, char **argv)
     int retval = 0;
     int res;
 
-    BSL_LOG_INFO("HELLO, MOCK BPA");
-
     if (BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(&agent)))
     {
         return 2;

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -682,7 +682,7 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
             break;
     }
 
-    char *eid_src_pat_str;
+    const char *eid_src_pat_str;
     if (policy_ignore)
     {
         BSL_LOG_INFO("Creating src eid pattern to match none - bundle should be ignored!");

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -518,7 +518,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
         BSLP_PolicyPredicate_InitFrom(&predicate, policy_loc_enum, src_eid_str, sec_src_eid_str, dest_eid_str);
 
         BSLP_PolicyRule_t rule; 
-        BSLP_PolicyRule_InitFrom(&rule, rule_id_str, &predicate, sec_ctx_id, sec_role, sec_block_type, target_block_type,
+        BSLP_PolicyRule_InitFrom(&rule, rule_id_str, sec_ctx_id, sec_role, sec_block_type, target_block_type,
                              policy_action_enum);
 
         // TODO validate params_got
@@ -541,7 +541,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
         BSLP_PolicyRule_CopyParam(&rule, params->param_test_key);
         BSLP_PolicyRule_CopyParam(&rule, params->param_use_wrapped_key);
 
-        BSLP_PolicyProvider_AddRule(policy, &rule);
+        BSLP_PolicyProvider_AddRule(policy, &rule, &predicate);
     }
 
     json_decref(root);
@@ -701,7 +701,7 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     BSLP_PolicyPredicate_InitFrom(&predicate_all_in, policy_loc_enum, eid_src_pat_str, "*:**", "*:**");
 
     BSLP_PolicyRule_t rule_all_in;
-    BSLP_PolicyRule_InitFrom(&rule_all_in, policybits_str, &predicate_all_in, sec_context, sec_role_enum, sec_block_emum, bundle_block_enum, policy_action_enum);
+    BSLP_PolicyRule_InitFrom(&rule_all_in, policybits_str, sec_context, sec_role_enum, sec_block_emum, bundle_block_enum, policy_action_enum);
 
     if (sec_block_emum == BSL_SECBLOCKTYPE_BCB)
     {
@@ -720,7 +720,7 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_use_wrapped_key);
     BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_test_key);
 
-    BSLP_PolicyProvider_AddRule(policy, &rule_all_in);
+    BSLP_PolicyProvider_AddRule(policy, &rule_all_in, &predicate_all_in);
 }
 
 int mock_bpa_handle_policy_config(const char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg)

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -61,9 +61,6 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
     const char *src_str;
     const char *dest_str;
     const char *sec_src_str;
-    const char *src_eid_str;
-    const char *dest_eid_str;
-    const char *sec_src_eid_str;
 
     const char *rule_id_str;
 
@@ -162,11 +159,10 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 src_str = json_string_value(src);
                 BSL_LOG_DEBUG("     src    : %s", src_str);
-                src_eid_str = src_str;
             }
             else
             {
-                src_eid_str = "*:**";
+                src_str = "*:**";
             }
 
             json_t *dest = json_object_get(filter, "dest");
@@ -174,11 +170,10 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 dest_str = json_string_value(dest);
                 BSL_LOG_DEBUG("     dest    : %s", dest_str);
-                dest_eid_str = dest_str;
             }
             else
             {
-                dest_eid_str = "*:**";
+                dest_str = "*:**";
             }
 
             json_t *sec_src = json_object_get(filter, "sec_src");
@@ -186,11 +181,10 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 sec_src_str = json_string_value(sec_src);
                 BSL_LOG_DEBUG("     sec_src    : %s", sec_src_str);
-                sec_src_eid_str = sec_src_str;
             }
             else
             {
-                sec_src_eid_str = "*:**";
+                sec_src_str = "*:**";
             }
 
             // check tgt (target block type)
@@ -515,7 +509,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
         }
 
         BSLP_PolicyPredicate_t predicate;
-        BSLP_PolicyPredicate_InitFrom(&predicate, policy_loc_enum, src_eid_str, sec_src_eid_str, dest_eid_str);
+        BSLP_PolicyPredicate_InitFrom(&predicate, policy_loc_enum, src_str, sec_src_str, dest_str);
 
         BSLP_PolicyRule_t rule;
         BSLP_PolicyRule_InitFrom(&rule, rule_id_str, sec_ctx_id, sec_role, sec_block_type, target_block_type,

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -28,14 +28,6 @@
 #include "policy_config.h"
 #include "text_util.h"
 
-static BSL_HostEIDPattern_t mock_bpa_util_get_eid_pattern_from_text(const char *text)
-{
-    BSL_HostEIDPattern_t pat;
-    BSL_HostEIDPattern_Init(&pat);
-    ASSERT_PROPERTY(0 == BSL_HostEIDPattern_DecodeFromText(&pat, text));
-    return pat;
-}
-
 int mock_bpa_rfc9173_bcb_cek(unsigned char *buf, int len)
 {
     if (len == 12) // IV
@@ -69,9 +61,9 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
     const char          *src_str;
     const char          *dest_str;
     const char          *sec_src_str;
-    BSL_HostEIDPattern_t src_eid;
-    BSL_HostEIDPattern_t dest_eid;
-    BSL_HostEIDPattern_t sec_src_eid;
+    const char *src_eid_str;
+    const char *dest_eid_str;
+    const char *sec_src_eid_str;
 
     const char *rule_id_str;
 
@@ -170,11 +162,11 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 src_str = json_string_value(src);
                 BSL_LOG_DEBUG("     src    : %s", src_str);
-                src_eid = mock_bpa_util_get_eid_pattern_from_text(src_str);
+                src_eid_str = src_str;
             }
             else
             {
-                src_eid = mock_bpa_util_get_eid_pattern_from_text("*:**");
+                src_eid_str = "*:**";
             }
 
             json_t *dest = json_object_get(filter, "dest");
@@ -182,11 +174,11 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 dest_str = json_string_value(dest);
                 BSL_LOG_DEBUG("     dest    : %s", dest_str);
-                dest_eid = mock_bpa_util_get_eid_pattern_from_text(dest_str);
+                dest_eid_str = dest_str;
             }
             else
             {
-                dest_eid = mock_bpa_util_get_eid_pattern_from_text("*:**");
+                dest_eid_str = "*:**";
             }
 
             json_t *sec_src = json_object_get(filter, "sec_src");
@@ -194,11 +186,11 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             {
                 sec_src_str = json_string_value(sec_src);
                 BSL_LOG_DEBUG("     sec_src    : %s", sec_src_str);
-                sec_src_eid = mock_bpa_util_get_eid_pattern_from_text(sec_src_str);
+                sec_src_eid_str = sec_src_str;
             }
             else
             {
-                sec_src_eid = mock_bpa_util_get_eid_pattern_from_text("*:**");
+                sec_src_eid_str = "*:**";
             }
 
             // check tgt (target block type)
@@ -522,11 +514,11 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             }
         }
 
-        BSLP_PolicyPredicate_t *predicate = &policy->predicates[policy->predicate_count++];
-        BSLP_PolicyPredicate_Init(predicate, policy_loc_enum, src_eid, sec_src_eid, dest_eid);
+        BSLP_PolicyPredicate_t predicate;
+        BSLP_PolicyPredicate_InitFrom(&predicate, policy_loc_enum, src_eid_str, sec_src_eid_str, dest_eid_str);
 
-        BSLP_PolicyRule_t *rule = &policy->rules[policy->rule_count++];
-        BSLP_PolicyRule_Init(rule, rule_id_str, predicate, sec_ctx_id, sec_role, sec_block_type, target_block_type,
+        BSLP_PolicyRule_t rule; 
+        BSLP_PolicyRule_InitFrom(&rule, rule_id_str, &predicate, sec_ctx_id, sec_role, sec_block_type, target_block_type,
                              policy_action_enum);
 
         // TODO validate params_got
@@ -534,20 +526,22 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
 
         if (sec_ctx_id == 2) // BCB
         {
-            BSLP_PolicyRule_CopyParam(rule, params->param_aes_variant);
+            BSLP_PolicyRule_CopyParam(&rule, params->param_aes_variant);
             if (sec_role == BSL_SECROLE_SOURCE)
             {
-                BSLP_PolicyRule_CopyParam(rule, params->param_aad_scope_flag);
+                BSLP_PolicyRule_CopyParam(&rule, params->param_aad_scope_flag);
                 BSL_Crypto_SetRngGenerator(mock_bpa_rfc9173_bcb_cek);
             }
         }
         else
         {
-            BSLP_PolicyRule_CopyParam(rule, params->param_sha_variant);
-            BSLP_PolicyRule_CopyParam(rule, params->param_integ_scope_flag);
+            BSLP_PolicyRule_CopyParam(&rule, params->param_sha_variant);
+            BSLP_PolicyRule_CopyParam(&rule, params->param_integ_scope_flag);
         }
-        BSLP_PolicyRule_CopyParam(rule, params->param_test_key);
-        BSLP_PolicyRule_CopyParam(rule, params->param_use_wrapped_key);
+        BSLP_PolicyRule_CopyParam(&rule, params->param_test_key);
+        BSLP_PolicyRule_CopyParam(&rule, params->param_use_wrapped_key);
+
+        BSLP_PolicyProvider_AddRule(policy, &rule);
     }
 
     json_decref(root);
@@ -688,44 +682,45 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
             break;
     }
 
-    BSL_HostEIDPattern_t eid_src_pat;
+    char *eid_src_pat_str;
     if (policy_ignore)
     {
         BSL_LOG_INFO("Creating src eid pattern to match none - bundle should be ignored!");
-        eid_src_pat = mock_bpa_util_get_eid_pattern_from_text("");
+        eid_src_pat_str = "";
     }
     else
     {
-        eid_src_pat = mock_bpa_util_get_eid_pattern_from_text("*:**");
+        eid_src_pat_str = "*:**";
     }
 
     // Create a rule to verify security block at APP/CLA Ingress
     char policybits_str[100];
     snprintf(policybits_str, 100, "Policy: %x", policy_bits);
-    BSLP_PolicyPredicate_t *predicate_all_in = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_all_in, policy_loc_enum, eid_src_pat,
-                              mock_bpa_util_get_eid_pattern_from_text("*:**"),
-                              mock_bpa_util_get_eid_pattern_from_text("*:**"));
-    BSLP_PolicyRule_t *rule_all_in = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_all_in, policybits_str, predicate_all_in, sec_context, sec_role_enum, sec_block_emum,
-                         bundle_block_enum, policy_action_enum);
+    
+    BSLP_PolicyPredicate_t predicate_all_in;
+    BSLP_PolicyPredicate_InitFrom(&predicate_all_in, policy_loc_enum, eid_src_pat_str, "*:**", "*:**");
+
+    BSLP_PolicyRule_t rule_all_in;
+    BSLP_PolicyRule_InitFrom(&rule_all_in, policybits_str, &predicate_all_in, sec_context, sec_role_enum, sec_block_emum, bundle_block_enum, policy_action_enum);
 
     if (sec_block_emum == BSL_SECBLOCKTYPE_BCB)
     {
-        BSLP_PolicyRule_CopyParam(rule_all_in, params->param_aes_variant);
+        BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_aes_variant);
         if (sec_role_enum == BSL_SECROLE_SOURCE)
         {
-            BSLP_PolicyRule_CopyParam(rule_all_in, params->param_aad_scope_flag);
+            BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_aad_scope_flag);
             BSL_Crypto_SetRngGenerator(mock_bpa_rfc9173_bcb_cek);
         }
     }
     else
     {
-        BSLP_PolicyRule_CopyParam(rule_all_in, params->param_sha_variant);
-        BSLP_PolicyRule_CopyParam(rule_all_in, params->param_integ_scope_flag);
+        BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_sha_variant);
+        BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_integ_scope_flag);
     }
-    BSLP_PolicyRule_CopyParam(rule_all_in, params->param_use_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_all_in, params->param_test_key);
+    BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_use_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_all_in, params->param_test_key);
+
+    BSLP_PolicyProvider_AddRule(policy, &rule_all_in);
 }
 
 int mock_bpa_handle_policy_config(const char *policies, BSLP_PolicyProvider_t *policy, mock_bpa_policy_registry_t *reg)

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -58,9 +58,9 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
     BSL_PolicyLocation_e policy_loc_enum;
     BSL_PolicyAction_e   policy_action_enum;
 
-    const char          *src_str;
-    const char          *dest_str;
-    const char          *sec_src_str;
+    const char *src_str;
+    const char *dest_str;
+    const char *sec_src_str;
     const char *src_eid_str;
     const char *dest_eid_str;
     const char *sec_src_eid_str;
@@ -517,9 +517,9 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
         BSLP_PolicyPredicate_t predicate;
         BSLP_PolicyPredicate_InitFrom(&predicate, policy_loc_enum, src_eid_str, sec_src_eid_str, dest_eid_str);
 
-        BSLP_PolicyRule_t rule; 
+        BSLP_PolicyRule_t rule;
         BSLP_PolicyRule_InitFrom(&rule, rule_id_str, sec_ctx_id, sec_role, sec_block_type, target_block_type,
-                             policy_action_enum);
+                                 policy_action_enum);
 
         // TODO validate params_got
         (void)params_got;
@@ -696,12 +696,13 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     // Create a rule to verify security block at APP/CLA Ingress
     char policybits_str[100];
     snprintf(policybits_str, 100, "Policy: %x", policy_bits);
-    
+
     BSLP_PolicyPredicate_t predicate_all_in;
     BSLP_PolicyPredicate_InitFrom(&predicate_all_in, policy_loc_enum, eid_src_pat_str, "*:**", "*:**");
 
     BSLP_PolicyRule_t rule_all_in;
-    BSLP_PolicyRule_InitFrom(&rule_all_in, policybits_str, sec_context, sec_role_enum, sec_block_emum, bundle_block_enum, policy_action_enum);
+    BSLP_PolicyRule_InitFrom(&rule_all_in, policybits_str, sec_context, sec_role_enum, sec_block_emum,
+                             bundle_block_enum, policy_action_enum);
 
     if (sec_block_emum == BSL_SECBLOCKTYPE_BCB)
     {

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -289,7 +289,7 @@ int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set
 int BSLP_FinalizePolicy(void *user_data _U_, const BSL_SecurityActionSet_t *output_action_set _U_,
                         const BSL_BundleRef_t *bundle, const BSL_SecurityResponseSet_t *response_output _U_)
 {
-    int                          error_ret = BSL_SUCCESS;
+    int                    error_ret = BSL_SUCCESS;
     BSLP_PolicyProvider_t *self      = user_data;
 
     for (size_t i = 0; i < BSL_SecurityActionSet_CountActions(output_action_set); i++)

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -345,7 +345,7 @@ int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t
     return error_ret;
 }
 
-// is this needed w/ shared mem model?
+/// @todo Do we need a deinit callback with shared mem model?
 void BSLP_Deinit(void *user_data)
 {
     (void)user_data;
@@ -433,7 +433,6 @@ int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocati
 
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self)
 {
-    BSL_LOG_INFO(" AM I BEING CALLED?");
     BSL_HostEIDPattern_Deinit(&self->dst_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->secsrc_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->src_eid_pattern);

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -140,11 +140,11 @@ static uint64_t get_target_block_id(const BSL_BundleRef_t *bundle, uint64_t targ
 /**
  * Note that criticality is HIGH
  */
-int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
+int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location)
 {
     // This is an output struct. The caller only provides the allocation for it (which must be zero)
-    const BSLP_PolicyProvider_t *self = user_data;
+    BSLP_PolicyProvider_t *self = user_data;
 
     BSL_PrimaryBlock_t primary_block = { 0 };
     if (BSL_SUCCESS != BSL_BundleCtx_GetBundleMetadata(bundle, &primary_block))
@@ -159,7 +159,7 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
     BSLP_SecOperPtrList_t secops;
     BSLP_SecOperPtrList_init(secops);
 
-    pthread_mutex_lock((pthread_mutex_t *)&self->mutex);
+    pthread_mutex_lock(&self->mutex);
     BSLP_PolicyRuleList_it_t rule_it;
     size_t                   rule_pred_index = 0;
     for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it);
@@ -265,7 +265,7 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
         }
         BSL_LOG_INFO("Created sec operation for rule `%s`", string_get_cstr(rule->description));
     }
-    pthread_mutex_unlock((pthread_mutex_t *)&self->mutex);
+    pthread_mutex_unlock(&self->mutex);
 
     BSL_PrimaryBlock_deinit(&primary_block);
 
@@ -286,19 +286,19 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
     return (int)BSL_SecurityActionSet_CountErrors(output_action_set);
 }
 
-int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t *output_action_set _U_,
+int BSLP_FinalizePolicy(void *user_data _U_, const BSL_SecurityActionSet_t *output_action_set _U_,
                         const BSL_BundleRef_t *bundle, const BSL_SecurityResponseSet_t *response_output _U_)
 {
     int                          error_ret = BSL_SUCCESS;
-    const BSLP_PolicyProvider_t *self      = user_data;
+    BSLP_PolicyProvider_t *self      = user_data;
 
     for (size_t i = 0; i < BSL_SecurityActionSet_CountActions(output_action_set); i++)
     {
         const BSL_SecurityAction_t *action = BSL_SecurityActionSet_GetActionAtIndex(output_action_set, i);
 
-        pthread_mutex_lock((pthread_mutex_t *)&self->mutex);
+        pthread_mutex_lock(&self->mutex);
         uint64_t pp_id = self->pp_id;
-        pthread_mutex_unlock((pthread_mutex_t *)&self->mutex);
+        pthread_mutex_unlock(&self->mutex);
 
         if (BSL_SecurityAction_GetPPID(action) != pp_id)
         {

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -159,12 +159,13 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
     BSLP_SecOperPtrList_t secops;
     BSLP_SecOperPtrList_init(secops);
 
-    pthread_mutex_lock((pthread_mutex_t *) &self->mutex);
+    pthread_mutex_lock((pthread_mutex_t *)&self->mutex);
     BSLP_PolicyRuleList_it_t rule_it;
-    size_t rule_pred_index = 0;
-    for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it); BSLP_PolicyRuleList_next(rule_it), rule_pred_index++)
+    size_t                   rule_pred_index = 0;
+    for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it);
+         BSLP_PolicyRuleList_next(rule_it), rule_pred_index++)
     {
-        const BSLP_PolicyRule_t *rule = BSLP_PolicyRuleList_cref(rule_it);
+        const BSLP_PolicyRule_t      *rule      = BSLP_PolicyRuleList_cref(rule_it);
         const BSLP_PolicyPredicate_t *predicate = BSLP_PolicyPredicateList_cget(self->predicates, rule_pred_index);
         if (!BSLP_PolicyRule_IsConsistent(rule))
         {
@@ -264,7 +265,7 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
         }
         BSL_LOG_INFO("Created sec operation for rule `%s`", string_get_cstr(rule->description));
     }
-    pthread_mutex_unlock((pthread_mutex_t *) &self->mutex);
+    pthread_mutex_unlock((pthread_mutex_t *)&self->mutex);
 
     BSL_PrimaryBlock_deinit(&primary_block);
 
@@ -295,10 +296,10 @@ int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t
     {
         const BSL_SecurityAction_t *action = BSL_SecurityActionSet_GetActionAtIndex(output_action_set, i);
 
-        pthread_mutex_lock((pthread_mutex_t *) &self->mutex);
+        pthread_mutex_lock((pthread_mutex_t *)&self->mutex);
         uint64_t pp_id = self->pp_id;
-        pthread_mutex_unlock((pthread_mutex_t *) &self->mutex);
-        
+        pthread_mutex_unlock((pthread_mutex_t *)&self->mutex);
+
         if (BSL_SecurityAction_GetPPID(action) != pp_id)
         {
             continue;
@@ -347,14 +348,14 @@ int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t
 // is this needed w/ shared mem model?
 void BSLP_Deinit(void *user_data)
 {
-    (void) user_data;
+    (void)user_data;
 }
 
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
 {
     BSLP_PolicyProvider_t *pp = BSL_malloc(sizeof(BSLP_PolicyProvider_t));
     ASSERT_ARG_NONNULL(pp);
-    
+
     ASSERT_ARG_EXPR(pp_id > 0);
     pp->pp_id = pp_id;
 
@@ -402,20 +403,22 @@ void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self)
 void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src)
 {
     // todo - eid patterns should be pointers since they are non-trivial copyable.
-    self->location = src->location;
-    self->src_eid_pattern.handle = src->src_eid_pattern.handle;
+    self->location                  = src->location;
+    self->src_eid_pattern.handle    = src->src_eid_pattern.handle;
     self->secsrc_eid_pattern.handle = src->secsrc_eid_pattern.handle;
-    self->dst_eid_pattern.handle = src->dst_eid_pattern.handle;
+    self->dst_eid_pattern.handle    = src->dst_eid_pattern.handle;
 }
 
-int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern)
-{    
+int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
+                                  const char *src_eid_pattern, const char *secsrc_eid_pattern,
+                                  const char *dst_eid_pattern)
+{
     BSLP_PolicyPredicate_Init(self);
     self->location = location;
 
-    if (BSL_HostEIDPattern_DecodeFromText(&self->src_eid_pattern, src_eid_pattern) ||
-        BSL_HostEIDPattern_DecodeFromText(&self->secsrc_eid_pattern, secsrc_eid_pattern) ||
-        BSL_HostEIDPattern_DecodeFromText(&self->dst_eid_pattern, dst_eid_pattern))
+    if (BSL_HostEIDPattern_DecodeFromText(&self->src_eid_pattern, src_eid_pattern)
+        || BSL_HostEIDPattern_DecodeFromText(&self->secsrc_eid_pattern, secsrc_eid_pattern)
+        || BSL_HostEIDPattern_DecodeFromText(&self->dst_eid_pattern, dst_eid_pattern))
     {
         return BSL_ERR_HOST_CALLBACK_FAILED;
     }
@@ -452,16 +455,18 @@ bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_Policy
     return is_location_match && is_src_pattern_match && is_dst_pattern_match;
 }
 
-int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code)
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role,
+                             BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type,
+                             BSL_PolicyAction_e failure_action_code)
 {
     BSLP_PolicyRule_Init(self);
     string_set_str(self->description, desc);
 
-    self->sec_block_type = sec_block_type;
-    self->target_block_type = target_block_type;
-    self->context_id = context_id;
+    self->sec_block_type      = sec_block_type;
+    self->target_block_type   = target_block_type;
+    self->context_id          = context_id;
     self->failure_action_code = failure_action_code;
-    self->role = role;
+    self->role                = role;
 
     if (!BSLP_PolicyRule_IsConsistent(self))
     {
@@ -483,16 +488,17 @@ void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *s
     string_init_set(self->description, src->description);
     BSLB_SecParamList_init_set(self->params, src->params);
 
-    self->role = src->role;
-    self->target_block_type = src->target_block_type;
-    self->sec_block_type = src->sec_block_type;
-    self->context_id = src->context_id;
+    self->role                = src->role;
+    self->target_block_type   = src->target_block_type;
+    self->sec_block_type      = src->sec_block_type;
+    self->context_id          = src->context_id;
     self->failure_action_code = src->failure_action_code;
 }
 
 void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self)
 {
-    BSL_LOG_INFO("BSLP_PolicyRule_Deinit: %s, nparams=%zu", string_get_cstr(self->description), BSLB_SecParamList_size(self->params));
+    BSL_LOG_INFO("BSLP_PolicyRule_Deinit: %s, nparams=%zu", string_get_cstr(self->description),
+                 BSLB_SecParamList_size(self->params));
 
     string_clear(self->description);
     BSLB_SecParamList_clear(self->params);
@@ -518,7 +524,9 @@ void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param)
     ASSERT_POSTCONDITION(BSLP_PolicyRule_IsConsistent(self));
 }
 
-int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate, BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location)
+int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate,
+                                      BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle,
+                                      BSL_PolicyLocation_e location)
 {
     CHK_ARG_NONNULL(sec_oper);
     CHK_ARG_NONNULL(bundle);

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -45,13 +45,6 @@ M_ARRAY_DEF(BSLP_SecOperPtrList, BSL_SecOper_t *, M_PTR_OPLIST)
 // NOLINTEND
 /// @endcond
 
-static bool BSLP_PolicyProvider_IsConsistent(const BSLP_PolicyProvider_t *self)
-{
-    ASSERT_ARG_NONNULL(self);
-    ASSERT_ARG_EXPR(self->rule_count < (sizeof(self->rules) / sizeof(BSLP_PolicyRule_t)));
-    return true;
-}
-
 static bool BSLP_PolicyPredicate_IsConsistent(const BSLP_PolicyPredicate_t *self)
 {
     ASSERT_ARG_NONNULL(self);
@@ -70,7 +63,7 @@ static bool BSLP_PolicyRule_IsConsistent(const BSLP_PolicyRule_t *self)
     ASSERT_ARG_EXPR(self->sec_block_type > 0);
     ASSERT_ARG_EXPR(self->context_id != 0);
     // NOLINTBEGIN
-    ASSERT_ARG_EXPR(BSLP_PolicyPredicate_IsConsistent(self->predicate));
+    ASSERT_ARG_EXPR(BSLP_PolicyPredicate_IsConsistent(&self->predicate));
     // NOLINTEND
     return true;
 }
@@ -155,7 +148,6 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
 {
     // This is an output struct. The caller only provides the allocation for it (which must be zero)
     const BSLP_PolicyProvider_t *self = user_data;
-    ASSERT_ARG_EXPR(BSLP_PolicyProvider_IsConsistent(self));
 
     BSL_PrimaryBlock_t primary_block = { 0 };
     if (BSL_SUCCESS != BSL_BundleCtx_GetBundleMetadata(bundle, &primary_block))
@@ -170,21 +162,22 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
     BSLP_SecOperPtrList_t secops;
     BSLP_SecOperPtrList_init(secops);
 
-    const size_t capacity = sizeof(self->rules) / sizeof(BSLP_PolicyRule_t);
-    for (size_t index = 0; (index < self->rule_count) && (index < capacity); index++)
+    pthread_mutex_lock((pthread_mutex_t *) &self->mutex);
+    BSLP_PolicyRuleList_it_t rule_it;
+    for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it); BSLP_PolicyRuleList_next(rule_it))
     {
-        const BSLP_PolicyRule_t *rule = &self->rules[index];
+        const BSLP_PolicyRule_t *rule = BSLP_PolicyRuleList_cref(rule_it);
         if (!BSLP_PolicyRule_IsConsistent(rule))
         {
-            BSL_LOG_ERR("Rule `%s` is not consistent", rule->description);
+            BSL_LOG_ERR("Rule `%s` is not consistent", string_get_cstr(rule->description));
             continue;
         }
-        BSL_LOG_DEBUG("Evaluating against rule `%s`", rule->description);
+        BSL_LOG_DEBUG("Evaluating against rule `%s`", string_get_cstr(rule->description));
 
-        if (!BSLP_PolicyPredicate_IsMatch(rule->predicate, location, primary_block.field_src_node_id,
+        if (!BSLP_PolicyPredicate_IsMatch(&rule->predicate, location, primary_block.field_src_node_id,
                                           primary_block.field_dest_eid))
         {
-            BSL_LOG_DEBUG("Rule `%s` not a match", rule->description);
+            BSL_LOG_DEBUG("Rule `%s` not a match", string_get_cstr(rule->description));
             continue;
         }
 
@@ -270,8 +263,10 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
             BSL_LOG_INFO("append to end");
             BSLP_SecOperPtrList_push_back(secops, sec_oper);
         }
-        BSL_LOG_INFO("Created sec operation for rule `%s`", rule->description);
+        BSL_LOG_INFO("Created sec operation for rule `%s`", string_get_cstr(rule->description));
     }
+    pthread_mutex_unlock((pthread_mutex_t *) &self->mutex);
+
     BSL_PrimaryBlock_deinit(&primary_block);
 
     // TODO replace a lot of copying with moving
@@ -296,13 +291,16 @@ int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t
 {
     int                          error_ret = BSL_SUCCESS;
     const BSLP_PolicyProvider_t *self      = user_data;
-    ASSERT_ARG_EXPR(BSLP_PolicyProvider_IsConsistent(self));
 
     for (size_t i = 0; i < BSL_SecurityActionSet_CountActions(output_action_set); i++)
     {
         const BSL_SecurityAction_t *action = BSL_SecurityActionSet_GetActionAtIndex(output_action_set, i);
 
-        if (BSL_SecurityAction_GetPPID(action) != self->pp_id)
+        pthread_mutex_lock((pthread_mutex_t *) &self->mutex);
+        uint64_t pp_id = self->pp_id;
+        pthread_mutex_unlock((pthread_mutex_t *) &self->mutex);
+        
+        if (BSL_SecurityAction_GetPPID(action) != pp_id)
         {
             continue;
         }
@@ -347,46 +345,74 @@ int BSLP_FinalizePolicy(const void *user_data _U_, const BSL_SecurityActionSet_t
     return error_ret;
 }
 
+// is this needed w/ shared mem model?
+void BSLP_Deinit(void *user_data)
+{
+    (void) user_data;
+}
+
+BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
+{
+    BSLP_PolicyProvider_t *pp = BSL_malloc(sizeof(BSLP_PolicyProvider_t));
+    pp->pp_id = pp_id;
+    BSLP_PolicyRuleList_init(pp->rules);
+    pthread_mutex_init(&pp->mutex, NULL);
+
+    return pp;
+}
+
+void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule)
+{
+    pthread_mutex_lock(&self->mutex);
+    BSLP_PolicyRuleList_push_back(self->rules, *rule);
+    pthread_mutex_unlock(&self->mutex);
+}
+
+void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self)
+{
+    pthread_mutex_lock(&self->mutex);
+    BSLP_PolicyRuleList_clear(self->rules);
+    pthread_mutex_unlock(&self->mutex);
+
+    pthread_mutex_destroy(&self->mutex);    
+}
+
+void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self)
+{
+    self->location = 0;
+    BSL_HostEIDPattern_Init(&self->src_eid_pattern);
+    BSL_HostEIDPattern_Init(&self->secsrc_eid_pattern);
+    BSL_HostEIDPattern_Init(&self->dst_eid_pattern);
+}
+
+void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src)
+{
+    self->location = src->location;
+    self->src_eid_pattern.handle = src->src_eid_pattern.handle;
+    self->secsrc_eid_pattern.handle = src->secsrc_eid_pattern.handle;
+    self->dst_eid_pattern.handle = src->dst_eid_pattern.handle;
+}
+
+void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern)
+{
+    // todo - eid patterns should be pointers since they are non-trivial copyable.
+    
+    BSLP_PolicyPredicate_Init(self);
+
+    self->location = location;
+
+    // FIXME check response from decode
+    BSL_HostEIDPattern_DecodeFromText(&self->src_eid_pattern, src_eid_pattern);
+    BSL_HostEIDPattern_DecodeFromText(&self->secsrc_eid_pattern, secsrc_eid_pattern);
+    BSL_HostEIDPattern_DecodeFromText(&self->dst_eid_pattern, dst_eid_pattern);
+}
+
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self)
 {
     BSL_HostEIDPattern_Deinit(&self->dst_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->secsrc_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->src_eid_pattern);
     memset(self, 0, sizeof(*self));
-}
-
-void BSLP_Deinit(void *user_data)
-{
-    BSLP_PolicyProvider_t *self = user_data;
-    ASSERT_ARG_EXPR(BSLP_PolicyProvider_IsConsistent(self));
-    for (size_t index = 0; index < self->rule_count; index++)
-    {
-        BSL_LOG_INFO("Sample Policy Provider deinit rule index %zu", index);
-        BSLP_PolicyRule_Deinit(&self->rules[index]);
-    }
-
-    for (size_t index = 0; index < self->predicate_count; index++)
-    {
-        BSLP_PolicyPredicate_Deinit(&self->predicates[index]);
-    }
-    memset(self, 0, sizeof(*self));
-    BSL_free(user_data);
-}
-
-void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
-                               BSL_HostEIDPattern_t src_eid_pattern, BSL_HostEIDPattern_t secsrc_eid_pattern,
-                               BSL_HostEIDPattern_t dst_eid_pattern)
-{
-    // todo - eid patterns should be pointers since they are non-trivial copyable.
-    ASSERT_ARG_NONNULL(self);
-    memset(self, 0, sizeof(*self));
-
-    self->location           = location;
-    self->src_eid_pattern    = src_eid_pattern;
-    self->secsrc_eid_pattern = secsrc_eid_pattern;
-    self->dst_eid_pattern    = dst_eid_pattern;
-
-    ASSERT_POSTCONDITION(BSLP_PolicyPredicate_IsConsistent(self));
 }
 
 bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
@@ -414,37 +440,59 @@ reject
      - Bitmask/something for HAS_BIB_ON_PRIMARY, HAS_BIB_ON_PAYLOAD, submasks for BIB_COVERS_PRIMARY, BIB_COVERS_TARGET
  Step 2: Populate security parameters unique to bundle and src/dst pair.
 */
-int BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
                          int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type,
                          BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code)
 {
-    ASSERT_ARG_NONNULL(self);
-    memset(self, 0, sizeof(*self));
+    string_init(self->description);
+    string_set_str(self->description, desc);
 
-    size_t desc_sz    = strnlen(desc, BSLP_POLICYPREDICATE_ARRAY_CAPACITY);
-    self->description = BSL_malloc(desc_sz + 1);
-    strncpy(self->description, desc, desc_sz);
-    self->description[desc_sz] = '\0';
+    memset(&self->predicate, 0, sizeof(BSLP_PolicyPredicate_t));
+    BSLP_PolicyPredicate_InitSet(&self->predicate, predicate);
 
     self->sec_block_type    = sec_block_type;
     self->target_block_type = target_block_type;
-    self->predicate         = predicate;
     self->context_id        = context_id;
-    // TODO(bvb) assert Role in expected range
     self->failure_action_code = failure_action_code;
     self->role                = role;
     BSLB_SecParamList_init(self->params);
-    ASSERT_POSTCONDITION(BSLP_PolicyRule_IsConsistent(self));
+
     return BSL_SUCCESS;
+}
+
+void BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self)
+{
+    string_init(self->description);
+    BSLB_SecParamList_init(self->params);
+    BSLP_PolicyPredicate_Init(&self->predicate);
+
+    self->role = 0;
+    self->target_block_type = 0;
+    self->sec_block_type = 0;
+    self->context_id = 0;
+    self->failure_action_code = 0;
+}
+
+void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *src)
+{
+    string_init_set(self->description, src->description);
+    BSLB_SecParamList_init_set(self->params, src->params);
+    BSLP_PolicyPredicate_InitSet(&self->predicate, &src->predicate);
+
+    self->role = src->role;
+    self->target_block_type = src->target_block_type;
+    self->sec_block_type = src->sec_block_type;
+    self->context_id = src->context_id;
+    self->failure_action_code = src->failure_action_code;
 }
 
 void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self)
 {
-    ASSERT_ARG_EXPR(BSLP_PolicyRule_IsConsistent(self));
-    BSL_LOG_INFO("BSLP_PolicyRule_Deinit: %s, nparams=%zu", self->description, BSLB_SecParamList_size(self->params));
-    BSL_free(self->description);
+    BSL_LOG_INFO("BSLP_PolicyRule_Deinit: %s, nparams=%zu", string_get_cstr(self->description), BSLB_SecParamList_size(self->params));
+
+    string_clear(self->description);
+    BSLP_PolicyPredicate_Deinit(&self->predicate);
     BSLB_SecParamList_clear(self->params);
-    memset(self, 0, sizeof(*self));
 }
 
 void BSLP_PolicyRule_CopyParam(BSLP_PolicyRule_t *self, const BSL_SecParam_t *param)
@@ -478,7 +526,7 @@ int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper
         // Confirm that the rule matches the bundle.
         BSL_PrimaryBlock_t primary_block = { 0 };
         BSL_BundleCtx_GetBundleMetadata(bundle, &primary_block);
-        CHK_PRECONDITION(BSLP_PolicyPredicate_IsMatch(self->predicate, location, primary_block.field_src_node_id,
+        CHK_PRECONDITION(BSLP_PolicyPredicate_IsMatch(&self->predicate, location, primary_block.field_src_node_id,
                                                       primary_block.field_dest_eid));
         BSL_PrimaryBlock_deinit(&primary_block);
     }
@@ -502,7 +550,7 @@ int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper
         const BSL_SecParam_t *param = BSLB_SecParamList_cref(pit);
         BSL_SecOper_AppendParam(sec_oper, param);
     }
-    BSL_LOG_INFO("Created sec operation for rule `%s`", self->description);
+    BSL_LOG_INFO("Created sec operation for rule `%s`", string_get_cstr(self->description));
 
     return BSL_SUCCESS;
 }

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -48,7 +48,7 @@ M_ARRAY_DEF(BSLP_SecOperPtrList, BSL_SecOper_t *, M_PTR_OPLIST)
 static bool BSLP_PolicyPredicate_IsConsistent(const BSLP_PolicyPredicate_t *self)
 {
     ASSERT_ARG_NONNULL(self);
-    ASSERT_ARG_EXPR(self->location > 0);
+    ASSERT_ARG_EXPR(self->location >= BSL_POLICYLOCATION_APPIN && self->location <= BSL_POLICYLOCATION_CLOUT);
     ASSERT_ARG_NONNULL(self->dst_eid_pattern.handle);
     ASSERT_ARG_NONNULL(self->src_eid_pattern.handle);
     ASSERT_ARG_NONNULL(self->secsrc_eid_pattern.handle);
@@ -353,7 +353,11 @@ void BSLP_Deinit(void *user_data)
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
 {
     BSLP_PolicyProvider_t *pp = BSL_malloc(sizeof(BSLP_PolicyProvider_t));
+    ASSERT_ARG_NONNULL(pp);
+    
+    ASSERT_ARG_EXPR(pp_id > 0);
     pp->pp_id = pp_id;
+
     BSLP_PolicyRuleList_init(pp->rules);
     BSLP_PolicyPredicateList_init(pp->predicates);
     pthread_mutex_init(&pp->mutex, NULL);
@@ -361,12 +365,19 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
     return pp;
 }
 
-void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate)
+int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate)
 {
+    if (!BSLP_PolicyRule_IsConsistent(rule) || !BSLP_PolicyPredicate_IsConsistent(predicate))
+    {
+        return BSL_ERR_ARG_INVALID;
+    }
+
     pthread_mutex_lock(&self->mutex);
     BSLP_PolicyRuleList_push_move(self->rules, rule);
     BSLP_PolicyPredicateList_push_back(self->predicates, *predicate);
     pthread_mutex_unlock(&self->mutex);
+
+    return BSL_SUCCESS;
 }
 
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self)
@@ -388,7 +399,7 @@ void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self)
     BSL_HostEIDPattern_Init(&self->dst_eid_pattern);
 }
 
-void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src)
+void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src)
 {
     // todo - eid patterns should be pointers since they are non-trivial copyable.
     self->location = src->location;
@@ -397,16 +408,24 @@ void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_Polic
     self->dst_eid_pattern.handle = src->dst_eid_pattern.handle;
 }
 
-void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern)
-{
+int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern)
+{    
     BSLP_PolicyPredicate_Init(self);
-
     self->location = location;
 
-    // FIXME check response from decode
-    BSL_HostEIDPattern_DecodeFromText(&self->src_eid_pattern, src_eid_pattern);
-    BSL_HostEIDPattern_DecodeFromText(&self->secsrc_eid_pattern, secsrc_eid_pattern);
-    BSL_HostEIDPattern_DecodeFromText(&self->dst_eid_pattern, dst_eid_pattern);
+    if (BSL_HostEIDPattern_DecodeFromText(&self->src_eid_pattern, src_eid_pattern) ||
+        BSL_HostEIDPattern_DecodeFromText(&self->secsrc_eid_pattern, secsrc_eid_pattern) ||
+        BSL_HostEIDPattern_DecodeFromText(&self->dst_eid_pattern, dst_eid_pattern))
+    {
+        return BSL_ERR_HOST_CALLBACK_FAILED;
+    }
+
+    if (!BSLP_PolicyPredicate_IsConsistent(self))
+    {
+        return BSL_ERR_PROPERTY_CHECK_FAILED;
+    }
+
+    return BSL_SUCCESS;
 }
 
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self)
@@ -433,16 +452,6 @@ bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_Policy
     return is_location_match && is_src_pattern_match && is_dst_pattern_match;
 }
 
-/*
-Example Rules:
- - Template: "If Bundle src/dst match PREDICATE, then (ADD|REMOVE|VALIDATE) SEC_BLOCK_TYPE using PARAM-KEY-VALUES"
- - "At ingress from the convergence layer, Bundles matching *.* must have a single BIB covering the primary and payload
-block using key 9" Step 1: Match the Bundle struct with all Rule structs to find a Rule that matches. If no match,
-reject
-   - Things to match on:
-     - Bitmask/something for HAS_BIB_ON_PRIMARY, HAS_BIB_ON_PAYLOAD, submasks for BIB_COVERS_PRIMARY, BIB_COVERS_TARGET
- Step 2: Populate security parameters unique to bundle and src/dst pair.
-*/
 int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code)
 {
     BSLP_PolicyRule_Init(self);
@@ -453,6 +462,11 @@ int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t 
     self->context_id = context_id;
     self->failure_action_code = failure_action_code;
     self->role = role;
+
+    if (!BSLP_PolicyRule_IsConsistent(self))
+    {
+        return BSL_ERR_PROPERTY_CHECK_FAILED;
+    }
 
     return BSL_SUCCESS;
 }

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -366,7 +366,7 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
     return pp;
 }
 
-int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate)
+int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, const BSLP_PolicyPredicate_t *predicate)
 {
     if (!BSLP_PolicyRule_IsConsistent(rule) || !BSLP_PolicyPredicate_IsConsistent(predicate))
     {

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -62,9 +62,6 @@ static bool BSLP_PolicyRule_IsConsistent(const BSLP_PolicyRule_t *self)
     ASSERT_ARG_EXPR(BSL_SECROLE_ISVALID(self->role));
     ASSERT_ARG_EXPR(self->sec_block_type > 0);
     ASSERT_ARG_EXPR(self->context_id != 0);
-    // NOLINTBEGIN
-    ASSERT_ARG_EXPR(BSLP_PolicyPredicate_IsConsistent(&self->predicate));
-    // NOLINTEND
     return true;
 }
 
@@ -164,9 +161,11 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
 
     pthread_mutex_lock((pthread_mutex_t *) &self->mutex);
     BSLP_PolicyRuleList_it_t rule_it;
-    for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it); BSLP_PolicyRuleList_next(rule_it))
+    size_t rule_pred_index = 0;
+    for (BSLP_PolicyRuleList_it(rule_it, self->rules); !BSLP_PolicyRuleList_end_p(rule_it); BSLP_PolicyRuleList_next(rule_it), rule_pred_index++)
     {
         const BSLP_PolicyRule_t *rule = BSLP_PolicyRuleList_cref(rule_it);
+        const BSLP_PolicyPredicate_t *predicate = BSLP_PolicyPredicateList_cget(self->predicates, rule_pred_index);
         if (!BSLP_PolicyRule_IsConsistent(rule))
         {
             BSL_LOG_ERR("Rule `%s` is not consistent", string_get_cstr(rule->description));
@@ -174,7 +173,7 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
         }
         BSL_LOG_DEBUG("Evaluating against rule `%s`", string_get_cstr(rule->description));
 
-        if (!BSLP_PolicyPredicate_IsMatch(&rule->predicate, location, primary_block.field_src_node_id,
+        if (!BSLP_PolicyPredicate_IsMatch(predicate, location, primary_block.field_src_node_id,
                                           primary_block.field_dest_eid))
         {
             BSL_LOG_DEBUG("Rule `%s` not a match", string_get_cstr(rule->description));
@@ -190,7 +189,7 @@ int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_acti
 
         BSL_SecOper_t *sec_oper = BSL_calloc(1, BSL_SecOper_Sizeof());
         BSL_SecOper_Init(sec_oper);
-        if (BSLP_PolicyRule_EvaluateAsSecOper(rule, sec_oper, bundle, location) < 0)
+        if (BSLP_PolicyRule_EvaluateAsSecOper(rule, predicate, sec_oper, bundle, location) < 0)
         {
             BSL_LOG_WARNING("SecOp evaluate failed");
             BSL_SecurityAction_IncrError(action);
@@ -356,15 +355,17 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
     BSLP_PolicyProvider_t *pp = BSL_malloc(sizeof(BSLP_PolicyProvider_t));
     pp->pp_id = pp_id;
     BSLP_PolicyRuleList_init(pp->rules);
+    BSLP_PolicyPredicateList_init(pp->predicates);
     pthread_mutex_init(&pp->mutex, NULL);
 
     return pp;
 }
 
-void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule)
+void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate)
 {
     pthread_mutex_lock(&self->mutex);
-    BSLP_PolicyRuleList_push_back(self->rules, *rule);
+    BSLP_PolicyRuleList_push_move(self->rules, rule);
+    BSLP_PolicyPredicateList_push_back(self->predicates, *predicate);
     pthread_mutex_unlock(&self->mutex);
 }
 
@@ -372,9 +373,11 @@ void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self)
 {
     pthread_mutex_lock(&self->mutex);
     BSLP_PolicyRuleList_clear(self->rules);
+    BSLP_PolicyPredicateList_clear(self->predicates);
     pthread_mutex_unlock(&self->mutex);
 
-    pthread_mutex_destroy(&self->mutex);    
+    pthread_mutex_destroy(&self->mutex);
+    BSL_free(self);
 }
 
 void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self)
@@ -387,6 +390,7 @@ void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self)
 
 void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src)
 {
+    // todo - eid patterns should be pointers since they are non-trivial copyable.
     self->location = src->location;
     self->src_eid_pattern.handle = src->src_eid_pattern.handle;
     self->secsrc_eid_pattern.handle = src->secsrc_eid_pattern.handle;
@@ -395,8 +399,6 @@ void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_Polic
 
 void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern)
 {
-    // todo - eid patterns should be pointers since they are non-trivial copyable.
-    
     BSLP_PolicyPredicate_Init(self);
 
     self->location = location;
@@ -409,10 +411,11 @@ void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocat
 
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self)
 {
+    BSL_LOG_INFO(" AM I BEING CALLED?");
     BSL_HostEIDPattern_Deinit(&self->dst_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->secsrc_eid_pattern);
     BSL_HostEIDPattern_Deinit(&self->src_eid_pattern);
-    memset(self, 0, sizeof(*self));
+    memset(self, 0, sizeof(BSLP_PolicyPredicate_t));
 }
 
 bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
@@ -440,44 +443,31 @@ reject
      - Bitmask/something for HAS_BIB_ON_PRIMARY, HAS_BIB_ON_PAYLOAD, submasks for BIB_COVERS_PRIMARY, BIB_COVERS_TARGET
  Step 2: Populate security parameters unique to bundle and src/dst pair.
 */
-int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
-                         int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type,
-                         BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code)
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code)
 {
-    string_init(self->description);
+    BSLP_PolicyRule_Init(self);
     string_set_str(self->description, desc);
 
-    memset(&self->predicate, 0, sizeof(BSLP_PolicyPredicate_t));
-    BSLP_PolicyPredicate_InitSet(&self->predicate, predicate);
-
-    self->sec_block_type    = sec_block_type;
+    self->sec_block_type = sec_block_type;
     self->target_block_type = target_block_type;
-    self->context_id        = context_id;
+    self->context_id = context_id;
     self->failure_action_code = failure_action_code;
-    self->role                = role;
-    BSLB_SecParamList_init(self->params);
+    self->role = role;
 
     return BSL_SUCCESS;
 }
 
 void BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self)
 {
+    memset(self, 0, sizeof(BSLP_PolicyRule_t));
     string_init(self->description);
     BSLB_SecParamList_init(self->params);
-    BSLP_PolicyPredicate_Init(&self->predicate);
-
-    self->role = 0;
-    self->target_block_type = 0;
-    self->sec_block_type = 0;
-    self->context_id = 0;
-    self->failure_action_code = 0;
 }
 
 void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *src)
 {
     string_init_set(self->description, src->description);
     BSLB_SecParamList_init_set(self->params, src->params);
-    BSLP_PolicyPredicate_InitSet(&self->predicate, &src->predicate);
 
     self->role = src->role;
     self->target_block_type = src->target_block_type;
@@ -491,7 +481,6 @@ void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self)
     BSL_LOG_INFO("BSLP_PolicyRule_Deinit: %s, nparams=%zu", string_get_cstr(self->description), BSLB_SecParamList_size(self->params));
 
     string_clear(self->description);
-    BSLP_PolicyPredicate_Deinit(&self->predicate);
     BSLB_SecParamList_clear(self->params);
 }
 
@@ -515,8 +504,7 @@ void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param)
     ASSERT_POSTCONDITION(BSLP_PolicyRule_IsConsistent(self));
 }
 
-int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper_t *sec_oper,
-                                      const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location)
+int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate, BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location)
 {
     CHK_ARG_NONNULL(sec_oper);
     CHK_ARG_NONNULL(bundle);
@@ -526,7 +514,7 @@ int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper
         // Confirm that the rule matches the bundle.
         BSL_PrimaryBlock_t primary_block = { 0 };
         BSL_BundleCtx_GetBundleMetadata(bundle, &primary_block);
-        CHK_PRECONDITION(BSLP_PolicyPredicate_IsMatch(&self->predicate, location, primary_block.field_src_node_id,
+        CHK_PRECONDITION(BSLP_PolicyPredicate_IsMatch(predicate, location, primary_block.field_src_node_id,
                                                       primary_block.field_dest_eid));
         BSL_PrimaryBlock_deinit(&primary_block);
     }

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -366,7 +366,8 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
     return pp;
 }
 
-int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, const BSLP_PolicyPredicate_t *predicate)
+int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule,
+                                const BSLP_PolicyPredicate_t *predicate)
 {
     if (!BSLP_PolicyRule_IsConsistent(rule) || !BSLP_PolicyPredicate_IsConsistent(predicate))
     {

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -345,7 +345,6 @@ int BSLP_FinalizePolicy(void *user_data _U_, const BSL_SecurityActionSet_t *outp
     return error_ret;
 }
 
-/// @todo Do we need a deinit callback with shared mem model?
 void BSLP_Deinit(void *user_data)
 {
     (void)user_data;

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -67,7 +67,9 @@ typedef struct
  *
  * @returns 0 on success
  */
-int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern);
+int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
+                                  const char *src_eid_pattern, const char *secsrc_eid_pattern,
+                                  const char *dst_eid_pattern);
 
 /** Initialize policy predicate and associated host eid pattern structures
  * @param self policy predicate
@@ -90,7 +92,7 @@ void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 // GCOV_EXCL_START
 M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicate_t,
             (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), SET(0),
-             CLEAR(API_2(BSLP_PolicyPredicate_Deinit))))// GCOV_EXCL_STOP
+             CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))) // GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
 
@@ -149,7 +151,9 @@ typedef struct BSLP_PolicyRule_s
  *
  * @returns Zero on success
  */
-int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role,
+                             BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type,
+                             BSL_PolicyAction_e failure_action_code);
 
 /** Initialize policy rule
  * @param self policy rule
@@ -173,7 +177,7 @@ void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self);
 // GCOV_EXCL_START
 M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRule_t,
             (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), SET(0),
-             CLEAR(API_2(BSLP_PolicyRule_Deinit))))// GCOV_EXCL_STOP
+             CLEAR(API_2(BSLP_PolicyRule_Deinit)))) // GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
 
@@ -197,40 +201,42 @@ void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param);
 /// @brief Concrete definition of a policy provider
 typedef struct BSLP_PolicyProvider_s
 {
-    BSLP_PolicyRuleList_t       rules;
-    BSLP_PolicyPredicateList_t  predicates;
-    pthread_mutex_t             mutex;
-    uint64_t                    pp_id;
+    BSLP_PolicyRuleList_t      rules;
+    BSLP_PolicyPredicateList_t predicates;
+    pthread_mutex_t            mutex;
+    uint64_t                   pp_id;
 } BSLP_PolicyProvider_t;
 
 /** Initialize policy provider
-* @param pp_id policy provider id (must be > 0)
-* @return valid pointer to dynamically allocated policy provider
-*/
+ * @param pp_id policy provider id (must be > 0)
+ * @return valid pointer to dynamically allocated policy provider
+ */
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
 
 /** Add rule and corresponding prediate to policy provider
-* @param self policy provider
-* @param rule policy rule to add
-* @param predicate predicate to be associated with policy rule
-*/
-int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate);
+ * @param self policy provider
+ * @param rule policy rule to add
+ * @param predicate predicate to be associated with policy rule
+ */
+int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule,
+                                BSLP_PolicyPredicate_t *predicate);
 
 /** Deinitialize policy provider
  * @param self policy provider
  */
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);
 
-
-/**  Evaluate policy rule as security operation 
+/**  Evaluate policy rule as security operation
  * @param self policy rule
  * @param predicate associated predicate
  * @param sec_oper security operation
  * @param bundle bundle reference
  * @param location policy location
  * @return 0 on success
-*/
-int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate, BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location);
+ */
+int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate,
+                                      BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle,
+                                      BSL_PolicyLocation_e location);
 
 int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location);

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -88,9 +88,9 @@ void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_P
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 
 /// OPLIST for ::BSLP_PolicyPredicate_t
-#define M_OPL_BSLP_PolicyPredicate_t() \
-   (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), \
-    SET(0), CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))
+#define M_OPL_BSLP_PolicyPredicate_t()                                                                  \
+    (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), SET(0), \
+     CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))
 
 /** @struct BSLP_PolicyPredicateList_t
  * Defines list of policy predicates (::BSLP_PolicyPredicate_t)
@@ -180,9 +180,9 @@ void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *s
 void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self);
 
 /// OPLIST for ::BSLP_PolicyRule_t
-#define M_OPL_BSLP_PolicyRule_t() \
-    (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), \
-        SET(0), CLEAR(API_2(BSLP_PolicyRule_Deinit)))
+#define M_OPL_BSLP_PolicyRule_t()                                                         \
+    (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), SET(0), \
+     CLEAR(API_2(BSLP_PolicyRule_Deinit)))
 
 /** @struct BSLP_PolicyRuleList_t
  * Defines list of policy rules (::BSLP_PolicyRule_t)

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -29,8 +29,15 @@
 #define BSLP_SAMPLE_POLICY_PROVIDER_H
 
 #include <stdint.h>
+#include <pthread.h>
+
+#include <m-array.h>
+#include <m-string.h>
+
 #include <BPSecLib_Private.h>
 #include <backend/SecParam.h>
+
+void BSLP_Deinit(void *user_data);
 
 /**
  * THE key function that matches a bundle against a rule to provide the output action and specific parameters to use for
@@ -60,10 +67,11 @@ typedef struct
  *
  * @returns Nothing
  */
-void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location,
-                               BSL_HostEIDPattern_t src_eid_pattern, BSL_HostEIDPattern_t secsrc_eid_pattern,
-                               BSL_HostEIDPattern_t dst_eid_pattern);
+void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern);
 
+// TODO docs
+void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self);
+void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src);
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 
 /**
@@ -98,8 +106,8 @@ bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_Policy
  */
 typedef struct BSLP_PolicyRule_s
 {
-    char                     *description;
-    BSLP_PolicyPredicate_t   *predicate;
+    string_t                  description;
+    BSLP_PolicyPredicate_t    predicate;
     BSL_SecRole_e             role;
     BSL_BundleBlockTypeCode_e target_block_type;
     BSL_SecBlockType_e        sec_block_type;
@@ -123,9 +131,13 @@ typedef struct BSLP_PolicyRule_s
  *
  * @returns Zero on success
  */
-int BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
-                         int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type,
-                         BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
+                                int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type,
+                                BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
+
+// TODO docs
+void BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self);
+void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *src);
 
 /**
  * @brief De-initialize, release any resources, and zero this struct.
@@ -133,6 +145,15 @@ int BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyP
  * @param[in] self This rule
  */
 void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self);
+
+/// @cond Doxygen_Suppress
+// NOLINTBEGIN
+// GCOV_EXCL_START
+M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRule_t,
+            (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), SET(0),
+             CLEAR(API_2(BSLP_PolicyRule_Deinit))))// GCOV_EXCL_STOP
+// NOLINTEND
+/// @endcond
 
 /**
  * @brief Include a BPSec parameter to this rule. Used immediately after Init.
@@ -167,14 +188,15 @@ int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper
 /// @brief Concrete definition of a policy provider
 typedef struct BSLP_PolicyProvider_s
 {
-    BSLP_PolicyPredicate_t predicates[BSLP_POLICYPREDICATE_ARRAY_CAPACITY];
-    size_t                 predicate_count;
-    BSLP_PolicyRule_t      rules[BSLP_POLICYPREDICATE_ARRAY_CAPACITY];
-    size_t                 rule_count;
-    uint64_t               pp_id;
+    BSLP_PolicyRuleList_t   rules;
+    pthread_mutex_t         mutex;
+    uint64_t                pp_id;
 } BSLP_PolicyProvider_t;
 
-void BSLP_Deinit(void *user_data);
+/// TODO docs
+BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
+void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule);
+void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);
 
 int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location);

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -233,7 +233,7 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
  * @param predicate predicate to be associated with policy rule
  */
 int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule,
-                                BSLP_PolicyPredicate_t *predicate);
+                                const BSLP_PolicyPredicate_t *predicate);
 
 /** Deinitialize policy provider
  * @param self policy provider

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -55,30 +55,41 @@ typedef struct
 } BSLP_PolicyPredicate_t;
 
 /**
- * @brief Initialize this policy predicate
+ * @brief Initialize policy predicate from cstring patterns
  *
  * A policy predicate represents a way to match whether a rule applies to a bundle.
  *
  * @param[in] self This predicate
  * @param[in] location The ::BSL_PolicyLocation_e location in the BPA
- * @param[in] src_eid_pattern Host-defined EID pattern to match for
- * @param[in] srcsrc_eid_pattern Host-defined EID pattern for SECURITY SOURCE in security block
- * @param[in] dst_eid_pattern Host-defined EID pattern for DESTINATION EID
+ * @param[in] src_eid_pattern c string pattern for SOURCE matching
+ * @param[in] srcsrc_eid_pattern c string pattern for SECURITY SOURCE matching
+ * @param[in] dst_eid_pattern c string pattern for DESTINATION matching
  *
- * @returns Nothing
+ * @returns 0 on success
  */
-void BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern);
+int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocation_e location, const char *src_eid_pattern, const char *secsrc_eid_pattern, const char *dst_eid_pattern);
 
-// TODO docs
+/** Initialize policy predicate and associated host eid pattern structures
+ * @param self policy predicate
+ */
 void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self);
-void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src);
+
+/** Shallow copy of policy predicate
+ * @param self dest policy predicate
+ * @param src source policy prediate
+ */
+void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src);
+
+/** Deinitialize policy predicate and associated host eid pattern structures
+ * @param self policy predicate
+ */
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 
 /// @cond Doxygen_Suppress
 // NOLINTBEGIN
 // GCOV_EXCL_START
 M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicate_t,
-            (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_InitSet)), SET(0),
+            (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), SET(0),
              CLEAR(API_2(BSLP_PolicyPredicate_Deinit))))// GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
@@ -125,7 +136,7 @@ typedef struct BSLP_PolicyRule_s
 } BSLP_PolicyRule_t;
 
 /**
- * @brief Initialize this policy rule
+ * @brief Initialize this policy rule from paramteres
  *
  * @param[in] self This policy rule
  * @param[in] dest Description of this rule (C-string). Will copy characters of parameter from index 0 to
@@ -140,8 +151,14 @@ typedef struct BSLP_PolicyRule_s
  */
 int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
 
-// TODO docs
+/** Initialize policy rule
+ * @param self policy rule
+ */
 void BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self);
+
+/** Deinitialize policy rule
+ * @param self policy rule
+ */
 void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *src);
 
 /**
@@ -186,12 +203,33 @@ typedef struct BSLP_PolicyProvider_s
     uint64_t                    pp_id;
 } BSLP_PolicyProvider_t;
 
-/// TODO docs
+/** Initialize policy provider
+* @param pp_id policy provider id (must be > 0)
+* @return valid pointer to dynamically allocated policy provider
+*/
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
-void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate);
+
+/** Add rule and corresponding prediate to policy provider
+* @param self policy provider
+* @param rule policy rule to add
+* @param predicate predicate to be associated with policy rule
+*/
+int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate);
+
+/** Deinitialize policy provider
+ * @param self policy provider
+ */
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);
 
-// TODO
+
+/**  Evaluate policy rule as security operation 
+ * @param self policy rule
+ * @param predicate associated predicate
+ * @param sec_oper security operation
+ * @param bundle bundle reference
+ * @param location policy location
+ * @return 0 on success
+*/
 int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate, BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location);
 
 int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -87,12 +87,19 @@ void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_P
  */
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 
+/// OPLIST for ::BSLP_PolicyPredicate_t
+#define M_OPL_BSLP_PolicyPredicate_t() \
+   (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), \
+    SET(0), CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))
+
+/** @struct BSLP_PolicyPredicateList_t
+ * Defines list of policy predicates (::BSLP_PolicyPredicate_t)
+ */
 /// @cond Doxygen_Suppress
 // NOLINTBEGIN
 // GCOV_EXCL_START
-M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicate_t,
-            (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_ShallowCopy)), SET(0),
-             CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))) // GCOV_EXCL_STOP
+M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicate_t, M_OPL_BSLP_PolicyPredicate_t())
+// GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
 
@@ -172,12 +179,19 @@ void BSLP_PolicyRule_InitSet(BSLP_PolicyRule_t *self, const BSLP_PolicyRule_t *s
  */
 void BSLP_PolicyRule_Deinit(BSLP_PolicyRule_t *self);
 
+/// OPLIST for ::BSLP_PolicyRule_t
+#define M_OPL_BSLP_PolicyRule_t() \
+    (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), \
+        SET(0), CLEAR(API_2(BSLP_PolicyRule_Deinit)))
+
+/** @struct BSLP_PolicyRuleList_t
+ * Defines list of policy rules (::BSLP_PolicyRule_t)
+ */
 /// @cond Doxygen_Suppress
 // NOLINTBEGIN
 // GCOV_EXCL_START
-M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRule_t,
-            (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(API_6(BSLP_PolicyRule_InitSet)), SET(0),
-             CLEAR(API_2(BSLP_PolicyRule_Deinit)))) // GCOV_EXCL_STOP
+M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRule_t, M_OPL_BSLP_PolicyRule_t()) // GCOV_EXCL_STOP
+// GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
 
@@ -238,10 +252,10 @@ int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_
                                       BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle,
                                       BSL_PolicyLocation_e location);
 
-int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
+int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location);
 
-int BSLP_FinalizePolicy(const void *user_data, const BSL_SecurityActionSet_t *output_action_set,
+int BSLP_FinalizePolicy(void *user_data, const BSL_SecurityActionSet_t *output_action_set,
                         const BSL_BundleRef_t *bundle, const BSL_SecurityResponseSet_t *response_output);
 
 #endif // BSLP_SAMPLE_POLICY_PROVIDER_H

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -74,6 +74,15 @@ void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self);
 void BSLP_PolicyPredicate_InitSet(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src);
 void BSLP_PolicyPredicate_Deinit(BSLP_PolicyPredicate_t *self);
 
+/// @cond Doxygen_Suppress
+// NOLINTBEGIN
+// GCOV_EXCL_START
+M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicate_t,
+            (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(API_6(BSLP_PolicyPredicate_InitSet)), SET(0),
+             CLEAR(API_2(BSLP_PolicyPredicate_Deinit))))// GCOV_EXCL_STOP
+// NOLINTEND
+/// @endcond
+
 /**
  * @brief Returns true if the given predicate matches the arguments
  *
@@ -107,7 +116,6 @@ bool BSLP_PolicyPredicate_IsMatch(const BSLP_PolicyPredicate_t *self, BSL_Policy
 typedef struct BSLP_PolicyRule_s
 {
     string_t                  description;
-    BSLP_PolicyPredicate_t    predicate;
     BSL_SecRole_e             role;
     BSL_BundleBlockTypeCode_e target_block_type;
     BSL_SecBlockType_e        sec_block_type;
@@ -122,7 +130,6 @@ typedef struct BSLP_PolicyRule_s
  * @param[in] self This policy rule
  * @param[in] dest Description of this rule (C-string). Will copy characters of parameter from index 0 to
  * ::BSLP_POLICY_RULE_DESCRIPTION_MAX_STRLEN - 1.
- * @param[in] predicate Predicate used to identify which bundles apply
  * @param[in] context_id Security context ID
  * @param[in] role Such as source, acceptor, etc
  * @param[in] sec_block_type Block type (BIB or BCB)
@@ -131,9 +138,7 @@ typedef struct BSLP_PolicyRule_s
  *
  * @returns Zero on success
  */
-int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, BSLP_PolicyPredicate_t *predicate,
-                                int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type,
-                                BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
+int BSLP_PolicyRule_InitFrom(BSLP_PolicyRule_t *self, const char *desc, int64_t context_id, BSL_SecRole_e role, BSL_SecBlockType_e sec_block_type, BSL_BundleBlockTypeCode_e target_block_type, BSL_PolicyAction_e failure_action_code);
 
 // TODO docs
 void BSLP_PolicyRule_Init(BSLP_PolicyRule_t *self);
@@ -171,32 +176,23 @@ void BSLP_PolicyRule_CopyParam(BSLP_PolicyRule_t *self, const BSL_SecParam_t *pa
  */
 void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param);
 
-/**
- * @brief Critical function creating a security operation from a bundle and location.
- *
- * @param[in] self This policy rule
- * @param[in] sec_oper @preallocated Caller-allocated space for the output security action.
- * @param[in] bundle Bundle to test match against
- * @param[in] location Location in the BPA
- *
- * @return Zero on success, negative on failure.
- */
-int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, BSL_SecOper_t *sec_oper,
-                                      const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location);
-
 #define BSLP_POLICYPREDICATE_ARRAY_CAPACITY (100)
 /// @brief Concrete definition of a policy provider
 typedef struct BSLP_PolicyProvider_s
 {
-    BSLP_PolicyRuleList_t   rules;
-    pthread_mutex_t         mutex;
-    uint64_t                pp_id;
+    BSLP_PolicyRuleList_t       rules;
+    BSLP_PolicyPredicateList_t  predicates;
+    pthread_mutex_t             mutex;
+    uint64_t                    pp_id;
 } BSLP_PolicyProvider_t;
 
 /// TODO docs
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
-void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule);
+void BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate);
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);
+
+// TODO
+int BSLP_PolicyRule_EvaluateAsSecOper(const BSLP_PolicyRule_t *self, const BSLP_PolicyPredicate_t *predicate, BSL_SecOper_t *sec_oper, const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location);
 
 int BSLP_QueryPolicy(const void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location);

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -138,7 +138,7 @@ typedef struct BSLP_PolicyRule_s
 } BSLP_PolicyRule_t;
 
 /**
- * @brief Initialize this policy rule from paramteres
+ * @brief Initialize this policy rule from parameters
  *
  * @param[in] self This policy rule
  * @param[in] dest Description of this rule (C-string). Will copy characters of parameter from index 0 to

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -220,10 +220,10 @@ void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param);
 /// @brief Policy provider data. References shared among individual providers in BSL context
 typedef struct BSLP_PolicyProvider_s
 {
-    BSLP_PolicyRuleList_t      rules;       ///< Variable-length list of policy rules
-    BSLP_PolicyPredicateList_t predicates;  ///< Variable-length list of policy predicates
-    pthread_mutex_t            mutex;       ///< Mutex for shared data
-    uint64_t                   pp_id;       ///< ID of policy provider
+    BSLP_PolicyRuleList_t      rules;      ///< Variable-length list of policy rules
+    BSLP_PolicyPredicateList_t predicates; ///< Variable-length list of policy predicates
+    pthread_mutex_t            mutex;      ///< Mutex for shared data
+    uint64_t                   pp_id;      ///< ID of policy provider
 } BSLP_PolicyProvider_t;
 
 /** Initialize policy provider data
@@ -242,7 +242,7 @@ int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *
                                 const BSLP_PolicyPredicate_t *predicate);
 
 /** Deinitialize policy provider data
- * References to this data will become invalid 
+ * References to this data will become invalid
  * @param self policy provider data to de-initialize
  */
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -37,7 +37,7 @@
 #include <BPSecLib_Private.h>
 #include <backend/SecParam.h>
 
-/** De-initialize polocy provider user_data.
+/** De-initialize policy provider user_data.
  *  Called during de-initialization of each library instance.
  *  @param user_data reference to shared data. Not owned by library context's policy provider
  */

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -37,6 +37,10 @@
 #include <BPSecLib_Private.h>
 #include <backend/SecParam.h>
 
+/** De-initialize polocy provider user_data.
+ *  Called during de-initialization of each library instance.
+ *  @param user_data reference to shared data. Not owned by library context's policy provider
+ */
 void BSLP_Deinit(void *user_data);
 
 /**
@@ -212,16 +216,18 @@ void BSLP_PolicyRule_CopyParam(BSLP_PolicyRule_t *self, const BSL_SecParam_t *pa
 void BSLP_PolicyRule_MoveParam(BSLP_PolicyRule_t *self, BSL_SecParam_t *param);
 
 #define BSLP_POLICYPREDICATE_ARRAY_CAPACITY (100)
-/// @brief Concrete definition of a policy provider
+
+/// @brief Policy provider data. References shared among individual providers in BSL context
 typedef struct BSLP_PolicyProvider_s
 {
-    BSLP_PolicyRuleList_t      rules;
-    BSLP_PolicyPredicateList_t predicates;
-    pthread_mutex_t            mutex;
-    uint64_t                   pp_id;
+    BSLP_PolicyRuleList_t      rules;       ///< Variable-length list of policy rules
+    BSLP_PolicyPredicateList_t predicates;  ///< Variable-length list of policy predicates
+    pthread_mutex_t            mutex;       ///< Mutex for shared data
+    uint64_t                   pp_id;       ///< ID of policy provider
 } BSLP_PolicyProvider_t;
 
-/** Initialize policy provider
+/** Initialize policy provider data
+ * Data owned by BPA, reference should be provided to BSL library context(s)
  * @param pp_id policy provider id (must be > 0)
  * @return valid pointer to dynamically allocated policy provider
  */
@@ -235,8 +241,9 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
 int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule,
                                 const BSLP_PolicyPredicate_t *predicate);
 
-/** Deinitialize policy provider
- * @param self policy provider
+/** Deinitialize policy provider data
+ * References to this data will become invalid 
+ * @param self policy provider data to de-initialize
  */
 void BSLP_PolicyProvider_Deinit(BSLP_PolicyProvider_t *self);
 

--- a/src/policy_provider/SamplePolicyProvider.h
+++ b/src/policy_provider/SamplePolicyProvider.h
@@ -55,7 +55,7 @@ typedef struct
 } BSLP_PolicyPredicate_t;
 
 /**
- * @brief Initialize policy predicate from cstring patterns
+ * @brief Initialize policy predicate from c string patterns
  *
  * A policy predicate represents a way to match whether a rule applies to a bundle.
  *
@@ -77,8 +77,8 @@ int BSLP_PolicyPredicate_InitFrom(BSLP_PolicyPredicate_t *self, BSL_PolicyLocati
 void BSLP_PolicyPredicate_Init(BSLP_PolicyPredicate_t *self);
 
 /** Shallow copy of policy predicate
- * @param self dest policy predicate
- * @param src source policy prediate
+ * @param self destination policy predicate
+ * @param src source policy predicate
  */
 void BSLP_PolicyPredicate_ShallowCopy(BSLP_PolicyPredicate_t *self, const BSLP_PolicyPredicate_t *src);
 
@@ -213,7 +213,7 @@ typedef struct BSLP_PolicyProvider_s
  */
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
 
-/** Add rule and corresponding prediate to policy provider
+/** Add rule and corresponding predicate to policy provider
  * @param self policy provider
  * @param rule policy rule to add
  * @param predicate predicate to be associated with policy rule

--- a/src/security_context/BIB_HMAC_SHA2.c
+++ b/src/security_context/BIB_HMAC_SHA2.c
@@ -62,9 +62,9 @@ bool BSLX_BCB_Validate(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const B
  * Provides the mapping from the security-context-specific ID defined in RFC9173
  * to the local ID of the SHA variant used by the crypto engine (OpenSSL).
  */
-static ssize_t map_rfc9173_sha_variant_to_crypto(size_t rfc9173_sha_variant)
+static int64_t map_rfc9173_sha_variant_to_crypto(int64_t rfc9173_sha_variant)
 {
-    ssize_t crypto_sha_variant = -1;
+    int64_t crypto_sha_variant = -1;
     if (rfc9173_sha_variant == RFC9173_BIB_SHA_HMAC512)
     {
         crypto_sha_variant = BSL_CRYPTO_SHA_512;

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -41,6 +41,7 @@
 #include "bsl_test_utils.h"
 
 static BSL_TestContext_t LocalTestCtx;
+static BSLP_PolicyProvider_t *policy_provider;
 
 void suiteSetUp(void)
 {
@@ -61,8 +62,10 @@ void setUp(void)
     setenv("BSL_TEST_LOCAL_IPN_EID", "ipn:2.1", 1);
     TEST_ASSERT_EQUAL(0, BSL_API_InitLib(&LocalTestCtx.bsl));
 
+    policy_provider = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID);
+
     BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
+    policy_desc.user_data        = policy_provider;
     policy_desc.query_fn         = BSLP_QueryPolicy;
     policy_desc.finalize_fn      = BSLP_FinalizePolicy;
     policy_desc.deinit_fn        = BSLP_Deinit;
@@ -74,6 +77,7 @@ void setUp(void)
 
 void tearDown(void)
 {
+    BSLP_PolicyProvider_Deinit(policy_provider);
     mock_bpa_ctr_deinit(&LocalTestCtx.mock_bpa_ctr);
     TEST_ASSERT_EQUAL(0, BSL_API_DeinitLib(&LocalTestCtx.bsl));
 }
@@ -108,13 +112,14 @@ void test_PolicyProvider_InspectSingleBIBRuleset(void)
 {
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
 
-    BSLP_PolicyPredicate_t *predicate = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
+    BSLP_PolicyPredicate_t predicate;
+    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
-    BSLP_PolicyRule_t *rule = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule, "Verify BIB on APPIN from anywhere", predicate, 1, BSL_SECROLE_VERIFIER,
+    BSLP_PolicyRule_t rule;
+    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER,
                          BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
+
+    BSLP_PolicyProvider_AddRule(policy, &rule, &predicate);
 
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -136,17 +141,18 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
 {
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
 
-    BSLP_PolicyPredicate_t *predicate = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
+    BSLP_PolicyPredicate_t predicate;
+    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
-    BSLP_PolicyRule_t *rule = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule, "Verify BIB on APPIN from anywhere", predicate, 1, BSL_SECROLE_VERIFIER,
+    BSLP_PolicyRule_t rule;
+    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER,
                          BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.sha_variant);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.scope_flags);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.test_key_id);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.sha_variant);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.scope_flags);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.test_key_id);
+
+    BSLP_PolicyProvider_AddRule(policy, &rule, &predicate);
 
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_bib));
@@ -171,42 +177,41 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
  */
 void test_MultiplePolicyProviders(void)
 {
+    BSLP_PolicyProvider_t *policy_provider2 = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID_2);
+
     BSL_PolicyDesc_t policy_desc_2 = { 0 };
-    policy_desc_2.user_data        = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
+    policy_desc_2.user_data        = policy_provider2;
     policy_desc_2.query_fn         = BSLP_QueryPolicy;
     policy_desc_2.finalize_fn      = BSLP_FinalizePolicy;
     policy_desc_2.deinit_fn        = BSLP_Deinit;
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID_2, policy_desc_2));
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
-    policy->pp_id                 = BSL_SAMPLE_PP_ID;
-
     BSLP_PolicyProvider_t *policy2 = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID_2)->user_data;
-    policy2->pp_id                 = BSL_SAMPLE_PP_ID_2;
 
-    BSLP_PolicyPredicate_t *predicate = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
+    BSLP_PolicyPredicate_t predicate;
+    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
-    BSLP_PolicyRule_t *rule = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule, "Source BIB over primary on APPIN from anywhere", predicate, 1, BSL_SECROLE_SOURCE,
+    BSLP_PolicyRule_t rule;
+    BSLP_PolicyRule_InitFrom(&rule, "Source BIB over primary on APPIN from anywhere", 1, BSL_SECROLE_SOURCE,
                          BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PRIMARY, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.sha_variant);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.scope_flags);
-    BSLP_PolicyRule_MoveParam(rule, &bib_params.test_key_id);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.sha_variant);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.scope_flags);
+    BSLP_PolicyRule_MoveParam(&rule, &bib_params.test_key_id);
+    BSLP_PolicyProvider_AddRule(policy, &rule, &predicate);
 
-    BSLP_PolicyPredicate_t *predicate2 = &policy2->predicates[policy2->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate2, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
+    BSLP_PolicyPredicate_t predicate2;
+    BSLP_PolicyPredicate_InitFrom(&predicate2, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
-    BSLP_PolicyRule_t *rule2 = &policy2->rules[policy2->rule_count++];
-    BSLP_PolicyRule_Init(rule2, "Source BIB over payload on APPIN from anywhere", predicate2, 1, BSL_SECROLE_SOURCE,
+    BSLP_PolicyRule_t rule2;
+    BSLP_PolicyRule_InitFrom(&rule2, "Source BIB over payload on APPIN from anywhere", 1, BSL_SECROLE_SOURCE,
                          BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params2 = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
-    BSLP_PolicyRule_MoveParam(rule2, &bib_params2.sha_variant);
-    BSLP_PolicyRule_MoveParam(rule2, &bib_params2.scope_flags);
-    BSLP_PolicyRule_MoveParam(rule2, &bib_params2.test_key_id);
+    BSLP_PolicyRule_MoveParam(&rule2, &bib_params2.sha_variant);
+    BSLP_PolicyRule_MoveParam(&rule2, &bib_params2.scope_flags);
+    BSLP_PolicyRule_MoveParam(&rule2, &bib_params2.test_key_id);
+    BSLP_PolicyProvider_AddRule(policy2, &rule2, &predicate2);
 
     TEST_ASSERT_EQUAL(
         0, BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.cbor_bundle_original));
@@ -244,5 +249,6 @@ void test_MultiplePolicyProviders(void)
                                                             &LocalTestCtx.mock_bpa_ctr.bundle_ref, response_set));
 
     BSL_SecurityActionSet_Deinit(&action_set);
+    BSLP_PolicyProvider_Deinit(policy_provider2);
     BSL_free(response_set);
 }

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -40,7 +40,7 @@
 
 #include "bsl_test_utils.h"
 
-static BSL_TestContext_t LocalTestCtx;
+static BSL_TestContext_t      LocalTestCtx;
 static BSLP_PolicyProvider_t *policy_provider;
 
 void suiteSetUp(void)
@@ -116,8 +116,8 @@ void test_PolicyProvider_InspectSingleBIBRuleset(void)
     BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
     BSLP_PolicyRule_t rule;
-    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER,
-                         BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB,
+                             BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
 
     BSLP_PolicyProvider_AddRule(policy, &rule, &predicate);
 
@@ -145,8 +145,8 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
     BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
     BSLP_PolicyRule_t rule;
-    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER,
-                         BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule, "Verify BIB on APPIN from anywhere", 1, BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB,
+                             BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
     BSLP_PolicyRule_MoveParam(&rule, &bib_params.sha_variant);
     BSLP_PolicyRule_MoveParam(&rule, &bib_params.scope_flags);
@@ -186,7 +186,7 @@ void test_MultiplePolicyProviders(void)
     policy_desc_2.deinit_fn        = BSLP_Deinit;
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID_2, policy_desc_2));
 
-    BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
+    BSLP_PolicyProvider_t *policy  = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
     BSLP_PolicyProvider_t *policy2 = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID_2)->user_data;
 
     BSLP_PolicyPredicate_t predicate;
@@ -194,7 +194,7 @@ void test_MultiplePolicyProviders(void)
 
     BSLP_PolicyRule_t rule;
     BSLP_PolicyRule_InitFrom(&rule, "Source BIB over primary on APPIN from anywhere", 1, BSL_SECROLE_SOURCE,
-                         BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PRIMARY, BSL_POLICYACTION_DROP_BUNDLE);
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PRIMARY, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
     BSLP_PolicyRule_MoveParam(&rule, &bib_params.sha_variant);
     BSLP_PolicyRule_MoveParam(&rule, &bib_params.scope_flags);
@@ -206,7 +206,7 @@ void test_MultiplePolicyProviders(void)
 
     BSLP_PolicyRule_t rule2;
     BSLP_PolicyRule_InitFrom(&rule2, "Source BIB over payload on APPIN from anywhere", 1, BSL_SECROLE_SOURCE,
-                         BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     RFC9173_A1_Params bib_params2 = BSL_TestUtils_GetRFC9173_A1Params(RFC9173_EXAMPLE_A1_KEY);
     BSLP_PolicyRule_MoveParam(&rule2, &bib_params2.sha_variant);
     BSLP_PolicyRule_MoveParam(&rule2, &bib_params2.scope_flags);

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -43,6 +43,7 @@ static BSL_SecParam_t param_test_bcb_key_correct;
 
 static BSL_TestContext_t       LocalTestCtx = { 0 };
 static BSL_SecurityActionSet_t action_set   = { 0 };
+static BSLP_PolicyProvider_t *policy_provider;
 
 static void *malloc_test(size_t size)
 {
@@ -105,9 +106,11 @@ void _setUp(void)
     BSL_SecParam_Init(&param_use_wrap_key);
     BSL_SecParam_Init(&param_test_bcb_key_correct);
 
+    policy_provider = BSLP_PolicyProvider_Init(1);
+
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
+    policy_desc.user_data        = policy_provider;
     policy_desc.query_fn         = BSLP_QueryPolicy;
     policy_desc.deinit_fn        = BSLP_Deinit;
     policy_desc.finalize_fn      = BSLP_FinalizePolicy;
@@ -115,34 +118,30 @@ void _setUp(void)
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
 
-    policy->pp_id = 1;
-
     BSL_SecParam_InitInt64(&param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT, RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_SecParam_InitInt64(&param_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
     BSL_SecParam_InitTextstr(&param_test_bcb_key_correct, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A2_KEY);
 
     // BSL_32
-    BSLP_PolicyPredicate_t *predicate_bsl_32a = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.3.2"));
-    BSLP_PolicyRule_t *rule_bsl_32a = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", predicate_bsl_32a, 2,
+    BSLP_PolicyPredicate_t predicate_bsl_32a;
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT,"*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyRule_t rule_bsl_32a;
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", 2,
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32a, &predicate_bsl_32a);
 
-    BSLP_PolicyPredicate_t *predicate_bsl_32b = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.3.2"));
-    BSLP_PolicyRule_t *rule_bsl_32b = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", predicate_bsl_32b, 2,
+    BSLP_PolicyPredicate_t predicate_bsl_32b;
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT,"*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyRule_t rule_bsl_32b;
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2,
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32b, &predicate_bsl_32b);
 
     /// Register the Security Context
     BSL_TestUtils_SetupDefaultSecurityContext(&LocalTestCtx.bsl);
@@ -152,6 +151,7 @@ void _setUp(void)
 void _tearDown(void)
 {
     BSL_SecurityActionSet_Deinit(&action_set);
+    BSLP_PolicyProvider_Deinit(policy_provider);
     mock_bpa_ctr_deinit(&LocalTestCtx.mock_bpa_ctr);
     BSL_CryptoDeinit();
     TEST_ASSERT_EQUAL(0, BSL_API_DeinitLib(&LocalTestCtx.bsl));

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -43,7 +43,7 @@ static BSL_SecParam_t param_test_bcb_key_correct;
 
 static BSL_TestContext_t       LocalTestCtx = { 0 };
 static BSL_SecurityActionSet_t action_set   = { 0 };
-static BSLP_PolicyProvider_t *policy_provider;
+static BSLP_PolicyProvider_t  *policy_provider;
 
 static void *malloc_test(size_t size)
 {
@@ -124,20 +124,21 @@ void _setUp(void)
 
     // BSL_32
     BSLP_PolicyPredicate_t predicate_bsl_32a;
-    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT,"*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
     BSLP_PolicyRule_t rule_bsl_32a;
     BSLP_PolicyRule_InitFrom(&rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", 2,
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
+                             BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_aes_variant_128);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &param_use_wrap_key);
     BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32a, &predicate_bsl_32a);
 
     BSLP_PolicyPredicate_t predicate_bsl_32b;
-    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT,"*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
     BSLP_PolicyRule_t rule_bsl_32b;
-    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2,
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2, BSL_SECROLE_SOURCE,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_aes_variant_128);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &param_use_wrap_key);

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -57,7 +57,7 @@ typedef struct
 static BSL_TestContext_t          LocalTestCtx = { 0 };
 static BSL_SecurityActionSet_t    action_set   = { 0 };
 static BSL_TestPublInterfaceCtx_t ctx          = { 0 };
-static BSLP_PolicyProvider_t *policy_provider;
+static BSLP_PolicyProvider_t     *policy_provider;
 
 void suiteSetUp(void)
 {
@@ -184,9 +184,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_1;
     BSLP_PolicyPredicate_InitFrom(&predicate_1, BSL_POLICYLOCATION_CLIN, "ipn:*.1.1", "*:**", "*:**");
     BSLP_PolicyRule_t rule_1;
-    BSLP_PolicyRule_InitFrom(&rule_1, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.1) WITH POLICY DROP BLOCK",
-                         1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_1, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.1) WITH POLICY DROP BLOCK", 1,
+                             BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_test_bib_key_correct);
@@ -197,9 +197,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_2;
     BSLP_PolicyPredicate_InitFrom(&predicate_2, BSL_POLICYLOCATION_CLIN, "ipn:*.1.2", "*:**", "*:**");
     BSLP_PolicyRule_t rule_2;
-    BSLP_PolicyRule_InitFrom(&rule_2, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.2)", 1,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule_2, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.2)", 1, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_test_bib_key_bad);
@@ -210,9 +209,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_3;
     BSLP_PolicyPredicate_InitFrom(&predicate_3, BSL_POLICYLOCATION_CLIN, "ipn:*.1.3", "*:**", "*:**");
     BSLP_PolicyRule_t rule_3;
-    BSLP_PolicyRule_InitFrom(&rule_3, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.3)", 1,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_3, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.3)", 1, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_test_bib_key_bad);
@@ -223,8 +221,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_4;
     BSLP_PolicyPredicate_InitFrom(&predicate_4, BSL_POLICYLOCATION_CLIN, "ipn:*.1.4", "*:**", "*:**");
     BSLP_PolicyRule_t rule_4;
-    BSLP_PolicyRule_InitFrom(&rule_4, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.4)", 1,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
+    BSLP_PolicyRule_InitFrom(&rule_4, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.4)", 1, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
     BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_test_bib_key_bad);
@@ -236,9 +234,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_5;
     BSLP_PolicyPredicate_InitFrom(&predicate_5, BSL_POLICYLOCATION_CLIN, "ipn:*.1.5", "*:**", "*:**");
     BSLP_PolicyRule_t rule_5;
-    BSLP_PolicyRule_InitFrom(&rule_5, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.5) WITH POLICY DROP BLOCK",
-                         2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_5, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.5) WITH POLICY DROP BLOCK", 2,
+                             BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_wrapped_key);
@@ -251,9 +249,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_6;
     BSLP_PolicyPredicate_InitFrom(&predicate_6, BSL_POLICYLOCATION_CLIN, "ipn:*.1.6", "*:**", "*:**");
     BSLP_PolicyRule_t rule_6;
-    BSLP_PolicyRule_InitFrom(&rule_6, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.6)", 2,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule_6, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.6)", 2, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_wrapped_key);
@@ -266,9 +263,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_7;
     BSLP_PolicyPredicate_InitFrom(&predicate_7, BSL_POLICYLOCATION_CLIN, "ipn:*.1.7", "*:**", "*:**");
     BSLP_PolicyRule_t rule_7;
-    BSLP_PolicyRule_InitFrom(&rule_7, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.7)", 2,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_7, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.7)", 2, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_wrapped_key);
@@ -281,8 +277,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_8;
     BSLP_PolicyPredicate_InitFrom(&predicate_8, BSL_POLICYLOCATION_CLIN, "ipn:*.1.8", "*:**", "*:**");
     BSLP_PolicyRule_t rule_8;
-    BSLP_PolicyRule_InitFrom(&rule_8, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.8)", 2,  
-                         BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
+    BSLP_PolicyRule_InitFrom(&rule_8, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.8)", 2, BSL_SECROLE_ACCEPTOR,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
     BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_wrapped_key);
@@ -297,9 +293,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_9a;
     BSLP_PolicyPredicate_InitFrom(&predicate_9a, BSL_POLICYLOCATION_CLIN, "ipn:*.1.9", "*:**", "*:**");
     BSLP_PolicyRule_t rule_9a;
-    BSLP_PolicyRule_InitFrom(&rule_9a, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
-                         1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_9a, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK", 1,
+                             BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_test_bib_key_correct);
@@ -309,9 +305,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_9b;
     BSLP_PolicyPredicate_InitFrom(&predicate_9b, BSL_POLICYLOCATION_CLIN, "ipn:*.1.9", "*:**", "*:**");
     BSLP_PolicyRule_t rule_9b;
-    BSLP_PolicyRule_InitFrom(&rule_9b, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
-                         2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_9b, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK", 2,
+                             BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_wrapped_key);
@@ -326,8 +322,8 @@ void setUp(void)
     BSLP_PolicyPredicate_InitFrom(&predicate_13, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.1");
     BSLP_PolicyRule_t rule_13;
     BSLP_PolicyRule_InitFrom(&rule_13, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.1) WITH POLICY DROP BLOCK",
-                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+                             1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_test_bib_key_correct);
@@ -339,8 +335,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_14;
     BSLP_PolicyPredicate_InitFrom(&predicate_14, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.5");
     BSLP_PolicyRule_t rule_14;
-    BSLP_PolicyRule_InitFrom(&rule_14, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.5)", 2,  
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_14, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.5)", 2, BSL_SECROLE_SOURCE,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_aes_variant_128);
     BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_use_wrap_key);
@@ -353,8 +349,8 @@ void setUp(void)
     BSLP_PolicyPredicate_InitFrom(&predicate_15a, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.9");
     BSLP_PolicyRule_t rule_15a;
     BSLP_PolicyRule_InitFrom(&rule_15a, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9) WITH POLICY DROP BLOCK",
-                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+                             1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_sha_variant_384);
     BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_scope_flag_7);
     BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_test_bib_key_correct);
@@ -364,8 +360,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_15b;
     BSLP_PolicyPredicate_InitFrom(&predicate_15b, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.9");
     BSLP_PolicyRule_t rule_15b;
-    BSLP_PolicyRule_InitFrom(&rule_15b, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9)", 2,  
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_15b, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9)", 2, BSL_SECROLE_SOURCE,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_test_bcb_2_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_aes_variant_256);
     BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_dont_use_wrap_key);
@@ -376,9 +372,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_17;
     BSLP_PolicyPredicate_InitFrom(&predicate_17, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.1");
     BSLP_PolicyRule_t rule_17;
-    BSLP_PolicyRule_InitFrom(&rule_17, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.1)", 1,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_17, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.1)", 1, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_test_bib_key_correct);
@@ -389,9 +384,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_18;
     BSLP_PolicyPredicate_InitFrom(&predicate_18, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.2");
     BSLP_PolicyRule_t rule_18;
-    BSLP_PolicyRule_InitFrom(&rule_18, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.2)", 1,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule_18, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.2)", 1, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_test_bib_key_bad);
@@ -402,9 +396,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_19;
     BSLP_PolicyPredicate_InitFrom(&predicate_19, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.3");
     BSLP_PolicyRule_t rule_19;
-    BSLP_PolicyRule_InitFrom(&rule_19, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.3)", 1,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_19, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.3)", 1, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_test_bib_key_bad);
@@ -415,8 +408,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_20;
     BSLP_PolicyPredicate_InitFrom(&predicate_20, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.4");
     BSLP_PolicyRule_t rule_20;
-    BSLP_PolicyRule_InitFrom(&rule_20, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.4)", 1,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
+    BSLP_PolicyRule_InitFrom(&rule_20, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.4)", 1, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
     BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_test_bib_key_bad);
@@ -428,9 +421,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_21;
     BSLP_PolicyPredicate_InitFrom(&predicate_21, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.5");
     BSLP_PolicyRule_t rule_21;
-    BSLP_PolicyRule_InitFrom(&rule_21, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.5)", 2,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_21, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.5)", 2, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_wrapped_key);
@@ -443,9 +435,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_22;
     BSLP_PolicyPredicate_InitFrom(&predicate_22, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.6");
     BSLP_PolicyRule_t rule_22;
-    BSLP_PolicyRule_InitFrom(&rule_22, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.6)", 2,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BUNDLE);
+    BSLP_PolicyRule_InitFrom(&rule_22, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.6)", 2, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
     BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_wrapped_key);
@@ -458,9 +449,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_23;
     BSLP_PolicyPredicate_InitFrom(&predicate_23, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.7");
     BSLP_PolicyRule_t rule_23;
-    BSLP_PolicyRule_InitFrom(&rule_23, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.7)", 2,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_23, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.7)", 2, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_wrapped_key);
@@ -473,8 +463,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_24;
     BSLP_PolicyPredicate_InitFrom(&predicate_24, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.8");
     BSLP_PolicyRule_t rule_24;
-    BSLP_PolicyRule_InitFrom(&rule_24, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.8)", 2,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
+    BSLP_PolicyRule_InitFrom(&rule_24, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.8)", 2, BSL_SECROLE_VERIFIER,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
     BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_test_bcb_key_bad);
     BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_wrapped_key);
@@ -489,9 +479,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_25a;
     BSLP_PolicyPredicate_InitFrom(&predicate_25a, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.9");
     BSLP_PolicyRule_t rule_25a;
-    BSLP_PolicyRule_InitFrom(&rule_25a, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 1,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_25a, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 1,
+                             BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_test_bib_key_correct);
@@ -501,9 +491,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_25b;
     BSLP_PolicyPredicate_InitFrom(&predicate_25b, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.9");
     BSLP_PolicyRule_t rule_25b;
-    BSLP_PolicyRule_InitFrom(&rule_25b, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 2,  
-                         BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_25b, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 2,
+                             BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_iv);
     BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_wrapped_key);
@@ -515,9 +505,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_bsl_6;
     BSLP_PolicyPredicate_InitFrom(&predicate_bsl_6, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.0.6");
     BSLP_PolicyRule_t rule_bsl_6;
-    BSLP_PolicyRule_InitFrom(&rule_bsl_6, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:0.6) WITH POLICY DROP BLOCK",
-                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
-                         BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(
+        &rule_bsl_6, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:0.6) WITH POLICY DROP BLOCK", 1,
+        BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_sha_variant_512);
     BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_scope_flag);
     BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_test_bib_key_correct);
@@ -528,8 +518,9 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_bsl_32a;
     BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
     BSLP_PolicyRule_t rule_bsl_32a;
-    BSLP_PolicyRule_InitFrom(&rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", 2,  
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", 2,
+                             BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+                             BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_aes_variant_128);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_use_wrap_key);
@@ -538,8 +529,8 @@ void setUp(void)
     BSLP_PolicyPredicate_t predicate_bsl_32b;
     BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
     BSLP_PolicyRule_t rule_bsl_32b;
-    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2,  
-                         BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2, BSL_SECROLE_SOURCE,
+                             BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_test_bcb_key_correct);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_aes_variant_128);
     BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_use_wrap_key);

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -57,6 +57,7 @@ typedef struct
 static BSL_TestContext_t          LocalTestCtx = { 0 };
 static BSL_SecurityActionSet_t    action_set   = { 0 };
 static BSL_TestPublInterfaceCtx_t ctx          = { 0 };
+static BSLP_PolicyProvider_t *policy_provider;
 
 void suiteSetUp(void)
 {
@@ -126,18 +127,17 @@ void setUp(void)
     BSL_CryptoInit();
 
     PublicInterfaceTestCtx_init(&ctx);
+    policy_provider = BSLP_PolicyProvider_Init(1);
 
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = BSL_calloc(1, sizeof(BSLP_PolicyProvider_t));
+    policy_desc.user_data        = policy_provider;
     policy_desc.query_fn         = BSLP_QueryPolicy;
     policy_desc.deinit_fn        = BSLP_Deinit;
     policy_desc.finalize_fn      = BSLP_FinalizePolicy;
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
-
-    policy->pp_id = 1;
 
     // FIXME these params need managed lifecycle to ensure Deinit (by some means)
     BSL_SecParam_InitInt64(&ctx.param_scope_flag, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
@@ -181,386 +181,369 @@ void setUp(void)
 
     // test bib accepting with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // CLIN, SRC=ipn:1.1, ACCEPTOR, BIB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_1 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_1, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.1"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_1 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_1, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.1) WITH POLICY DROP BLOCK",
-                         predicate_1, 1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_1;
+    BSLP_PolicyPredicate_InitFrom(&predicate_1, BSL_POLICYLOCATION_CLIN, "ipn:*.1.1", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_1;
+    BSLP_PolicyRule_InitFrom(&rule_1, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.1) WITH POLICY DROP BLOCK",
+                         1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_1, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_1, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_1, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_1, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_1, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_1, &predicate_1);
 
     // CLIN, SRC=ipn:1.2, ACCEPTOR, BIB, PAYLOAD, DROP BUNDLE, bad key
-    BSLP_PolicyPredicate_t *predicate_2 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_2, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.2"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_2 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_2, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.2)", predicate_2, 1,
+    BSLP_PolicyPredicate_t predicate_2;
+    BSLP_PolicyPredicate_InitFrom(&predicate_2, BSL_POLICYLOCATION_CLIN, "ipn:*.1.2", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_2;
+    BSLP_PolicyRule_InitFrom(&rule_2, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.2)", 1,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BUNDLE);
-    BSLP_PolicyRule_CopyParam(rule_2, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_2, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_2, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_2, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_2, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_2, &predicate_2);
 
     // CLIN, SRC=ipn:1.3, ACCEPTOR, BIB, PAYLOAD, DROP BLOCK, bad key
-    BSLP_PolicyPredicate_t *predicate_3 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_3, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.3"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_3 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_3, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.3)", predicate_3, 1,
+    BSLP_PolicyPredicate_t predicate_3;
+    BSLP_PolicyPredicate_InitFrom(&predicate_3, BSL_POLICYLOCATION_CLIN, "ipn:*.1.3", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_3;
+    BSLP_PolicyRule_InitFrom(&rule_3, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.3)", 1,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_3, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_3, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_3, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_3, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_3, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_3, &predicate_3);
 
     // CLIN, SRC=ipn:1.4, ACCEPTOR, BIB, PAYLOAD, NOTHING, bad key
-    BSLP_PolicyPredicate_t *predicate_4 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_4, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.4"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_4 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_4, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.4)", predicate_4, 1,
+    BSLP_PolicyPredicate_t predicate_4;
+    BSLP_PolicyPredicate_InitFrom(&predicate_4, BSL_POLICYLOCATION_CLIN, "ipn:*.1.4", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_4;
+    BSLP_PolicyRule_InitFrom(&rule_4, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.4)", 1,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
-    BSLP_PolicyRule_CopyParam(rule_4, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_4, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_4, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_4, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_4, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_4, &predicate_4);
 
     // test bcb accepting with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // CLIN, SRC=ipn:1.5, ACCEPTOR, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_5 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_5, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.5"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_5 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_5, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.5) WITH POLICY DROP BLOCK",
-                         predicate_5, 2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_5;
+    BSLP_PolicyPredicate_InitFrom(&predicate_5, BSL_POLICYLOCATION_CLIN, "ipn:*.1.5", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_5;
+    BSLP_PolicyRule_InitFrom(&rule_5, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.5) WITH POLICY DROP BLOCK",
+                         2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_5, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_5, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_5, &predicate_5);
 
     // CLIN, SRC=ipn:1.6, ACCEPTOR, BCB, PAYLOAD, DROP BUNDLE, bad key
-    BSLP_PolicyPredicate_t *predicate_6 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_6, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.6"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_6 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_6, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.6)", predicate_6, 2,
+    BSLP_PolicyPredicate_t predicate_6;
+    BSLP_PolicyPredicate_InitFrom(&predicate_6, BSL_POLICYLOCATION_CLIN, "ipn:*.1.6", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_6;
+    BSLP_PolicyRule_InitFrom(&rule_6, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.6)", 2,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BUNDLE);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_6, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_6, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_6, &predicate_6);
 
     // CLIN, SRC=ipn:1.7, ACCEPTOR, BCB, PAYLOAD, DROP BLOCK, bad key
-    BSLP_PolicyPredicate_t *predicate_7 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_7, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.7"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_7 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_7, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.7)", predicate_7, 2,
+    BSLP_PolicyPredicate_t predicate_7;
+    BSLP_PolicyPredicate_InitFrom(&predicate_7, BSL_POLICYLOCATION_CLIN, "ipn:*.1.7", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_7;
+    BSLP_PolicyRule_InitFrom(&rule_7, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.7)", 2,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_7, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_7, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_7, &predicate_7);
 
     // CLIN, SRC=ipn:1.8, ACCEPTOR, BCB, PAYLOAD, NOTHING, bad key
-    BSLP_PolicyPredicate_t *predicate_8 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_8, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.8"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_8 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_8, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.8)", predicate_8, 2,
+    BSLP_PolicyPredicate_t predicate_8;
+    BSLP_PolicyPredicate_InitFrom(&predicate_8, BSL_POLICYLOCATION_CLIN, "ipn:*.1.8", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_8;
+    BSLP_PolicyRule_InitFrom(&rule_8, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.8)", 2,  
                          BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_8, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_8, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_8, &predicate_8);
 
     // test bib & bcb accpeting with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // CLIN, SRC=ipn:1.9, ACCEPTOR, BIB, PAYLOAD, DROP BLOCK, good key
     // CLIN, SRC=ipn:1.9, ACCEPTOR, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_9a = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_9a, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_9a = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_9a, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
-                         predicate_9a, 1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_9a;
+    BSLP_PolicyPredicate_InitFrom(&predicate_9a, BSL_POLICYLOCATION_CLIN, "ipn:*.1.9", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_9a;
+    BSLP_PolicyRule_InitFrom(&rule_9a, "ACCEPT BIB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
+                         1, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_9a, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_9a, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_9a, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_9a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_9a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_9a, &predicate_9a);
 
-    BSLP_PolicyPredicate_t *predicate_9b = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_9b, BSL_POLICYLOCATION_CLIN, BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-    BSLP_PolicyRule_t *rule_9b = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_9b, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
-                         predicate_9b, 2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_9b;
+    BSLP_PolicyPredicate_InitFrom(&predicate_9b, BSL_POLICYLOCATION_CLIN, "ipn:*.1.9", "*:**", "*:**");
+    BSLP_PolicyRule_t rule_9b;
+    BSLP_PolicyRule_InitFrom(&rule_9b, "ACCEPT BCB OVER PAYLOAD AT CLIN FILTER(SRC=ipn:1.9) WITH POLICY DROP BLOCK",
+                         2, BSL_SECROLE_ACCEPTOR, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_9b, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_9b, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_9b, &predicate_9b);
 
     // test bib sourcing with good key
     // CLOUT, DEST=ipn:1.1, SOURCE, BIB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_13 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_13, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.1"));
-    BSLP_PolicyRule_t *rule_13 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_13, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.1) WITH POLICY DROP BLOCK",
-                         predicate_13, 1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_13;
+    BSLP_PolicyPredicate_InitFrom(&predicate_13, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.1");
+    BSLP_PolicyRule_t rule_13;
+    BSLP_PolicyRule_InitFrom(&rule_13, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.1) WITH POLICY DROP BLOCK",
+                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_13, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_13, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_13, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_13, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_13, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_13, &predicate_13);
 
     // test bcb sourcing with good key
     // CLOUT, DEST=ipn:1.5, SOURCE, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_14 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_14, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.5"));
-    BSLP_PolicyRule_t *rule_14 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_14, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.5)", predicate_14, 2,
+    BSLP_PolicyPredicate_t predicate_14;
+    BSLP_PolicyPredicate_InitFrom(&predicate_14, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.5");
+    BSLP_PolicyRule_t rule_14;
+    BSLP_PolicyRule_InitFrom(&rule_14, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.5)", 2,  
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_14, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_14, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_14, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_14, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_14, &predicate_14);
 
     // test bib & bcb sourcing with good key
     // CLOUT, DEST=ipn:1.9, SOURCE, BIB, PAYLOAD, DROP BLOCK, good key
     // CLOUT, DEST=ipn:1.9, SOURCE, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_15a = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_15a, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"));
-    BSLP_PolicyRule_t *rule_15a = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_15a, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9) WITH POLICY DROP BLOCK",
-                         predicate_15a, 1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_15a;
+    BSLP_PolicyPredicate_InitFrom(&predicate_15a, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.9");
+    BSLP_PolicyRule_t rule_15a;
+    BSLP_PolicyRule_InitFrom(&rule_15a, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9) WITH POLICY DROP BLOCK",
+                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_15a, &ctx.param_sha_variant_384);
-    BSLP_PolicyRule_CopyParam(rule_15a, &ctx.param_scope_flag_7);
-    BSLP_PolicyRule_CopyParam(rule_15a, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_15a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_sha_variant_384);
+    BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_scope_flag_7);
+    BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_15a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_15a, &predicate_15a);
 
-    BSLP_PolicyPredicate_t *predicate_15b = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_15b, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"));
-    BSLP_PolicyRule_t *rule_15b = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_15b, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9)", predicate_15b, 2,
+    BSLP_PolicyPredicate_t predicate_15b;
+    BSLP_PolicyPredicate_InitFrom(&predicate_15b, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.1.9");
+    BSLP_PolicyRule_t rule_15b;
+    BSLP_PolicyRule_InitFrom(&rule_15b, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:1.9)", 2,  
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_15b, &ctx.param_test_bcb_2_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_15b, &ctx.param_aes_variant_256);
-    BSLP_PolicyRule_CopyParam(rule_15b, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_test_bcb_2_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_aes_variant_256);
+    BSLP_PolicyRule_CopyParam(&rule_15b, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_15b, &predicate_15b);
 
     // test bib verif with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // APPIN, DEST=ipn:1.1, VERIF, BIB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_17 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_17, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.1"));
-    BSLP_PolicyRule_t *rule_17 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_17, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.1)", predicate_17, 1,
+    BSLP_PolicyPredicate_t predicate_17;
+    BSLP_PolicyPredicate_InitFrom(&predicate_17, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.1");
+    BSLP_PolicyRule_t rule_17;
+    BSLP_PolicyRule_InitFrom(&rule_17, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.1)", 1,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_17, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_17, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_17, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_17, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_17, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_17, &predicate_17);
 
     // APPIN, DEST=ipn:1.2, VERIF, BIB, PAYLOAD, DROP BUNDLE, bad key
-    BSLP_PolicyPredicate_t *predicate_18 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_18, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.2"));
-    BSLP_PolicyRule_t *rule_18 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_18, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.2)", predicate_18, 1,
+    BSLP_PolicyPredicate_t predicate_18;
+    BSLP_PolicyPredicate_InitFrom(&predicate_18, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.2");
+    BSLP_PolicyRule_t rule_18;
+    BSLP_PolicyRule_InitFrom(&rule_18, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.2)", 1,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BUNDLE);
-    BSLP_PolicyRule_CopyParam(rule_18, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_18, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_18, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_18, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_18, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_18, &predicate_18);
 
     // APPIN, DEST=ipn:1.3, VERIF, BIB, PAYLOAD, DROP BLOCK, bad key
-    BSLP_PolicyPredicate_t *predicate_19 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_19, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.3"));
-    BSLP_PolicyRule_t *rule_19 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_19, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.3)", predicate_19, 1,
+    BSLP_PolicyPredicate_t predicate_19;
+    BSLP_PolicyPredicate_InitFrom(&predicate_19, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.3");
+    BSLP_PolicyRule_t rule_19;
+    BSLP_PolicyRule_InitFrom(&rule_19, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.3)", 1,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_19, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_19, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_19, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_19, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_19, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_19, &predicate_19);
 
     // APPIN, DEST=ipn:1.4, VERIF, BIB, PAYLOAD, NOTHING, bad key
-    BSLP_PolicyPredicate_t *predicate_20 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_20, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.4"));
-    BSLP_PolicyRule_t *rule_20 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_20, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.4)", predicate_20, 1,
+    BSLP_PolicyPredicate_t predicate_20;
+    BSLP_PolicyPredicate_InitFrom(&predicate_20, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.4");
+    BSLP_PolicyRule_t rule_20;
+    BSLP_PolicyRule_InitFrom(&rule_20, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.4)", 1,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
-    BSLP_PolicyRule_CopyParam(rule_20, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_20, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_20, &ctx.param_test_bib_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_20, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_test_bib_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_20, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_20, &predicate_20);
 
     // test bcb verif with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // APPIN, DEST=ipn:1.5, VERIF, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_21 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_21, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.5"));
-    BSLP_PolicyRule_t *rule_21 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_21, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.5)", predicate_21, 2,
+    BSLP_PolicyPredicate_t predicate_21;
+    BSLP_PolicyPredicate_InitFrom(&predicate_21, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.5");
+    BSLP_PolicyRule_t rule_21;
+    BSLP_PolicyRule_InitFrom(&rule_21, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.5)", 2,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_21, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_21, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_21, &predicate_21);
 
     // APPIN, DEST=ipn:1.6, VERIF, BCB, PAYLOAD, DROP BUNDLE, bad key
-    BSLP_PolicyPredicate_t *predicate_22 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_22, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.6"));
-    BSLP_PolicyRule_t *rule_22 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_22, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.6)", predicate_22, 2,
+    BSLP_PolicyPredicate_t predicate_22;
+    BSLP_PolicyPredicate_InitFrom(&predicate_22, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.6");
+    BSLP_PolicyRule_t rule_22;
+    BSLP_PolicyRule_InitFrom(&rule_22, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.6)", 2,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BUNDLE);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_22, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_22, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_22, &predicate_22);
 
     // APPIN, DEST=ipn:1.7, VERIF, BCB, PAYLOAD, DROP BLOCK, bad key
-    BSLP_PolicyPredicate_t *predicate_23 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_23, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.7"));
-    BSLP_PolicyRule_t *rule_23 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_23, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.7)", predicate_23, 2,
+    BSLP_PolicyPredicate_t predicate_23;
+    BSLP_PolicyPredicate_InitFrom(&predicate_23, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.7");
+    BSLP_PolicyRule_t rule_23;
+    BSLP_PolicyRule_InitFrom(&rule_23, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.7)", 2,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_23, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_23, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_23, &predicate_23);
 
     // APPIN, DEST=ipn:1.8, VERIF, BCB, PAYLOAD, NOTHING, bad key
-    BSLP_PolicyPredicate_t *predicate_24 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_24, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.8"));
-    BSLP_PolicyRule_t *rule_24 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_24, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.8)", predicate_24, 2,
+    BSLP_PolicyPredicate_t predicate_24;
+    BSLP_PolicyPredicate_InitFrom(&predicate_24, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.8");
+    BSLP_PolicyRule_t rule_24;
+    BSLP_PolicyRule_InitFrom(&rule_24, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.8)", 2,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_NOTHING);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_test_bcb_key_bad);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_24, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_test_bcb_key_bad);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_24, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_24, &predicate_24);
 
     // test bib & bcb verif with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
     // APPIN, DEST=ipn:1.9, VERIF, BIB, PAYLOAD, DROP BLOCK, good key
     // APPIN, DEST=ipn:1.9, VERIF, BCB, PAYLOAD, DROP BLOCK, good key
-    BSLP_PolicyPredicate_t *predicate_25a = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_25a, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"));
-    BSLP_PolicyRule_t *rule_25a = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_25a, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", predicate_25a, 1,
+    BSLP_PolicyPredicate_t predicate_25a;
+    BSLP_PolicyPredicate_InitFrom(&predicate_25a, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.9");
+    BSLP_PolicyRule_t rule_25a;
+    BSLP_PolicyRule_InitFrom(&rule_25a, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 1,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_25a, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_25a, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_25a, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_25a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_25a, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_25a, &predicate_25a);
 
-    BSLP_PolicyPredicate_t *predicate_25b = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_25b, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.1.9"));
-    BSLP_PolicyRule_t *rule_25b = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_25b, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", predicate_25b, 2,
+    BSLP_PolicyPredicate_t predicate_25b;
+    BSLP_PolicyPredicate_InitFrom(&predicate_25b, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "ipn:*.1.9");
+    BSLP_PolicyRule_t rule_25b;
+    BSLP_PolicyRule_InitFrom(&rule_25b, "VERIFY BCB OVER PAYLOAD AT APPIN FILTER(DEST=ipn:1.9)", 2,  
                          BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_25b, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_25b, &ctx.param_iv);
-    BSLP_PolicyRule_CopyParam(rule_25b, &ctx.param_wrapped_key);
-    BSLP_PolicyRule_CopyParam(rule_25b, &ctx.param_auth_tag);
-    BSLP_PolicyRule_CopyParam(rule_25b, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_iv);
+    BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_wrapped_key);
+    BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_auth_tag);
+    BSLP_PolicyRule_CopyParam(&rule_25b, &ctx.param_aes_variant_128);
+    BSLP_PolicyProvider_AddRule(policy, &rule_25b, &predicate_25b);
 
     // BSL 6
-    BSLP_PolicyPredicate_t *predicate_bsl_6 = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_bsl_6, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.0.6"));
-    BSLP_PolicyRule_t *rule_bsl_6 = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_bsl_6, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:0.6) WITH POLICY DROP BLOCK",
-                         predicate_bsl_6, 1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
+    BSLP_PolicyPredicate_t predicate_bsl_6;
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_6, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.0.6");
+    BSLP_PolicyRule_t rule_bsl_6;
+    BSLP_PolicyRule_InitFrom(&rule_bsl_6, "SOURCE BIB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:0.6) WITH POLICY DROP BLOCK",
+                         1, BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD,
                          BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_bsl_6, &ctx.param_sha_variant_512);
-    BSLP_PolicyRule_CopyParam(rule_bsl_6, &ctx.param_scope_flag);
-    BSLP_PolicyRule_CopyParam(rule_bsl_6, &ctx.param_test_bib_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_bsl_6, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_sha_variant_512);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_scope_flag);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_test_bib_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_6, &ctx.param_dont_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_bsl_6, &predicate_bsl_6);
 
     // BSL_32
-    BSLP_PolicyPredicate_t *predicate_bsl_32a = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.3.2"));
-    BSLP_PolicyRule_t *rule_bsl_32a = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", predicate_bsl_32a, 2,
+    BSLP_PolicyPredicate_t predicate_bsl_32a;
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32a, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyRule_t rule_bsl_32a;
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32a, "SOURCE BCB OVER PAYLOAD AT CLOUT FILTER(DEST=ipn:3.2)", 2,  
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32a, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32a, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32a, &predicate_bsl_32a);
 
-    BSLP_PolicyPredicate_t *predicate_bsl_32b = &policy->predicates[policy->predicate_count++];
-    BSLP_PolicyPredicate_Init(predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("ipn:*.3.2"));
-    BSLP_PolicyRule_t *rule_bsl_32b = &policy->rules[policy->rule_count++];
-    BSLP_PolicyRule_Init(rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", predicate_bsl_32b, 2,
+    BSLP_PolicyPredicate_t predicate_bsl_32b;
+    BSLP_PolicyPredicate_InitFrom(&predicate_bsl_32b, BSL_POLICYLOCATION_CLOUT, "*:**", "*:**", "ipn:*.3.2");
+    BSLP_PolicyRule_t rule_bsl_32b;
+    BSLP_PolicyRule_InitFrom(&rule_bsl_32b, "SOURCE BCB OVER BIB AT CLOUT FILTER(DEST=ipn:3.2)", 2,  
                          BSL_SECROLE_SOURCE, BSL_SECBLOCKTYPE_BCB, BSL_BLOCK_TYPE_BIB, BSL_POLICYACTION_DROP_BLOCK);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &ctx.param_test_bcb_key_correct);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &ctx.param_aes_variant_128);
-    BSLP_PolicyRule_CopyParam(rule_bsl_32b, &ctx.param_use_wrap_key);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_test_bcb_key_correct);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_aes_variant_128);
+    BSLP_PolicyRule_CopyParam(&rule_bsl_32b, &ctx.param_use_wrap_key);
+    BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32b, &predicate_bsl_32b);
 
     /// Register the Security Context
     BSL_TestUtils_SetupDefaultSecurityContext(&LocalTestCtx.bsl);
@@ -569,6 +552,7 @@ void setUp(void)
 void tearDown(void)
 {
     BSL_SecurityActionSet_Deinit(&action_set);
+    BSLP_PolicyProvider_Deinit(policy_provider);
     mock_bpa_ctr_deinit(&LocalTestCtx.mock_bpa_ctr);
     BSL_CryptoDeinit();
     TEST_ASSERT_EQUAL(0, BSL_API_DeinitLib(&LocalTestCtx.bsl));

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -92,19 +92,18 @@ void test_SamplePolicyProvider_WildcardPolicyRuleVerifiesBIB(void)
 
     // Create a predicate: "At location APPIN, match Bundles from anywhere, to anywhere, with any security source"
     BSLP_PolicyPredicate_t predicate;
-    BSLP_PolicyPredicate_Init(&predicate, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
+    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**","*:**", "*:**");
 
     // Create a rule to verify the bundle contains a BIB block covering the payload
     BSLP_PolicyRule_t rule;
-    BSLP_PolicyRule_Init(&rule, "Confirm bundle has BIB protecting payload", &predicate, 1, BSL_SECROLE_VERIFIER,
+    BSLP_PolicyRule_InitFrom(&rule, "Confirm bundle has BIB protecting payload", 1, BSL_SECROLE_VERIFIER,
                          BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
 
     // Now evaluate the rule to get as a SecOper
     // This populates it with actual parameters.
     BSL_SecOper_t sec_oper;
     BSL_SecOper_Init(&sec_oper);
-    TEST_ASSERT_EQUAL(0, BSLP_PolicyRule_EvaluateAsSecOper(&rule, &sec_oper, &LocalTestCtx.mock_bpa_ctr.bundle_ref,
+    TEST_ASSERT_EQUAL(0, BSLP_PolicyRule_EvaluateAsSecOper(&rule, &predicate, &sec_oper, &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
 
     // Confirm the security operation uses BIB
@@ -121,42 +120,3 @@ void test_SamplePolicyProvider_WildcardPolicyRuleVerifiesBIB(void)
     BSLP_PolicyRule_Deinit(&rule);
     BSLP_PolicyPredicate_Deinit(&predicate);
 }
-
-TEST_CASE("")
-TEST_CASE("1")
-TEST_CASE(
-    "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789") // 100 char
-TEST_CASE(
-    "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890") // 101 char
-void test_SamplePolicyProvider_PolicyRuleInit_Description(const char *description)
-{
-    BSLP_PolicyPredicate_t predicate;
-    BSLP_PolicyPredicate_Init(&predicate, BSL_POLICYLOCATION_APPIN, BSL_TestUtils_GetEidPatternFromText("*:**"),
-                              BSL_TestUtils_GetEidPatternFromText("*:**"), BSL_TestUtils_GetEidPatternFromText("*:**"));
-
-    BSLP_PolicyRule_t rule;
-    BSLP_PolicyRule_Init(&rule, description, &predicate, 1, BSL_SECROLE_VERIFIER, BSL_SECBLOCKTYPE_BIB,
-                         BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
-
-    TEST_ASSERT_LESS_OR_EQUAL(BSLP_POLICY_RULE_DESCRIPTION_MAX_STRLEN, strlen(rule.description));
-
-    if (strlen(description) <= BSLP_POLICY_RULE_DESCRIPTION_MAX_STRLEN)
-    {
-        TEST_ASSERT_EQUAL(strlen(description), strlen(rule.description));
-    }
-    else
-    {
-        TEST_ASSERT_EQUAL(BSLP_POLICY_RULE_DESCRIPTION_MAX_STRLEN, strlen(rule.description));
-    }
-
-    // unity doesn't like TEST_ASSERT_EQUAL_MEMORY call on 0 length buffer
-    if (strlen(description) > 0)
-    {
-        TEST_ASSERT_EQUAL_MEMORY(description, rule.description, strlen(rule.description));
-    }
-
-    BSLP_PolicyRule_Deinit(&rule);
-    BSLP_PolicyPredicate_Deinit(&predicate);
-}
-
-// TODO(bvb) more tests with more granular predicates and rules

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -92,18 +92,19 @@ void test_SamplePolicyProvider_WildcardPolicyRuleVerifiesBIB(void)
 
     // Create a predicate: "At location APPIN, match Bundles from anywhere, to anywhere, with any security source"
     BSLP_PolicyPredicate_t predicate;
-    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**","*:**", "*:**");
+    BSLP_PolicyPredicate_InitFrom(&predicate, BSL_POLICYLOCATION_APPIN, "*:**", "*:**", "*:**");
 
     // Create a rule to verify the bundle contains a BIB block covering the payload
     BSLP_PolicyRule_t rule;
     BSLP_PolicyRule_InitFrom(&rule, "Confirm bundle has BIB protecting payload", 1, BSL_SECROLE_VERIFIER,
-                         BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
+                             BSL_SECBLOCKTYPE_BIB, BSL_BLOCK_TYPE_PAYLOAD, BSL_POLICYACTION_DROP_BUNDLE);
 
     // Now evaluate the rule to get as a SecOper
     // This populates it with actual parameters.
     BSL_SecOper_t sec_oper;
     BSL_SecOper_Init(&sec_oper);
-    TEST_ASSERT_EQUAL(0, BSLP_PolicyRule_EvaluateAsSecOper(&rule, &predicate, &sec_oper, &LocalTestCtx.mock_bpa_ctr.bundle_ref,
+    TEST_ASSERT_EQUAL(0, BSLP_PolicyRule_EvaluateAsSecOper(&rule, &predicate, &sec_oper,
+                                                           &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
 
     // Confirm the security operation uses BIB


### PR DESCRIPTION
- BPA threads now have one shared (mutex protected) policy provider
- Updated backend to use m*lib array definition instead of static arrays
- Updated API/workflow for initializing and adding policy rules and predicates to policy provider

Closes #109 #81 