### PR TITLE
153 Add option to send mock bpa bundles to both appin and clin

### DIFF
--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -23,6 +23,7 @@ from enum import IntEnum, unique
 from dataclasses import dataclass
 from typing import Any
 
+
 @unique
 class DataFormat(IntEnum):
     BUNDLEARRAY = 0
@@ -30,10 +31,12 @@ class DataFormat(IntEnum):
     ERR = 2
     NONE = 3
 
+
 @unique
 class BundleDestLoc(IntEnum):
     APPIN = 0
     CLIN = 1
+
 
 @dataclass
 # Holds a simple test case
@@ -41,7 +44,7 @@ class _TestCase:
     # list representation of bundle
     input_data: Any
 
-    # either list representation of expected output bundle OR a string to search log output for match 
+    # either list representation of expected output bundle OR a string to search log output for match
     expected_output: DataFormat
 
     # decimal digit representing uint32 for policy configuration OR path to JSON-encoded ION-like policy rules

--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -19,42 +19,45 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from enum import Enum
+from enum import IntEnum, unique
+from dataclasses import dataclass
+from typing import Any
 
-
-class DataFormat(Enum):
+@unique
+class DataFormat(IntEnum):
     BUNDLEARRAY = 0
     HEX = 1
     ERR = 2
     NONE = 3
 
-class BundleDestLoc(Enum):
+@unique
+class BundleDestLoc(IntEnum):
     APPIN = 0
     CLIN = 1
 
-# "structure" to hold a simple test case
-
-
+@dataclass
+# Holds a simple test case
 class _TestCase:
-    '''
-    @param input_data: list representation of bundle
-    @param expected_output: either list representation of expected output bundle OR a string to search log output for match 
-    @param policy_config: decimal digit representing uint32 for policy configuration OR path to JSON-encoded ION-like policy rules
-    @param key_set: path to JWK-encoded key set
-    @param is_working: True if test working
-    @param input/output_data_format: data format of input/output
-    '''
+    # list representation of bundle
+    input_data: Any
 
-    def __init__(self, input_data, expected_output: DataFormat, policy_config: str, bundle_dest_loc: BundleDestLoc, key_set: str, 
-                 is_working: bool, input_data_format: DataFormat, expected_output_format: DataFormat):
-        self.input_data = input_data
-        self.expected_output = expected_output
-        self.policy_config = policy_config
-        self.bundle_dest_loc = bundle_dest_loc
-        self.key_set = key_set
+    # either list representation of expected output bundle OR a string to search log output for match 
+    expected_output: DataFormat
 
-        # can be removed once all tests are working
-        self.is_working = is_working
+    # decimal digit representing uint32 for policy configuration OR path to JSON-encoded ION-like policy rules
+    policy_config: str
 
-        self.input_data_format = input_data_format
-        self.expected_output_format = expected_output_format
+    # path to JWK-encoded key set
+    key_set: str
+
+    # data format of input
+    input_data_format: DataFormat
+
+    # data format of output
+    expected_output_format: DataFormat
+
+    # True if test working (can be removed once all tests are working)
+    is_working: bool = True
+
+    # destination location of the bundle
+    bundle_dest_loc: BundleDestLoc = BundleDestLoc.CLIN

--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -28,6 +28,7 @@ class DataFormat(Enum):
     ERR = 2
     NONE = 3
 
+
 class BundleDestLoc(Enum):
     APPIN = 0
     CLIN = 1
@@ -45,7 +46,7 @@ class _TestCase:
     @param input/output_data_format: data format of input/output
     '''
 
-    def __init__(self, input_data, expected_output: DataFormat, policy_config: str, bundle_dest_loc: BundleDestLoc, key_set: str, 
+    def __init__(self, input_data, expected_output: DataFormat, policy_config: str, bundle_dest_loc: BundleDestLoc, key_set: str,
                  is_working: bool, input_data_format: DataFormat, expected_output_format: DataFormat):
         self.input_data = input_data
         self.expected_output = expected_output

--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -28,6 +28,10 @@ class DataFormat(Enum):
     ERR = 2
     NONE = 3
 
+class BundleDestLoc(Enum):
+    APPIN = 0
+    CLIN = 1
+
 # "structure" to hold a simple test case
 
 
@@ -41,11 +45,12 @@ class _TestCase:
     @param input/output_data_format: data format of input/output
     '''
 
-    def __init__(self, input_data, expected_output: DataFormat, policy_config: str, key_set: str, is_working: bool,
-                 input_data_format: DataFormat, expected_output_format: DataFormat):
+    def __init__(self, input_data, expected_output: DataFormat, policy_config: str, bundle_dest_loc: BundleDestLoc, key_set: str, 
+                 is_working: bool, input_data_format: DataFormat, expected_output_format: DataFormat):
         self.input_data = input_data
         self.expected_output = expected_output
         self.policy_config = policy_config
+        self.bundle_dest_loc = bundle_dest_loc
         self.key_set = key_set
 
         # can be removed once all tests are working

--- a/mock-bpa-test/policy_provider_test.json
+++ b/mock-bpa-test/policy_provider_test.json
@@ -33,7 +33,7 @@
         ]
       },
       "es_ref": "d_integrity",
-      "_temp_not_ion_spec_policy_action_on_fail": "delete_bundle"
+      "policy_action_on_fail": "delete_bundle"
     },
     "event_set": {
       "es_ref": "d_integrity",
@@ -78,7 +78,7 @@
         ]
       },
       "es_ref": "d_confidentiality",
-      "_temp_not_ion_spec_policy_action_on_fail": "delete_bundle"
+      "policy_action_on_fail": "delete_bundle"
     },
     "event_set": {
       "es_ref": "d_confidentiality",

--- a/mock-bpa-test/policy_provider_test.json
+++ b/mock-bpa-test/policy_provider_test.json
@@ -7,7 +7,7 @@
         "rule_id": "1",
         "role": "s",
         "tgt": 1,
-        "loc": "clin",
+        "loc": "appin",
         "sc_id": 1
       },
       "spec": {
@@ -52,7 +52,7 @@
         "rule_id": "2",
         "role": "s",
         "tgt": 1,
-        "loc": "clin",
+        "loc": "appin",
         "sc_id": 2
       },
       "spec": {

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -35,7 +35,7 @@ import unittest
 import cbor2
 
 from helpers import CmdRunner, compose_args
-from _test_util import _TestCase, DataFormat
+from _test_util import _TestCase, DataFormat, BundleDestLoc
 
 OWNPATH = os.path.dirname(os.path.abspath(__file__))
 LOGGER = logging.getLogger(__name__)
@@ -141,14 +141,18 @@ class TestAgent(unittest.TestCase):
         tx_data = testcase.input_data if (
             testcase.input_data_format == DataFormat.HEX) else self._encode(testcase.input_data)
 
+        test_sock = self._ul_sock
+        if (testcase.bundle_dest_loc == BundleDestLoc.APPIN):
+            test_sock = self._ol_sock
+
         if (testcase.expected_output_format == DataFormat.BUNDLEARRAY):
             expected_rx = testcase.expected_output if (
                 testcase.expected_output == "HEX") else self._encode(testcase.expected_output)
 
-            self._ul_sock.send(tx_data)
+            test_sock.send(tx_data)
             LOGGER.debug('waiting')
 
-            rx_data = self._wait_for(self._ul_sock)
+            rx_data = self._wait_for(test_sock)
 
             LOGGER.info('\nTransferred data:\n%s\n', binascii.hexlify(tx_data))
             LOGGER.info('\nReceived data:\n%s\n', binascii.hexlify(rx_data))
@@ -161,11 +165,11 @@ class TestAgent(unittest.TestCase):
             self.assertEqual(binascii.hexlify(expected_rx), binascii.hexlify(rx_data))
 
         elif (testcase.expected_output_format == DataFormat.NONE):
-            self._ul_sock.send(tx_data)
+            test_sock.send(tx_data)
             LOGGER.debug('waiting')
 
             with self.assertRaises(TimeoutError):
-                self._wait_for(self._ul_sock)
+                self._wait_for(test_sock)
 
             LOGGER.info('\nTransferred data:\n%s\n', binascii.hexlify(tx_data))
 
@@ -179,11 +183,11 @@ class TestAgent(unittest.TestCase):
             self.assertNotEqual("", found)
 
         elif (testcase.expected_output_format == DataFormat.ERR):
-            self._ul_sock.send(tx_data)
+            test_sock.send(tx_data)
             LOGGER.debug('waiting')
 
             with self.assertRaises(TimeoutError):
-                self._wait_for(self._ul_sock)
+                self._wait_for(test_sock)
 
             LOGGER.info('\nTransferred data:\n%s\n', binascii.hexlify(tx_data))
 

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -141,11 +141,9 @@ class TestAgent(unittest.TestCase):
         tx_data = testcase.input_data if (
             testcase.input_data_format == DataFormat.HEX) else self._encode(testcase.input_data)
 
-        test_sock = self._ul_sock
-        if (testcase.bundle_dest_loc == BundleDestLoc.APPIN):
-            test_sock = self._ol_sock
+        test_sock = self._ol_sock if testcase.bundle_dest_loc == BundleDestLoc.APPIN else self._ul_sock
 
-        if (testcase.expected_output_format == DataFormat.BUNDLEARRAY):
+        if testcase.expected_output_format == DataFormat.BUNDLEARRAY:
             expected_rx = testcase.expected_output if (
                 testcase.expected_output == "HEX") else self._encode(testcase.expected_output)
 
@@ -164,7 +162,7 @@ class TestAgent(unittest.TestCase):
 
             self.assertEqual(binascii.hexlify(expected_rx), binascii.hexlify(rx_data))
 
-        elif (testcase.expected_output_format == DataFormat.NONE):
+        elif testcase.expected_output_format == DataFormat.NONE:
             test_sock.send(tx_data)
             LOGGER.debug('waiting')
 
@@ -182,7 +180,7 @@ class TestAgent(unittest.TestCase):
             LOGGER.debug("\nFOUND OCCURENCE: %s", found)
             self.assertNotEqual("", found)
 
-        elif (testcase.expected_output_format == DataFormat.ERR):
+        elif testcase.expected_output_format == DataFormat.ERR:
             test_sock.send(tx_data)
             LOGGER.debug('waiting')
 

--- a/mock-bpa-test/test_ccsds.py
+++ b/mock-bpa-test/test_ccsds.py
@@ -178,7 +178,7 @@ def load_ccsds():
                 expected_output=output if (
                     output_format == DataFormat.BUNDLEARRAY) else r".*Delete bundle due to failed security operation",
                 policy_config=finame,
-                bundle_dest_loc = BundleDestLoc.APPIN,
+                bundle_dest_loc=BundleDestLoc.APPIN,
                 key_set="mock-bpa-test/key_set_1.json",
                 is_working=True,
                 input_data_format=input_format,

--- a/mock-bpa-test/test_ccsds.py
+++ b/mock-bpa-test/test_ccsds.py
@@ -24,7 +24,7 @@ import cbor2
 import binascii
 import tempfile
 import json
-from _test_util import _TestCase, DataFormat
+from _test_util import _TestCase, DataFormat, BundleDestLoc
 from test_bpa import TestAgent
 
 
@@ -150,7 +150,7 @@ def load_ccsds():
                             'rule_id': str(i),
                             'role': sec_role,
                             'tgt': int(target),
-                            'loc': 'clin',
+                            'loc': 'appin',
                             'sc_id': sec_ctx,
                         },
                         'spec': {
@@ -178,6 +178,7 @@ def load_ccsds():
                 expected_output=output if (
                     output_format == DataFormat.BUNDLEARRAY) else r".*Delete bundle due to failed security operation",
                 policy_config=finame,
+                bundle_dest_loc = BundleDestLoc.APPIN,
                 key_set="mock-bpa-test/key_set_1.json",
                 is_working=True,
                 input_data_format=input_format,

--- a/mock-bpa-test/test_ccsds.py
+++ b/mock-bpa-test/test_ccsds.py
@@ -157,7 +157,7 @@ def load_ccsds():
                             'sc_id': sec_ctx,
                             'sc_parms': params
                         },
-                        '_temp_not_ion_spec_policy_action_on_fail': 'delete_bundle'
+                        'policy_action_on_fail': 'delete_bundle'
                     }
                 }
                 print(f'Appending new Policy Rule {pr}')

--- a/mock-bpa-test/test_json_policy.py
+++ b/mock-bpa-test/test_json_policy.py
@@ -19,7 +19,7 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from _test_util import _TestCase, DataFormat
+from _test_util import _TestCase, DataFormat, BundleDestLoc
 from test_bpa import TestAgent
 
 # Test Cases utilizing JSON policy definitions
@@ -46,6 +46,7 @@ class Test_ION_JSON_Policy(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='mock-bpa-test/policy_provider_test.json',
+            bundle_dest_loc = BundleDestLoc.APPIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,

--- a/mock-bpa-test/test_json_policy.py
+++ b/mock-bpa-test/test_json_policy.py
@@ -46,7 +46,7 @@ class Test_ION_JSON_Policy(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='mock-bpa-test/policy_provider_test.json',
-            bundle_dest_loc = BundleDestLoc.APPIN,
+            bundle_dest_loc=BundleDestLoc.APPIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,

--- a/mock-bpa-test/test_requirements.py
+++ b/mock-bpa-test/test_requirements.py
@@ -49,7 +49,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x1A6,0x1A7',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -76,7 +76,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -103,7 +103,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0xA6',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -130,7 +130,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -160,7 +160,7 @@ class TestRequirements(TestAgent):
             ],
             # policy_config = BIB_VERIFIER,
             policy_config='0x66',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -203,7 +203,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x2A0',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -231,7 +231,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -259,7 +259,7 @@ class TestRequirements(TestAgent):
             #
             # policy_config = BIB_VERIFIER,
             policy_config='0x62',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -283,7 +283,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0xA2',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -318,7 +318,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x5E',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -343,7 +343,7 @@ class TestRequirements(TestAgent):
             # No output because it was deleted, logs to indicate deletion.
             expected_output=r".*Delete bundle due to failed security operation",
             policy_config='0x62',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -377,7 +377,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x1A6,0x1A7',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -406,7 +406,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -434,7 +434,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -465,7 +465,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -487,7 +487,7 @@ class TestRequirements(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='0x105',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -515,7 +515,7 @@ class TestRequirements(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='0x105',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -543,7 +543,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -565,7 +565,7 @@ class TestRequirements(TestAgent):
             expected_output=r".*failed to decode bundle",
             # Execute as a BIB acceptor.
             policy_config='0x86',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.HEX,
@@ -590,7 +590,7 @@ class TestRequirements(TestAgent):
             # Ensure that the host interface returns an error code (since the block does not exist). Confirm that a log indicating this error is created.
             expected_output=r".*Deleting bundle due to block target num 99 security failure",
             policy_config='0x66',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -619,7 +619,7 @@ class TestRequirements(TestAgent):
             # confirm that no further security operation processing was taken (specifically, no BIB operations should be seen).
             expected_output=r".*Failed to perform cryptographic action",
             policy_config='0x1A6,0x1A7',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -645,7 +645,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x0A',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -670,7 +670,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x0A',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -700,7 +700,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x46',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -732,7 +732,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x46',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -759,7 +759,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -787,7 +787,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x96',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -816,7 +816,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x105',
-			bundle_dest_loc = BundleDestLoc.CLIN,
+            bundle_dest_loc=BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,

--- a/mock-bpa-test/test_requirements.py
+++ b/mock-bpa-test/test_requirements.py
@@ -19,7 +19,7 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from _test_util import _TestCase, DataFormat
+from _test_util import _TestCase, DataFormat, BundleDestLoc
 from test_bpa import TestAgent
 
 # Test Cases specified by the Requirements Document
@@ -49,6 +49,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x1A6,0x1A7',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -75,6 +76,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -101,6 +103,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0xA6',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -127,6 +130,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -156,6 +160,7 @@ class TestRequirements(TestAgent):
             ],
             # policy_config = BIB_VERIFIER,
             policy_config='0x66',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -198,6 +203,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x2A0',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -225,6 +231,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -252,6 +259,7 @@ class TestRequirements(TestAgent):
             #
             # policy_config = BIB_VERIFIER,
             policy_config='0x62',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -275,6 +283,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0xA2',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -309,6 +318,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x5E',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -333,6 +343,7 @@ class TestRequirements(TestAgent):
             # No output because it was deleted, logs to indicate deletion.
             expected_output=r".*Delete bundle due to failed security operation",
             policy_config='0x62',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -366,6 +377,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x1A6,0x1A7',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -394,6 +406,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -421,6 +434,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -451,6 +465,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -472,6 +487,7 @@ class TestRequirements(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='0x105',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -499,6 +515,7 @@ class TestRequirements(TestAgent):
                     '3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a')]
             ],
             policy_config='0x105',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -526,6 +543,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -547,6 +565,7 @@ class TestRequirements(TestAgent):
             expected_output=r".*failed to decode bundle",
             # Execute as a BIB acceptor.
             policy_config='0x86',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.HEX,
@@ -571,6 +590,7 @@ class TestRequirements(TestAgent):
             # Ensure that the host interface returns an error code (since the block does not exist). Confirm that a log indicating this error is created.
             expected_output=r".*Deleting bundle due to block target num 99 security failure",
             policy_config='0x66',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -599,6 +619,7 @@ class TestRequirements(TestAgent):
             # confirm that no further security operation processing was taken (specifically, no BIB operations should be seen).
             expected_output=r".*Failed to perform cryptographic action",
             policy_config='0x1A6,0x1A7',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -624,6 +645,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x0A',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -648,6 +670,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x0A',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -677,6 +700,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')],
             ],
             policy_config='0x46',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -708,6 +732,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x46',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -734,6 +759,7 @@ class TestRequirements(TestAgent):
                     '526561647920746F2067656E657261746520612033322D62797465207061796C6F6164')]
             ],
             policy_config='0x04',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -761,6 +787,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x96',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,
@@ -789,6 +816,7 @@ class TestRequirements(TestAgent):
             ],
             #
             policy_config='0x105',
+			bundle_dest_loc = BundleDestLoc.CLIN,
             key_set="mock-bpa-test/key_set_1.json",
             is_working=True,
             input_data_format=DataFormat.BUNDLEARRAY,

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -256,8 +256,8 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
             BSL_LOG_DEBUG("NO ES REF");
         }
 
-        // _temp_not_ion_spec_policy_action_on_fail
-        json_t *policy_action_on_fail = json_object_get(policyrule, "_temp_not_ion_spec_policy_action_on_fail");
+        // policy_action_on_fail
+        json_t *policy_action_on_fail = json_object_get(policyrule, "policy_action_on_fail");
         if (!policy_action_on_fail || !json_is_string(policy_action_on_fail))
         {
             BSL_LOG_ERR("NO POLICY ACTION");


### PR DESCRIPTION
Fairly trivial mock bpa test changes to:
- Add option to send bundles to appin instead of all to clin
- rename policy on fail json attribute

Closes #153 