### PR TITLE
Separated block sorting from encoding, use block number as key

### DIFF
--- a/mock-bpa-test/test_requirements.py
+++ b/mock-bpa-test/test_requirements.py
@@ -216,10 +216,10 @@ class TestRequirements(TestAgent):
             #
             expected_output=[
                 [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
-                [11, 2, 0, 0, bytes.fromhex(
-                    '810001018202820201828201078203008181820158405d9bdd1e2f043cf971588111f2fe1b847666cfacb7fb403c2468ef92a8ec93df80b41620df5bc639d0c355e1cce6217e17d3b8c5560edc14aba3d005196b046e')],
                 [11, 3, 0, 0, bytes.fromhex(
                     '810101018202820201828201078203008181820158403bdc69b3a34a2b5d3a8554368bd1e808f606219d2a10a846eae3886ae4ecc83c4ee550fdfb1cc636b904e2f1a73e303dcd4b6ccece003e95e8164dcc89a156e1')],
+                [11, 2, 0, 0, bytes.fromhex(
+                    '810001018202820201828201078203008181820158405d9bdd1e2f043cf971588111f2fe1b847666cfacb7fb403c2468ef92a8ec93df80b41620df5bc639d0c355e1cce6217e17d3b8c5560edc14aba3d005196b046e')],
                 [1, 1, 0, 0, bytes.fromhex(
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
@@ -641,9 +641,9 @@ class TestRequirements(TestAgent):
             # Result asserts there are three blocks present, each with the expected type.
             expected_output=[
                 [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
-                [192, 2, 0, 0, bytes.fromhex('676f20647261676f6e666c7921')],
                 [11, 3, 0, 0, bytes.fromhex(
                     '8102010182028202018282010782030081818201584037f54fd9c08b1b9225e74e821ef4ead35dc850ea98a2b944105447d12d145416dadb83c5123c44bab0e57c20196eff060ddcdc7412e948fd46527101e54c201e')],
+                [192, 2, 0, 0, bytes.fromhex('676f20647261676f6e666c7921')],
                 [1, 1, 0, 0, bytes.fromhex(
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -935,19 +935,13 @@ size_t BSL_AbsSecBlock_Sizeof(void);
  *
  * @param[in,out] self This ASB
  * @param[in] sec_context_id Security Context ID
- * @param[in] source_eid Source EID in format native to host BPA.
  */
-void BSL_AbsSecBlock_Init(BSL_AbsSecBlock_t *self, int64_t sec_context_id, BSL_HostEID_t source_eid);
+void BSL_AbsSecBlock_Init(BSL_AbsSecBlock_t *self);
 
 /** Checks internal consistency and sanity of this structure.
  * @param[in] self This ASB
  */
 bool BSL_AbsSecBlock_IsConsistent(const BSL_AbsSecBlock_t *self);
-
-/** Initialize a pre-allocated ASB with no contents.
- * @param[in,out] self This ASB
- */
-void BSL_AbsSecBlock_InitEmpty(BSL_AbsSecBlock_t *self);
 
 /** Deinitializes and clears this ASB, clearing and releasing any owned memory.
  *

--- a/src/backend/AbsSecBlock.c
+++ b/src/backend/AbsSecBlock.c
@@ -84,30 +84,19 @@ void BSL_AbsSecBlock_Print(const BSL_AbsSecBlock_t *self)
     }
 }
 
-void BSL_AbsSecBlock_InitEmpty(BSL_AbsSecBlock_t *self)
+void BSL_AbsSecBlock_Init(BSL_AbsSecBlock_t *self)
 {
     // GCOV_EXCL_START
     ASSERT_ARG_NONNULL(self);
     // GCOV_EXCL_STOP
 
     memset(self, 0, sizeof(*self));
+
+    uint64_list_init(self->targets);
+    self->sec_context_id = 0;
+    BSL_HostEID_Init(&self->source_eid);
     BSLB_SecParamList_init(self->params);
     BSLB_SecResultList_init(self->results);
-    uint64_list_init(self->targets);
-}
-
-void BSL_AbsSecBlock_Init(BSL_AbsSecBlock_t *self, int64_t sec_context_id, BSL_HostEID_t source_eid)
-{
-    // GCOV_EXCL_START
-    ASSERT_ARG_NONNULL(self);
-    // GCOV_EXCL_STOP
-
-    memset(self, 0, sizeof(*self));
-    self->sec_context_id = sec_context_id;
-    self->source_eid     = source_eid;
-    BSLB_SecParamList_init(self->params);
-    BSLB_SecResultList_init(self->results);
-    uint64_list_init(self->targets);
 
     // GCOV_EXCL_START
     ASSERT_POSTCONDITION(BSL_AbsSecBlock_IsConsistent(self));
@@ -120,10 +109,11 @@ void BSL_AbsSecBlock_Deinit(BSL_AbsSecBlock_t *self)
     ASSERT_PRECONDITION(BSL_AbsSecBlock_IsConsistent(self));
     // GCOV_EXCL_STOP
 
-    BSLB_SecParamList_clear(self->params);
     BSLB_SecResultList_clear(self->results);
-    uint64_list_clear(self->targets);
+    BSLB_SecParamList_clear(self->params);
     BSL_HostEID_Deinit(&self->source_eid);
+    uint64_list_clear(self->targets);
+
     memset(self, 0, sizeof(*self));
 }
 
@@ -486,7 +476,6 @@ int BSL_AbsSecBlock_DecodeFromCBOR(BSL_AbsSecBlock_t *self, const BSL_Data_t *bu
     BSL_Data_t eid_cbor_data;
     BSL_Data_InitView(&eid_cbor_data, eid_raw.len, (uint8_t *)eid_raw.ptr);
 
-    BSL_HostEID_Init(&self->source_eid);
     int res = BSL_HostEID_DecodeFromCBOR(&eid_cbor_data, &self->source_eid);
     BSL_Data_Deinit(&eid_cbor_data);
     if (res != BSL_SUCCESS)

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -192,7 +192,7 @@ int BSL_API_QuerySecurity(const BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *outp
                 BSL_SeqReader_Destroy(btsd_read);
 
                 BSL_AbsSecBlock_t *abs_sec_block = BSL_calloc(1, BSL_AbsSecBlock_Sizeof());
-                BSL_AbsSecBlock_InitEmpty(abs_sec_block);
+                BSL_AbsSecBlock_Init(abs_sec_block);
                 if (BSL_AbsSecBlock_DecodeFromCBOR(abs_sec_block, &btsd_copy) == 0)
                 {
                     if (BSL_AbsSecBlock_ContainsTarget(abs_sec_block, sec_oper->target_block_num))

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -117,17 +117,16 @@ static int BSL_ExecBIBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
         return BSL_ERR_SECURITY_OPERATION_FAILED;
     }
 
-    BSL_HostEID_t sec_source_eid = { 0 };
-    // TODO - The ownership of this should be cleaned up(!)
-    BSL_HostEID_Init(&sec_source_eid);
-    if (BSL_Host_GetSecSrcEID(&sec_source_eid) != BSL_SUCCESS)
+    BSL_AbsSecBlock_t abs_sec_block;
+    BSL_AbsSecBlock_Init(&abs_sec_block);
+    if (BSL_Host_GetSecSrcEID(&abs_sec_block.source_eid) != BSL_SUCCESS)
     {
         BSL_LOG_ERR("Could not get local security source EID");
+        BSL_AbsSecBlock_Deinit(&abs_sec_block);
         BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
         return BSL_ERR_HOST_CALLBACK_FAILED;
     }
-    BSL_AbsSecBlock_t abs_sec_block = { 0 };
-    BSL_AbsSecBlock_Init(&abs_sec_block, sec_oper->context_id, sec_source_eid);
+    abs_sec_block.sec_context_id = sec_oper->context_id;
     BSL_AbsSecBlock_AddTarget(&abs_sec_block, sec_oper->target_block_num);
 
     size_t n_results = BSL_SecOutcome_CountResults(outcome);
@@ -146,11 +145,10 @@ static int BSL_ExecBIBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
     if (res != BSL_SUCCESS)
     {
         BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return res;
     }
 
     BSL_AbsSecBlock_Deinit(&abs_sec_block);
-    return BSL_SUCCESS;
+    return res;
 }
 
 static int BSL_ExecBIBAccept(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle,
@@ -178,7 +176,7 @@ static int BSL_ExecBIBAccept(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
     BSL_SeqReader_Destroy(btsd_read);
 
     BSL_AbsSecBlock_t abs_sec_block;
-    BSL_AbsSecBlock_InitEmpty(&abs_sec_block);
+    BSL_AbsSecBlock_Init(&abs_sec_block);
     if (BSL_AbsSecBlock_DecodeFromCBOR(&abs_sec_block, &btsd_copy) != BSL_SUCCESS)
     {
         BSL_LOG_ERR("Failed to parse ASB CBOR");
@@ -295,7 +293,7 @@ static int BSL_ExecBCBAcceptor(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t
     BSL_SeqReader_Destroy(btsd_read);
 
     BSL_AbsSecBlock_t abs_sec_block;
-    BSL_AbsSecBlock_InitEmpty(&abs_sec_block);
+    BSL_AbsSecBlock_Init(&abs_sec_block);
     if (BSL_AbsSecBlock_DecodeFromCBOR(&abs_sec_block, &btsd_copy) != BSL_SUCCESS)
     {
         BSL_LOG_ERR("Failed to parse ASB CBOR");
@@ -425,18 +423,15 @@ static int BSL_ExecBCBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
     }
 
     BSL_AbsSecBlock_t abs_sec_block;
+    BSL_AbsSecBlock_Init(&abs_sec_block);
+    if (BSL_SUCCESS != BSL_Host_GetSecSrcEID(&abs_sec_block.source_eid))
     {
-        BSL_HostEID_t src_eid = { 0 };
-        BSL_HostEID_Init(&src_eid);
-        if (BSL_SUCCESS != BSL_Host_GetSecSrcEID(&src_eid))
-        {
-            BSL_LOG_ERR("Failed to get host EID");
-            BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-            return BSL_ERR_HOST_CALLBACK_FAILED;
-        }
-        BSL_AbsSecBlock_Init(&abs_sec_block, sec_oper->context_id, src_eid);
+        BSL_LOG_ERR("Failed to get host EID");
+        BSL_AbsSecBlock_Deinit(&abs_sec_block);
+        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
+        return BSL_ERR_HOST_CALLBACK_FAILED;
     }
-
+    abs_sec_block.sec_context_id = sec_oper->context_id;
     BSL_AbsSecBlock_AddTarget(&abs_sec_block, sec_oper->target_block_num);
 
     size_t n_results = BSL_SecOutcome_CountResults(outcome);
@@ -457,11 +452,10 @@ static int BSL_ExecBCBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *
     if (res != BSL_SUCCESS)
     {
         BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return res;
     }
 
     BSL_AbsSecBlock_Deinit(&abs_sec_block);
-    return BSL_SUCCESS;
+    return res;
 }
 
 int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet_t *output_response,

--- a/src/mock_bpa/agent.c
+++ b/src/mock_bpa/agent.c
@@ -725,7 +725,7 @@ static void *MockBPA_Agent_work_over_rx(void *arg)
             break;
         }
         BSL_LOG_INFO("over_rx item");
-        mock_bpa_decode(&item);
+        mock_bpa_ctr_decode(&item);
 
         MockBPA_Bundle_t *bundle = item.bundle_ref.data;
         if (MockBPA_Agent_process(agent, &agent->appin, BSL_POLICYLOCATION_APPIN, bundle))
@@ -764,7 +764,7 @@ static void *MockBPA_Agent_work_under_rx(void *arg)
         }
 
         BSL_LOG_INFO("under_rx item");
-        if (mock_bpa_decode(&item))
+        if (mock_bpa_ctr_decode(&item))
         {
             BSL_LOG_ERR("failed to decode bundle");
             mock_bpa_ctr_deinit(&item);
@@ -822,7 +822,7 @@ static void *MockBPA_Agent_work_deliver(void *arg)
             continue;
         }
 
-        mock_bpa_encode(&item);
+        mock_bpa_ctr_encode(&item);
         MockBPA_data_queue_push(agent->over_tx, item);
         {
             uint8_t buf    = 0;
@@ -867,7 +867,7 @@ static void *MockBPA_Agent_work_forward(void *arg)
             continue;
         }
 
-        mock_bpa_encode(&item);
+        mock_bpa_ctr_encode(&item);
         MockBPA_data_queue_push(agent->under_tx, item);
         {
             uint8_t buf    = 0;

--- a/src/mock_bpa/agent.c
+++ b/src/mock_bpa/agent.c
@@ -822,6 +822,7 @@ static void *MockBPA_Agent_work_deliver(void *arg)
             continue;
         }
 
+        mock_bpa_ctr_sort_blocks(&item);
         mock_bpa_ctr_encode(&item);
         MockBPA_data_queue_push(agent->over_tx, item);
         {
@@ -867,6 +868,7 @@ static void *MockBPA_Agent_work_forward(void *arg)
             continue;
         }
 
+        mock_bpa_ctr_sort_blocks(&item);
         mock_bpa_ctr_encode(&item);
         MockBPA_data_queue_push(agent->under_tx, item);
         {

--- a/src/mock_bpa/bundle.c
+++ b/src/mock_bpa/bundle.c
@@ -21,12 +21,22 @@
  */
 #include "bundle.h"
 
+int MockBPA_CanonicalBlock_cmp(const MockBPA_CanonicalBlock_t *block_a, const MockBPA_CanonicalBlock_t *block_b)
+{
+    return M_CMP_DEFAULT(block_b->blk_num, block_a->blk_num);
+}
+
 int MockBPA_Bundle_Init(MockBPA_Bundle_t *bundle)
 {
     ASSERT_ARG_NONNULL(bundle);
     memset(bundle, 0, sizeof(*bundle));
 
     bundle->retain = true;
+
+    BSL_Data_Init(&bundle->primary_block.encoded);
+    BSL_HostEID_Init(&bundle->primary_block.src_node_id);
+    BSL_HostEID_Init(&bundle->primary_block.dest_eid);
+    BSL_HostEID_Init(&bundle->primary_block.report_to_eid);
 
     MockBPA_BlockList_init(bundle->blocks);
     MockBPA_BlockByNum_init(bundle->blocks_num);

--- a/src/mock_bpa/bundle.h
+++ b/src/mock_bpa/bundle.h
@@ -29,6 +29,7 @@
 
 #include "eid.h"
 
+#include <m-algo.h>
 #include <m-deque.h>
 #include <m-bptree.h>
 
@@ -68,16 +69,27 @@ typedef struct
  */
 typedef struct
 {
+    /// Block type code
     uint64_t blk_type;
+    /// Unique block number, with 0 reserved and 1 for payload
     uint64_t blk_num;
+    /// Block processing control flags
     uint64_t flags;
+    /// CRC type code
     uint64_t crc_type;
 
-    /// Pointer to memory managed by the BPA
+    /// Pointer to memory managed by the BPA outside this struct
     void *btsd;
     /// Known length of the #btsd
     size_t btsd_len;
 } MockBPA_CanonicalBlock_t;
+
+/** Block comparison which will order by block number in descending order.
+ */
+int MockBPA_CanonicalBlock_cmp(const MockBPA_CanonicalBlock_t *block_a, const MockBPA_CanonicalBlock_t *block_b);
+
+/// M*LIB OPLIST for ::MockBPA_CanonicalBlock_t
+#define M_OPL_MockBPA_CanonicalBlock_t() M_OPEXTEND(M_POD_OPLIST, CMP(API_6(MockBPA_CanonicalBlock_cmp)))
 
 /** @struct MockBPA_BlockList_t
  * An ordered list of ::MockBPA_CanonicalBlock_t storage
@@ -89,15 +101,20 @@ typedef struct
  */
 /// @cond Doxygen_Suppress
 // GCOV_EXCL_START
-M_DEQUE_DEF(MockBPA_BlockList, MockBPA_CanonicalBlock_t, M_POD_OPLIST)
+M_DEQUE_DEF(MockBPA_BlockList, MockBPA_CanonicalBlock_t, M_OPL_MockBPA_CanonicalBlock_t())
+M_ALGO_DEF(MockBPA_BlockList, M_DEQUE_OPLIST(MockBPA_BlockList, M_OPL_MockBPA_CanonicalBlock_t()))
 M_BPTREE_DEF2(MockBPA_BlockByNum, 4, uint64_t, M_BASIC_OPLIST, MockBPA_CanonicalBlock_t *, M_PTR_OPLIST)
 // GCOV_EXCL_STOP
 /// @endcond
 
 typedef struct MockBPA_Bundle_s
 {
-    uint64_t               id;
-    bool                   retain;
+    /** Explicit retention constraint.
+     * When true, indicates to retain this bundle after forwarding or delivery.
+     * This defaults to true.
+     */
+    bool retain;
+    /// Primary block contents
     MockBPA_PrimaryBlock_t primary_block;
 
     /// Storage for blocks in this bundle

--- a/src/mock_bpa/ctr.c
+++ b/src/mock_bpa/ctr.c
@@ -24,7 +24,6 @@
  * Container structs for BPv7 data.
  */
 #include <BPSecLib_Private.h>
-#include <m-algo.h>
 
 #include "ctr.h"
 #include "decode.h"
@@ -68,7 +67,14 @@ void mock_bpa_ctr_deinit(mock_bpa_ctr_t *ctr)
     }
 }
 
-int mock_bpa_decode(mock_bpa_ctr_t *ctr)
+void mock_bpa_ctr_sort_blocks(mock_bpa_ctr_t *ctr)
+{
+    BSL_CHKVOID(ctr);
+    // normalize block list by block number in descending order
+    MockBPA_BlockList_sort(ctr->bundle->blocks);
+}
+
+int mock_bpa_ctr_decode(mock_bpa_ctr_t *ctr)
 {
     BSL_CHKERR1(ctr);
     MockBPA_Bundle_t *bundle = ctr->bundle_ref.data;
@@ -93,33 +99,11 @@ int mock_bpa_decode(mock_bpa_ctr_t *ctr)
     return 0;
 }
 
-// TODO this is not really defined by BPSec or BPv7
-static int block_cmp(const MockBPA_CanonicalBlock_t *block_a, const MockBPA_CanonicalBlock_t *block_b)
-{
-    if (block_b->blk_type > block_a->blk_type)
-    {
-        return 1;
-    }
-    else if (block_b->blk_type < block_a->blk_type)
-    {
-        return -1;
-    }
-    return 0;
-}
-
-// Add comparison by block type to sort just before encoding
-// GCOV_EXCL_START
-M_ALGO_DEF(MockBPA_BlockList, M_DEQUE_OPLIST(MockBPA_BlockList, M_OPEXTEND(M_POD_OPLIST, CMP(API_6(block_cmp)))))
-// GCOV_EXCL_STOP
-
-int mock_bpa_encode(mock_bpa_ctr_t *ctr)
+int mock_bpa_ctr_encode(mock_bpa_ctr_t *ctr)
 {
     BSL_CHKERR1(ctr);
-    MockBPA_Bundle_t *bundle = ctr->bundle_ref.data;
+    const MockBPA_Bundle_t *bundle = ctr->bundle_ref.data;
     BSL_CHKERR1(bundle);
-
-    // TODO this is not really defined by BPSec or BPv7
-    MockBPA_BlockList_sort(bundle->blocks);
 
     QCBOREncodeContext encoder;
     // first round of encoding is to get the full size

--- a/src/mock_bpa/ctr.h
+++ b/src/mock_bpa/ctr.h
@@ -49,10 +49,25 @@ void mock_bpa_ctr_init_move(mock_bpa_ctr_t *ctr, mock_bpa_ctr_t *src);
 
 void mock_bpa_ctr_deinit(mock_bpa_ctr_t *ctr);
 
-int mock_bpa_decode(mock_bpa_ctr_t *ctr);
+/** Sort canonical blocks in a bundle by descending block number.
+ * This ensures the primary block is the last block.
+ * @param[in,out] ctr The container to read and decode PDU data from.
+ */
+void mock_bpa_ctr_sort_blocks(mock_bpa_ctr_t *ctr);
 
-int mock_bpa_encode(mock_bpa_ctr_t *ctr);
+/** Decode a bundle PDU into a container.
+ * @param[in,out] ctr The container to read and decode PDU data from.
+ * @return Zero if successful.
+ */
+int mock_bpa_ctr_decode(mock_bpa_ctr_t *ctr);
 
+/** Encode to a bundle PDU in a container.
+ * @param[in,out] ctr The container to encode and write PDU data into.
+ * @return Zero if successful.
+ */
+int mock_bpa_ctr_encode(mock_bpa_ctr_t *ctr);
+
+/// M*LIB OPLIST for ::mock_bpa_ctr_t
 #define M_OPL_mock_bpa_ctr_t() \
     (INIT(API_2(mock_bpa_ctr_init)), INIT_MOVE(API_6(mock_bpa_ctr_init_move)), CLEAR(API_2(mock_bpa_ctr_deinit)))
 

--- a/src/mock_bpa/decode.c
+++ b/src/mock_bpa/decode.c
@@ -166,19 +166,16 @@ int bsl_mock_decode_primary(QCBORDecodeContext *dec, MockBPA_PrimaryBlock_t *blk
     QCBORDecode_GetUInt64(dec, &(blk->flags));
     QCBORDecode_GetUInt64(dec, &(blk->crc_type));
 
-    MockBPA_EID_Init(NULL, &blk->dest_eid);
     if (0 != bsl_mock_decode_eid_from_ctx(dec, &(blk->dest_eid)))
     {
         return 2;
     }
 
-    MockBPA_EID_Init(NULL, &blk->src_node_id);
     if (0 != bsl_mock_decode_eid_from_ctx(dec, &(blk->src_node_id)))
     {
         return 2;
     }
 
-    MockBPA_EID_Init(NULL, &blk->report_to_eid);
     if (0 != bsl_mock_decode_eid_from_ctx(dec, &(blk->report_to_eid)))
     {
         return 2;

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -343,7 +343,7 @@ int BSL_TestUtils_LoadBundleFromCBOR(BSL_TestContext_t *test_ctx, const char *cb
     MockBPA_Bundle_t *bundle = test_ctx->mock_bpa_ctr.bundle_ref.data;
     assert(bundle != NULL);
 
-    int decode_status = mock_bpa_decode(&(test_ctx->mock_bpa_ctr));
+    int decode_status = mock_bpa_ctr_decode(&(test_ctx->mock_bpa_ctr));
     assert(bundle->primary_block.version == 7);
     assert(bundle->primary_block.timestamp.seq_num > 0);
     assert(bundle->primary_block.lifetime > 0);

--- a/test/fuzz_dynamic_asb_cbor.cpp
+++ b/test/fuzz_dynamic_asb_cbor.cpp
@@ -45,7 +45,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     int retval = 0;
 
     BSL_AbsSecBlock_t *asb = (BSL_AbsSecBlock_t *)BSL_malloc(BSL_AbsSecBlock_Sizeof());
-    BSL_AbsSecBlock_InitEmpty(asb);
+    BSL_AbsSecBlock_Init(asb);
 
     {
         BSL_Data_t buf;

--- a/test/test_AbsSecBlock.c
+++ b/test/test_AbsSecBlock.c
@@ -54,7 +54,7 @@ void TestASBDecodeEncodeClosure(uint8_t *asb_cbor, size_t asb_cbor_bytelen, int6
     BSL_Data_t asb_cbor_data;
     BSL_Data_InitView(&asb_cbor_data, asb_cbor_bytelen, asb_cbor);
     BSL_AbsSecBlock_t *asb = BSL_calloc(1, BSL_AbsSecBlock_Sizeof());
-    BSL_AbsSecBlock_InitEmpty(asb);
+    BSL_AbsSecBlock_Init(asb);
 
     const int decode_result = BSL_AbsSecBlock_DecodeFromCBOR(asb, &asb_cbor_data);
     TEST_ASSERT_EQUAL(BSL_SUCCESS, decode_result);
@@ -148,7 +148,7 @@ void test_AbsSecBlock_Decode_failure(const char *hexdata)
     }
 
     BSL_AbsSecBlock_t *asb = BSL_calloc(1, BSL_AbsSecBlock_Sizeof());
-    BSL_AbsSecBlock_InitEmpty(asb);
+    BSL_AbsSecBlock_Init(asb);
 
     const int decode_result = BSL_AbsSecBlock_DecodeFromCBOR(asb, &in_data);
     TEST_ASSERT_EQUAL_INT(BSL_ERR_DECODING, decode_result);

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -108,7 +108,8 @@ void test_SecurityContext_BIB_Source(void)
                                            (BSL_Data_t) { .len = target_block->btsd_len, .ptr = target_block->btsd });
     TEST_ASSERT_TRUE(x);
 
-    TEST_ASSERT_EQUAL(0, mock_bpa_encode(mock_bpa_ctr));
+    mock_bpa_ctr_sort_blocks(mock_bpa_ctr);
+    TEST_ASSERT_EQUAL(0, mock_bpa_ctr_encode(mock_bpa_ctr));
     bool is_expected =
         (BSL_TestUtils_IsB16StrEqualTo(RFC9173_TestVectors_AppendixA1.cbor_bundle_bib, mock_bpa_ctr->encoded));
 
@@ -149,7 +150,7 @@ void test_SecurityContext_BIB_Verifier(void)
 
     TEST_ASSERT_EQUAL(0, BSL_SecCtx_ExecutePolicyActionSet(&LocalTestCtx.bsl, malloced_responseset,
                                                            &mock_bpa_ctr->bundle_ref, malloced_actionset));
-    TEST_ASSERT_EQUAL(0, mock_bpa_encode(mock_bpa_ctr));
+    TEST_ASSERT_EQUAL(0, mock_bpa_ctr_encode(mock_bpa_ctr));
     bool is_match =
         (BSL_TestUtils_IsB16StrEqualTo(RFC9173_TestVectors_AppendixA1.cbor_bundle_bib, mock_bpa_ctr->encoded));
 
@@ -243,7 +244,7 @@ void test_SecurityContext_BIB_Acceptor(void)
     if (sec_context_result != 0)
         goto cleanup;
 
-    encode_result = mock_bpa_encode(mock_bpa_ctr);
+    encode_result = mock_bpa_ctr_encode(mock_bpa_ctr);
     if (encode_result != 0)
         goto cleanup;
 
@@ -528,7 +529,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     const char *expected_processed_bundle = ("9f88070000820282010282028202018202820201820018281a000f424085010100"
                                              "005823526561647920746f2067656e657261746520612033322d6279746520706179"
                                              "6c6f6164ff");
-    TEST_ASSERT_EQUAL(0, mock_bpa_encode(mock_bpa_ctr));
+    TEST_ASSERT_EQUAL(0, mock_bpa_ctr_encode(mock_bpa_ctr));
     TEST_ASSERT_TRUE(BSL_TestUtils_IsB16StrEqualTo(expected_processed_bundle, mock_bpa_ctr->encoded));
 
     BSL_SecurityAction_Deinit(malloced_action);

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -219,10 +219,6 @@ void test_bsl_mock_encode_bundle(void)
     {
         MockBPA_PrimaryBlock_t *prim = &bundle.primary_block;
         prim->version                = 7;
-        BSL_HostEID_Init(&prim->src_node_id);
-        BSL_HostEID_Init(&prim->dest_eid);
-        BSL_HostEID_Init(&prim->report_to_eid);
-
         TEST_ASSERT_EQUAL_INT(0, BSL_HostEID_DecodeFromText(&(prim->src_node_id), "ipn:1.2"));
         TEST_ASSERT_EQUAL_INT(0, BSL_HostEID_DecodeFromText(&(prim->dest_eid), "ipn:3.4"));
         TEST_ASSERT_EQUAL_INT(0, BSL_HostEID_DecodeFromText(&(prim->report_to_eid), "ipn:0.0"));

--- a/test/test_mock_bpa_ctr.c
+++ b/test/test_mock_bpa_ctr.c
@@ -77,10 +77,12 @@ void test_mock_bpa_ctr_loopback_decode_encode(const char *hexdata)
     mock_bpa_ctr_init(&ctr);
     TEST_ASSERT_EQUAL_INT(0, BSL_Data_CopyFrom(&ctr.encoded, in_data.len, in_data.ptr));
 
-    int res = mock_bpa_decode(&ctr);
+    int res = mock_bpa_ctr_decode(&ctr);
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, res, "mock_bpa_decode() failed");
 
-    res = mock_bpa_encode(&ctr);
+    mock_bpa_ctr_sort_blocks(&ctr);
+
+    res = mock_bpa_ctr_encode(&ctr);
     TEST_ASSERT_EQUAL_INT_MESSAGE(0, res, "mock_bpa_encode() failed");
 
     TEST_ASSERT_EQUAL_INT(in_data.len, ctr.encoded.len);


### PR DESCRIPTION
This block ordering is mock-BPA specific but does fit within BPv7 constraints and is deterministic.

This also fixes bad EID lifecycles with init hapenning while decoding.

Closes #36 