### PR TITLE
Consistent naming of Sec Param Int/Uint

### DIFF
--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -626,7 +626,7 @@ size_t BSL_SecResult_Sizeof(void);
 enum BSL_SecParam_Types_e
 {
     BSL_SECPARAM_TYPE_UNKNOWN = 0, ///< Indicates parsed value not of expected type.
-    BSL_SECPARAM_TYPE_UINT64,       ///< Indicates value type is an unsigned integer.
+    BSL_SECPARAM_TYPE_UINT64,      ///< Indicates value type is an unsigned integer.
     BSL_SECPARAM_TYPE_BYTESTR,     ///< Indicates the value type is a byte string.
     BSL_SECPARAM_TYPE_TEXTSTR,     ///< Indicates the value is a text string.
 };

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -626,7 +626,7 @@ size_t BSL_SecResult_Sizeof(void);
 enum BSL_SecParam_Types_e
 {
     BSL_SECPARAM_TYPE_UNKNOWN = 0, ///< Indicates parsed value not of expected type.
-    BSL_SECPARAM_TYPE_INT64,       ///< Indicates value type is an unsigned integer.
+    BSL_SECPARAM_TYPE_UINT64,       ///< Indicates value type is an unsigned integer.
     BSL_SECPARAM_TYPE_BYTESTR,     ///< Indicates the value type is a byte string.
     BSL_SECPARAM_TYPE_TEXTSTR,     ///< Indicates the value is a text string.
 };
@@ -723,7 +723,7 @@ int BSL_SecParam_InitBytestr(BSL_SecParam_t *self, uint64_t param_id, BSL_Data_t
  * @param[in] value View of bytes, which get copied into this Security Parameter.
  * @return Negative on an error.
  */
-int BSL_SecParam_InitInt64(BSL_SecParam_t *self, uint64_t param_id, uint64_t value);
+int BSL_SecParam_InitUint64(BSL_SecParam_t *self, uint64_t param_id, uint64_t value);
 
 /** Initialize as a parameter containing a byte string with a null-terminated
  * text value.
@@ -740,15 +740,15 @@ int BSL_SecParam_InitTextstr(BSL_SecParam_t *self, uint64_t param_id, const char
  * @param[in] self This Security Parameter
  * @return True when value type is integer.
  */
-bool BSL_SecParam_IsInt64(const BSL_SecParam_t *self);
+bool BSL_SecParam_IsUint64(const BSL_SecParam_t *self);
 
 /** Retrieve integer value of result when this result type is integer.
- * @warning Always check using BSL_SecParam_IsInt64() first.
+ * @warning Always check using BSL_SecParam_IsUint64() first.
  *
  * @param[in] self This Security Parameter
  * @return Integer value of parameter if present, panics/aborts otherwise.
  */
-uint64_t BSL_SecParam_GetAsUInt64(const BSL_SecParam_t *self);
+uint64_t BSL_SecParam_GetAsUint64(const BSL_SecParam_t *self);
 
 /** Returns true when the value type is a byte string.
  *

--- a/src/backend/AbsSecBlock.c
+++ b/src/backend/AbsSecBlock.c
@@ -57,7 +57,7 @@ void BSL_AbsSecBlock_Print(const BSL_AbsSecBlock_t *self)
     for (size_t index = 0; index < BSLB_SecParamList_size(self->params); index++)
     {
         BSL_SecParam_t *param = BSLB_SecParamList_get(self->params, index);
-        if (BSL_SecParam_IsInt64(param))
+        if (BSL_SecParam_IsUint64(param))
         {
             BSL_LOG_INFO("ASB  Param[%zu]: id=%" PRIu64 " val=%" PRIu64, index, param->param_id, param->_uint_value);
         }
@@ -340,9 +340,9 @@ ssize_t BSL_AbsSecBlock_EncodeToCBOR(const BSL_AbsSecBlock_t *self, BSL_Data_t *
             const BSL_SecParam_t *param = BSLB_SecParamList_cref(pit);
             QCBOREncode_OpenArray(&encoder);
             QCBOREncode_AddUInt64(&encoder, param->param_id);
-            if (BSL_SecParam_IsInt64(param))
+            if (BSL_SecParam_IsUint64(param))
             {
-                QCBOREncode_AddUInt64(&encoder, BSL_SecParam_GetAsUInt64(param));
+                QCBOREncode_AddUInt64(&encoder, BSL_SecParam_GetAsUint64(param));
             }
             else if (BSL_SecParam_IsBytestr(param))
             {
@@ -529,7 +529,7 @@ int BSL_AbsSecBlock_DecodeFromCBOR(BSL_AbsSecBlock_t *self, const BSL_Data_t *bu
                     }
                     BSL_LOG_DEBUG("ASB: Parsed Param[%" PRIu64 "] = %" PRIu64, item_id, dec_value);
                     BSL_SecParam_t param;
-                    BSL_SecParam_InitInt64(&param, item_id, dec_value);
+                    BSL_SecParam_InitUint64(&param, item_id, dec_value);
                     BSLB_SecParamList_push_back(self->params, param);
                     BSL_SecParam_Deinit(&param);
                     break;

--- a/src/backend/SecParam.c
+++ b/src/backend/SecParam.c
@@ -100,29 +100,29 @@ int BSL_SecParam_InitBytestr(BSL_SecParam_t *self, uint64_t param_id, BSL_Data_t
     return BSL_SUCCESS;
 }
 
-int BSL_SecParam_InitInt64(BSL_SecParam_t *self, uint64_t param_id, uint64_t value)
+int BSL_SecParam_InitUint64(BSL_SecParam_t *self, uint64_t param_id, uint64_t value)
 {
     CHK_ARG_NONNULL(self);
 
     memset(self, 0, sizeof(*self));
     self->param_id    = param_id;
-    self->_type       = BSL_SECPARAM_TYPE_INT64;
+    self->_type       = BSL_SECPARAM_TYPE_UINT64;
     self->_uint_value = value;
     m_bstring_init(self->_bytes);
 
     return BSL_SUCCESS;
 }
 
-bool BSL_SecParam_IsInt64(const BSL_SecParam_t *self)
+bool BSL_SecParam_IsUint64(const BSL_SecParam_t *self)
 {
     CHK_AS_BOOL(self);
-    return (self->_type == BSL_SECPARAM_TYPE_INT64);
+    return (self->_type == BSL_SECPARAM_TYPE_UINT64);
 }
 
-uint64_t BSL_SecParam_GetAsUInt64(const BSL_SecParam_t *self)
+uint64_t BSL_SecParam_GetAsUint64(const BSL_SecParam_t *self)
 {
     ASSERT_ARG_NONNULL(self);
-    ASSERT_PRECONDITION(self->_type == BSL_SECPARAM_TYPE_INT64);
+    ASSERT_PRECONDITION(self->_type == BSL_SECPARAM_TYPE_UINT64);
 
     return self->_uint_value;
 }
@@ -169,7 +169,7 @@ bool BSL_SecParam_IsConsistent(const BSL_SecParam_t *self)
     CHK_AS_BOOL(self->param_id > 0);
     CHK_AS_BOOL(self->_type > BSL_SECPARAM_TYPE_UNKNOWN && self->_type <= BSL_SECPARAM_TYPE_TEXTSTR);
 
-    if (self->_type == BSL_SECPARAM_TYPE_INT64)
+    if (self->_type == BSL_SECPARAM_TYPE_UINT64)
     {
         CHK_AS_BOOL(m_bstring_empty_p(self->_bytes));
     }

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -352,14 +352,14 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                 }
 
                                 BSL_SecParam_InitUint64(params->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT,
-                                                       sha_var);
+                                                        sha_var);
                                 params_got |= 0x2;
                             }
                             else if (0 == strcmp(id_str, "scope_flags"))
                             {
                                 uint64_t flag = strtol(value_str, NULL, 10); // FIXME
                                 BSL_SecParam_InitUint64(params->param_integ_scope_flag,
-                                                       RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, flag);
+                                                        RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, flag);
                                 params_got |= 0x4;
                             }
                             else if (0 == strcmp(id_str, "key_wrap"))
@@ -375,7 +375,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                 }
 
                                 BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
-                                                       keywrap);
+                                                        keywrap);
                                 params_got |= 0x8;
                             }
                             else
@@ -411,14 +411,14 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                 }
 
                                 BSL_SecParam_InitUint64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                                                       aes_var);
+                                                        aes_var);
                                 params_got |= 0x4;
                             }
                             else if (0 == strcmp(id_str, "aad_scope"))
                             {
                                 uint64_t flag = strtol(value_str, NULL, 10); // FIXME
                                 BSL_SecParam_InitUint64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
-                                                       flag);
+                                                        flag);
                                 params_got |= 0x8;
                             }
                             else if (0 == strcmp(id_str, "key_wrap"))
@@ -434,7 +434,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                 }
 
                                 BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
-                                                       keywrap);
+                                                        keywrap);
                                 params_got |= 0x10;
                             }
                             else
@@ -563,9 +563,9 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     if (sec_block_type == 1)
     {
         BSL_SecParam_InitUint64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
-                               RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
+                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
         BSL_SecParam_InitUint64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                               RFC9173_BCB_AES_VARIANT_A128GCM);
+                                RFC9173_BCB_AES_VARIANT_A128GCM);
         if (use_wrapped_key)
         {
             BSL_SecParam_InitTextstr(params->param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "9103");

--- a/src/mock_bpa/policy_config.c
+++ b/src/mock_bpa/policy_config.c
@@ -351,14 +351,14 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                     sha_var = RFC9173_BIB_SHA_HMAC512;
                                 }
 
-                                BSL_SecParam_InitInt64(params->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT,
+                                BSL_SecParam_InitUint64(params->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT,
                                                        sha_var);
                                 params_got |= 0x2;
                             }
                             else if (0 == strcmp(id_str, "scope_flags"))
                             {
                                 uint64_t flag = strtol(value_str, NULL, 10); // FIXME
-                                BSL_SecParam_InitInt64(params->param_integ_scope_flag,
+                                BSL_SecParam_InitUint64(params->param_integ_scope_flag,
                                                        RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, flag);
                                 params_got |= 0x4;
                             }
@@ -374,7 +374,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                     keywrap = 1;
                                 }
 
-                                BSL_SecParam_InitInt64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
+                                BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
                                                        keywrap);
                                 params_got |= 0x8;
                             }
@@ -410,14 +410,14 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                     aes_var = RFC9173_BCB_AES_VARIANT_A256GCM;
                                 }
 
-                                BSL_SecParam_InitInt64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+                                BSL_SecParam_InitUint64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                                                        aes_var);
                                 params_got |= 0x4;
                             }
                             else if (0 == strcmp(id_str, "aad_scope"))
                             {
                                 uint64_t flag = strtol(value_str, NULL, 10); // FIXME
-                                BSL_SecParam_InitInt64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
+                                BSL_SecParam_InitUint64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
                                                        flag);
                                 params_got |= 0x8;
                             }
@@ -433,7 +433,7 @@ int mock_bpa_register_policy_from_json(const char *pp_cfg_file_path, BSLP_Policy
                                     keywrap = 1;
                                 }
 
-                                BSL_SecParam_InitInt64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
+                                BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP,
                                                        keywrap);
                                 params_got |= 0x10;
                             }
@@ -562,27 +562,27 @@ static void mock_bpa_register_policy(const bsl_mock_policy_configuration_t polic
     // Init params for BCB if equal to 1, otherwise BIB
     if (sec_block_type == 1)
     {
-        BSL_SecParam_InitInt64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
+        BSL_SecParam_InitUint64(params->param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE,
                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
-        BSL_SecParam_InitInt64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+        BSL_SecParam_InitUint64(params->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                                RFC9173_BCB_AES_VARIANT_A128GCM);
         if (use_wrapped_key)
         {
             BSL_SecParam_InitTextstr(params->param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "9103");
-            BSL_SecParam_InitInt64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
+            BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
         }
         else
         {
             BSL_SecParam_InitTextstr(params->param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "9102");
-            BSL_SecParam_InitInt64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
+            BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
         }
     }
     else
     {
-        BSL_SecParam_InitInt64(params->param_integ_scope_flag, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-        BSL_SecParam_InitInt64(params->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+        BSL_SecParam_InitUint64(params->param_integ_scope_flag, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+        BSL_SecParam_InitUint64(params->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
         BSL_SecParam_InitTextstr(params->param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "9100");
-        BSL_SecParam_InitInt64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
+        BSL_SecParam_InitUint64(params->param_use_wrapped_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
     }
 
     BSL_SecBlockType_e sec_block_emum;

--- a/src/security_context/BCB_AES_GCM.c
+++ b/src/security_context/BCB_AES_GCM.c
@@ -414,7 +414,7 @@ int BSLX_BCB_GetParams(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, c
     for (size_t param_index = 0; param_index < BSL_SecOper_CountParams(sec_oper); param_index++)
     {
         const BSL_SecParam_t *param  = BSL_SecOper_GetParamAt(sec_oper, param_index);
-        bool                  is_int = BSL_SecParam_IsInt64(param);
+        bool                  is_int = BSL_SecParam_IsUint64(param);
 
         uint64_t param_id = BSL_SecParam_GetId(param);
         BSL_LOG_DEBUG("BCB parsing param id %" PRIu64, param_id);
@@ -440,7 +440,7 @@ int BSLX_BCB_GetParams(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, c
             {
                 BSL_LOG_DEBUG("BCB parsing AES variant (optid=%" PRIu64 ")", param_id);
                 ASSERT_PRECONDITION(is_int);
-                bcb_context->aes_variant = BSL_SecParam_GetAsUInt64(param);
+                bcb_context->aes_variant = BSL_SecParam_GetAsUint64(param);
                 if (bcb_context->aes_variant < RFC9173_BCB_AES_VARIANT_A128GCM
                     || bcb_context->aes_variant > RFC9173_BCB_AES_VARIANT_A256GCM)
                 {
@@ -470,7 +470,7 @@ int BSLX_BCB_GetParams(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, c
             case RFC9173_BCB_SECPARAM_AADSCOPE:
             {
                 ASSERT_PRECONDITION(is_int);
-                uint64_t aad_scope = BSL_SecParam_GetAsUInt64(param);
+                uint64_t aad_scope = BSL_SecParam_GetAsUint64(param);
                 BSL_LOG_DEBUG("Param[%" PRIu64 "]: AAD_SCOPE value = %" PRIu64, param_id, aad_scope);
                 bcb_context->aad_scope = aad_scope;
                 if ((aad_scope & RFC9173_BCB_AADSCOPEFLAGID_INC_PRIM_BLOCK) == 0)
@@ -505,7 +505,7 @@ int BSLX_BCB_GetParams(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, c
             }
             case BSL_SECPARAM_USE_KEY_WRAP:
             {
-                const uint64_t arg_val = BSL_SecParam_GetAsUInt64(param);
+                const uint64_t arg_val = BSL_SecParam_GetAsUint64(param);
                 BSL_LOG_DEBUG("Param[%" PRIu64 "]: USE_WRAPPED_KEY value = %" PRIu64, param_id, arg_val);
                 bcb_context->keywrap = arg_val;
                 break;
@@ -692,7 +692,7 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib _U_, BSL_BundleRef_t *bundle, const BSL_S
     }
 
     BSL_SecParam_t *aes_param = BSL_calloc(1, BSL_SecParam_Sizeof());
-    if (BSL_SUCCESS != BSL_SecParam_InitInt64(aes_param, RFC9173_BCB_SECPARAM_AESVARIANT, bcb_context.aes_variant))
+    if (BSL_SUCCESS != BSL_SecParam_InitUint64(aes_param, RFC9173_BCB_SECPARAM_AESVARIANT, bcb_context.aes_variant))
     {
         BSL_LOG_ERR("Failed to append BCB AES param");
         BSL_SecParam_Deinit(aes_param);
@@ -731,7 +731,7 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib _U_, BSL_BundleRef_t *bundle, const BSL_S
     }
 
     BSL_SecParam_t *scope_flag_param = BSL_calloc(1, BSL_SecParam_Sizeof());
-    if (BSL_SUCCESS != BSL_SecParam_InitInt64(scope_flag_param, RFC9173_BCB_SECPARAM_AADSCOPE, bcb_context.aad_scope))
+    if (BSL_SUCCESS != BSL_SecParam_InitUint64(scope_flag_param, RFC9173_BCB_SECPARAM_AADSCOPE, bcb_context.aad_scope))
     {
         BSL_LOG_ERR("Failed to append BCB scope flag param");
         BSL_SecParam_Deinit(scope_flag_param);

--- a/src/security_context/BIB_HMAC_SHA2.c
+++ b/src/security_context/BIB_HMAC_SHA2.c
@@ -109,7 +109,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
         const BSL_SecParam_t *param    = BSL_SecOper_GetParamAt(sec_oper, param_index);
         uint64_t              param_id = BSL_SecParam_GetId(param);
         bool                  is_int   = BSL_SecParam_IsUint64(param);
-        uint64_t              int_val = 0;
+        uint64_t              int_val  = 0;
         if (is_int)
         {
             int_val = BSL_SecParam_GetAsUint64(param);

--- a/src/security_context/BIB_HMAC_SHA2.c
+++ b/src/security_context/BIB_HMAC_SHA2.c
@@ -62,7 +62,7 @@ bool BSLX_BCB_Validate(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const B
  * Provides the mapping from the security-context-specific ID defined in RFC9173
  * to the local ID of the SHA variant used by the crypto engine (OpenSSL).
  */
-static int64_t map_rfc9173_sha_variant_to_crypto(int64_t rfc9173_sha_variant)
+static int64_t map_rfc9173_sha_variant_to_crypto(uint64_t rfc9173_sha_variant)
 {
     int64_t crypto_sha_variant = -1;
     if (rfc9173_sha_variant == RFC9173_BIB_SHA_HMAC512)
@@ -108,11 +108,11 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
     {
         const BSL_SecParam_t *param    = BSL_SecOper_GetParamAt(sec_oper, param_index);
         uint64_t              param_id = BSL_SecParam_GetId(param);
-        bool                  is_int   = BSL_SecParam_IsInt64(param);
-        int64_t               int_val  = -1;
+        bool                  is_int   = BSL_SecParam_IsUint64(param);
+        uint64_t              int_val = 0;
         if (is_int)
         {
-            int_val = BSL_SecParam_GetAsUInt64(param);
+            int_val = BSL_SecParam_GetAsUint64(param);
         }
 
         if (param_id == BSL_SECPARAM_TYPE_KEY_ID)
@@ -149,7 +149,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
         }
         else if (param_id == BSL_SECPARAM_USE_KEY_WRAP)
         {
-            const uint64_t arg_val = BSL_SecParam_GetAsUInt64(param);
+            const uint64_t arg_val = BSL_SecParam_GetAsUint64(param);
             BSL_LOG_DEBUG("Param[%" PRIu64 "]: USE_WRAPPED_KEY value = %" PRIu64, param_id, arg_val);
             self->keywrap = arg_val;
         }

--- a/src/security_context/DefaultSecContext_Private.h
+++ b/src/security_context/DefaultSecContext_Private.h
@@ -64,8 +64,6 @@ typedef struct BSLX_BIB_s
     int64_t              integrity_scope_flags;
     int64_t              sha_variant;
     uint64_t             hash_size;
-    uint64_t             sha_variant_uint;
-    int64_t              _crypto_sha_variant;
     BSL_Data_t           wrapped_key;
     int64_t              keywrap;
     uint64_t             hmac_result_id;

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -124,7 +124,7 @@ void BSL_TestUtils_InitBCB_Appendix2(BCBTestContext *context, BSL_SecRole_e role
     BSL_SecParam_InitUint64(&context->param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
     BSL_SecParam_InitTextstr(&context->param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A2_KEY);
     BSL_SecParam_InitUint64(&context->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                           RFC9173_BCB_AES_VARIANT_A128GCM);
+                            RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_SecParam_InitBytestr(&context->param_init_vec, RFC9173_BCB_SECPARAM_IV, context->init_vector);
     BSL_SecParam_InitBytestr(&context->param_auth_tag, BSL_SECPARAM_TYPE_AUTH_TAG, context->auth_tag);
     BSL_SecParam_InitBytestr(&context->param_wrapped_key, RFC9173_BCB_SECPARAM_WRAPPEDKEY, context->wrapped_key);
@@ -366,9 +366,9 @@ RFC9173_A1_Params BSL_TestUtils_GetRFC9173_A1Params(const char *key_id)
 {
     RFC9173_A1_Params params;
     BSL_SecParam_InitUint64(&params.sha_variant, RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_key,
-                           RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_value);
+                            RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_value);
     BSL_SecParam_InitUint64(&params.scope_flags, RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_key,
-                           RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_value);
+                            RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_value);
     BSL_SecParam_InitTextstr(&params.test_key_id, BSL_SECPARAM_TYPE_KEY_ID, key_id);
     BSL_SecParam_InitUint64(&params.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
     return params;

--- a/test/bsl_test_utils.c
+++ b/test/bsl_test_utils.c
@@ -101,10 +101,10 @@ void BSL_TestUtils_InitBIB_AppendixA1(BIBTestContext *context, BSL_SecRole_e rol
     quick_data(context->hmac, ApxA1_HMAC);
 
     BSL_SecParam_InitTextstr(&context->param_test_key, BSL_SECPARAM_TYPE_KEY_ID, key_id);
-    BSL_SecParam_InitInt64(&context->param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-    BSL_SecParam_InitInt64(&context->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+    BSL_SecParam_InitUint64(&context->param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+    BSL_SecParam_InitUint64(&context->param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
     BSL_SecParam_InitBytestr(&context->param_hmac, BSL_SECPARAM_TYPE_AUTH_TAG, context->hmac);
-    BSL_SecParam_InitInt64(&context->use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&context->use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_Populate(&context->sec_oper, 1, 1, 2, BSL_SECBLOCKTYPE_BIB, role, BSL_POLICYACTION_DROP_BLOCK);
 
@@ -121,14 +121,14 @@ void BSL_TestUtils_InitBCB_Appendix2(BCBTestContext *context, BSL_SecRole_e role
     quick_data(context->wrapped_key, ApxA2_WrappedKey);
     quick_data(context->key_enc_key, ApxA2_KeyEncKey);
 
-    BSL_SecParam_InitInt64(&context->param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
+    BSL_SecParam_InitUint64(&context->param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
     BSL_SecParam_InitTextstr(&context->param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A2_KEY);
-    BSL_SecParam_InitInt64(&context->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+    BSL_SecParam_InitUint64(&context->param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                            RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_SecParam_InitBytestr(&context->param_init_vec, RFC9173_BCB_SECPARAM_IV, context->init_vector);
     BSL_SecParam_InitBytestr(&context->param_auth_tag, BSL_SECPARAM_TYPE_AUTH_TAG, context->auth_tag);
     BSL_SecParam_InitBytestr(&context->param_wrapped_key, RFC9173_BCB_SECPARAM_WRAPPEDKEY, context->wrapped_key);
-    BSL_SecParam_InitInt64(&context->use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
+    BSL_SecParam_InitUint64(&context->use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
 
     BSL_SecOper_Populate(&context->sec_oper, 2, 1, 2, BSL_SECBLOCKTYPE_BCB, role, BSL_POLICYACTION_NOTHING);
 
@@ -365,12 +365,12 @@ BSL_HostEIDPattern_t BSL_TestUtils_GetEidPatternFromText(const char *text)
 RFC9173_A1_Params BSL_TestUtils_GetRFC9173_A1Params(const char *key_id)
 {
     RFC9173_A1_Params params;
-    BSL_SecParam_InitInt64(&params.sha_variant, RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_key,
+    BSL_SecParam_InitUint64(&params.sha_variant, RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_key,
                            RFC9173_TestVectors_AppendixA1.bib_asb_sha_variant_value);
-    BSL_SecParam_InitInt64(&params.scope_flags, RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_key,
+    BSL_SecParam_InitUint64(&params.scope_flags, RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_key,
                            RFC9173_TestVectors_AppendixA1.bib_asb_scope_flags_value);
     BSL_SecParam_InitTextstr(&params.test_key_id, BSL_SECPARAM_TYPE_KEY_ID, key_id);
-    BSL_SecParam_InitInt64(&params.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&params.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
     return params;
 }
 

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -468,7 +468,7 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A4_BCB_KEY);
     BSL_SecParam_InitUint64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
     BSL_SecParam_InitUint64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                           RFC9173_BCB_AES_VARIANT_A256GCM);
+                            RFC9173_BCB_AES_VARIANT_A256GCM);
     BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bcb_op_tgt_payload;
@@ -578,7 +578,7 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A4_BCB_KEY);
     BSL_SecParam_InitUint64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
     BSL_SecParam_InitUint64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                           RFC9173_BCB_AES_VARIANT_A256GCM);
+                            RFC9173_BCB_AES_VARIANT_A256GCM);
     BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bcb_op_tgt_payload;

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -287,7 +287,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     BIBTestContext_Init(&bib_context);
 
     BSL_SecParam_InitTextstr(&bib_context.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A1_KEY);
-    BSL_SecParam_InitInt64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
     BSL_SecOper_t bib_oper_primary;
     BSL_SecOper_Init(&bib_oper_primary);
     BSL_SecOper_Populate(&bib_oper_primary, 1, 0, 3, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_ACCEPTOR,
@@ -305,7 +305,7 @@ void test_RFC9173_AppendixA_Example3_Acceptor(void)
     BCBTestContext_Init(&bcb_context);
 
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A3_KEY);
-    BSL_SecParam_InitInt64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
     BSL_SecOper_t bcb_oper;
     BSL_SecOper_Init(&bcb_oper);
     BSL_SecOper_Populate(&bcb_oper, 2, 1, 4, BSL_SECBLOCKTYPE_BCB, BSL_SECROLE_ACCEPTOR, BSL_POLICYACTION_DROP_BLOCK);
@@ -358,9 +358,9 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BIBTestContext_Init(&bib_context);
 
     BSL_SecParam_InitTextstr(&bib_context.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A1_KEY);
-    BSL_SecParam_InitInt64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC256);
-    BSL_SecParam_InitInt64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-    BSL_SecParam_InitInt64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC256);
+    BSL_SecParam_InitUint64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+    BSL_SecParam_InitUint64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bib_oper_primary;
     BSL_SecOper_Init(&bib_oper_primary);
@@ -384,9 +384,9 @@ void test_RFC9173_AppendixA_Example3_Source(void)
     BCBTestContext_Init(&bcb_context);
 
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A3_KEY);
-    BSL_SecParam_InitInt64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
-    BSL_SecParam_InitInt64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT, 1);
-    BSL_SecParam_InitInt64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
+    BSL_SecParam_InitUint64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT, 1);
+    BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bcb_oper;
     BSL_SecOper_Init(&bcb_oper);
@@ -466,10 +466,10 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
 
     // FIRST we must decrypt the BCB targets.
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A4_BCB_KEY);
-    BSL_SecParam_InitInt64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
-    BSL_SecParam_InitInt64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+    BSL_SecParam_InitUint64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
+    BSL_SecParam_InitUint64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                            RFC9173_BCB_AES_VARIANT_A256GCM);
-    BSL_SecParam_InitInt64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bcb_op_tgt_payload;
     BSL_SecOper_Init(&bcb_op_tgt_payload);
@@ -493,9 +493,9 @@ void test_RFC9173_AppendixA_Example4_Acceptor(void)
     BIBTestContext_Init(&bib_context);
 
     BSL_SecParam_InitTextstr(&bib_context.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A1_KEY);
-    BSL_SecParam_InitInt64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
-    BSL_SecParam_InitInt64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x07);
-    BSL_SecParam_InitInt64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
+    BSL_SecParam_InitUint64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x07);
+    BSL_SecParam_InitUint64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bib_oper_payload;
     BSL_SecOper_Init(&bib_oper_payload);
@@ -559,9 +559,9 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BIBTestContext_Init(&bib_context);
 
     BSL_SecParam_InitTextstr(&bib_context.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A1_KEY);
-    BSL_SecParam_InitInt64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
-    BSL_SecParam_InitInt64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x07);
-    BSL_SecParam_InitInt64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bib_context.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
+    BSL_SecParam_InitUint64(&bib_context.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x07);
+    BSL_SecParam_InitUint64(&bib_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bib_oper_payload;
     BSL_SecOper_Init(&bib_oper_payload);
@@ -576,10 +576,10 @@ void test_RFC9173_AppendixA_Example4_Source(void)
     BCBTestContext_Init(&bcb_context);
 
     BSL_SecParam_InitTextstr(&bcb_context.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A4_BCB_KEY);
-    BSL_SecParam_InitInt64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
-    BSL_SecParam_InitInt64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+    BSL_SecParam_InitUint64(&bcb_context.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE, 0x07);
+    BSL_SecParam_InitUint64(&bcb_context.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                            RFC9173_BCB_AES_VARIANT_A256GCM);
-    BSL_SecParam_InitInt64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&bcb_context.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecOper_t bcb_op_tgt_payload;
     BSL_SecOper_Init(&bcb_op_tgt_payload);

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -320,17 +320,17 @@ void test_sec_source_keywrap(bool wrap, bool bib)
         {
             BSL_Crypto_AddRegistryKey("kek_wrap", kek_data.ptr, kek_data.len);
             BSL_SecParam_InitTextstr(&bibcontext.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "kek_wrap");
-            BSL_SecParam_InitInt64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
+            BSL_SecParam_InitUint64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
             BSL_Crypto_SetRngGenerator(rfc3394_cek);
         }
         else
         {
             BSL_Crypto_AddRegistryKey("cek_wrap", cek_data.ptr, cek_data.len);
             BSL_SecParam_InitTextstr(&bibcontext.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "cek_wrap");
-            BSL_SecParam_InitInt64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+            BSL_SecParam_InitUint64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
         }
-        BSL_SecParam_InitInt64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-        BSL_SecParam_InitInt64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+        BSL_SecParam_InitUint64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
 
         BSL_SecOper_Populate(&bibcontext.sec_oper, 1, 1, 2, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_SOURCE,
                              BSL_POLICYACTION_DROP_BLOCK);
@@ -358,17 +358,17 @@ void test_sec_source_keywrap(bool wrap, bool bib)
         {
             BSL_Crypto_AddRegistryKey("kek_wrap", kek_data.ptr, kek_data.len);
             BSL_SecParam_InitTextstr(&bcbcontext.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, "kek_wrap");
-            BSL_SecParam_InitInt64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
+            BSL_SecParam_InitUint64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
         }
         else
         {
             BSL_Crypto_AddRegistryKey("cek_wrap", cek_data.ptr, cek_data.len);
             BSL_SecParam_InitTextstr(&bcbcontext.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, "cek_wrap");
-            BSL_SecParam_InitInt64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
+            BSL_SecParam_InitUint64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
         }
-        BSL_SecParam_InitInt64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
+        BSL_SecParam_InitUint64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
-        BSL_SecParam_InitInt64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+        BSL_SecParam_InitUint64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                                RFC9173_BCB_AES_VARIANT_A128GCM);
 
         BSL_SecOper_Populate(&bcbcontext.sec_oper, 2, 1, 2, BSL_SECBLOCKTYPE_BCB, BSL_SECROLE_SOURCE,
@@ -532,10 +532,10 @@ void test_sec_accept_keyunwrap(bool bib)
     {
         BSL_Crypto_AddRegistryKey("kek_wrap", kek_data.ptr, kek_data.len);
         BSL_SecParam_InitTextstr(&bibcontext.param_test_key, BSL_SECPARAM_TYPE_KEY_ID, "kek_wrap");
-        BSL_SecParam_InitInt64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
+        BSL_SecParam_InitUint64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
         BSL_SecParam_InitBytestr(&bibcontext.param_wrapped_key, RFC9173_BIB_PARAMID_WRAPPED_KEY, wrapped_key_data);
-        BSL_SecParam_InitInt64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-        BSL_SecParam_InitInt64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+        BSL_SecParam_InitUint64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
 
         BSL_SecOper_Populate(&bibcontext.sec_oper, 1, 1, 2, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_ACCEPTOR,
                              BSL_POLICYACTION_DROP_BLOCK);
@@ -557,13 +557,13 @@ void test_sec_accept_keyunwrap(bool bib)
 
         BSL_Crypto_AddRegistryKey("kek_wrap", kek_data.ptr, kek_data.len);
         BSL_SecParam_InitTextstr(&bcbcontext.param_test_key_id, BSL_SECPARAM_TYPE_KEY_ID, "kek_wrap");
-        BSL_SecParam_InitInt64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
+        BSL_SecParam_InitUint64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
         BSL_SecParam_InitBytestr(&bcbcontext.param_wrapped_key, RFC9173_BCB_SECPARAM_WRAPPEDKEY, wrapped_key_data);
         BSL_SecParam_InitBytestr(&bcbcontext.param_auth_tag, BSL_SECPARAM_TYPE_AUTH_TAG, result_data);
         BSL_SecParam_InitBytestr(&bcbcontext.param_init_vec, RFC9173_BCB_SECPARAM_IV, iv_data);
-        BSL_SecParam_InitInt64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
+        BSL_SecParam_InitUint64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
-        BSL_SecParam_InitInt64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
+        BSL_SecParam_InitUint64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
                                RFC9173_BCB_AES_VARIANT_A128GCM);
 
         BSL_SecOper_Populate(&bcbcontext.sec_oper, 2, 1, 2, BSL_SECBLOCKTYPE_BCB, BSL_SECROLE_ACCEPTOR,

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -330,7 +330,8 @@ void test_sec_source_keywrap(bool wrap, bool bib)
             BSL_SecParam_InitUint64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
         }
         BSL_SecParam_InitUint64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT,
+                                RFC9173_BIB_SHA_HMAC512);
 
         BSL_SecOper_Populate(&bibcontext.sec_oper, 1, 1, 2, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_SOURCE,
                              BSL_POLICYACTION_DROP_BLOCK);
@@ -367,9 +368,9 @@ void test_sec_source_keywrap(bool wrap, bool bib)
             BSL_SecParam_InitUint64(&bcbcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 0);
         }
         BSL_SecParam_InitUint64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
-                               RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
+                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
         BSL_SecParam_InitUint64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                               RFC9173_BCB_AES_VARIANT_A128GCM);
+                                RFC9173_BCB_AES_VARIANT_A128GCM);
 
         BSL_SecOper_Populate(&bcbcontext.sec_oper, 2, 1, 2, BSL_SECBLOCKTYPE_BCB, BSL_SECROLE_SOURCE,
                              BSL_POLICYACTION_DROP_BLOCK);
@@ -535,7 +536,8 @@ void test_sec_accept_keyunwrap(bool bib)
         BSL_SecParam_InitUint64(&bibcontext.use_key_wrap, BSL_SECPARAM_USE_KEY_WRAP, 1);
         BSL_SecParam_InitBytestr(&bibcontext.param_wrapped_key, RFC9173_BIB_PARAMID_WRAPPED_KEY, wrapped_key_data);
         BSL_SecParam_InitUint64(&bibcontext.param_scope_flags, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+        BSL_SecParam_InitUint64(&bibcontext.param_sha_variant, RFC9173_BIB_PARAMID_SHA_VARIANT,
+                                RFC9173_BIB_SHA_HMAC512);
 
         BSL_SecOper_Populate(&bibcontext.sec_oper, 1, 1, 2, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_ACCEPTOR,
                              BSL_POLICYACTION_DROP_BLOCK);
@@ -562,9 +564,9 @@ void test_sec_accept_keyunwrap(bool bib)
         BSL_SecParam_InitBytestr(&bcbcontext.param_auth_tag, BSL_SECPARAM_TYPE_AUTH_TAG, result_data);
         BSL_SecParam_InitBytestr(&bcbcontext.param_init_vec, RFC9173_BCB_SECPARAM_IV, iv_data);
         BSL_SecParam_InitUint64(&bcbcontext.param_scope_flags, RFC9173_BCB_SECPARAM_AADSCOPE,
-                               RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
+                                RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);
         BSL_SecParam_InitUint64(&bcbcontext.param_aes_variant, RFC9173_BCB_SECPARAM_AESVARIANT,
-                               RFC9173_BCB_AES_VARIANT_A128GCM);
+                                RFC9173_BCB_AES_VARIANT_A128GCM);
 
         BSL_SecOper_Populate(&bcbcontext.sec_oper, 2, 1, 2, BSL_SECBLOCKTYPE_BCB, BSL_SECROLE_ACCEPTOR,
                              BSL_POLICYACTION_DROP_BLOCK);

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -114,8 +114,8 @@ void _setUp(void)
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
 
-    BSL_SecParam_InitInt64(&param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT, RFC9173_BCB_AES_VARIANT_A128GCM);
-    BSL_SecParam_InitInt64(&param_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
+    BSL_SecParam_InitUint64(&param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT, RFC9173_BCB_AES_VARIANT_A128GCM);
+    BSL_SecParam_InitUint64(&param_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
     BSL_SecParam_InitTextstr(&param_test_bcb_key_correct, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A2_KEY);
 
     // BSL_32

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -135,16 +135,16 @@ void setUp(void)
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;
 
     // FIXME these params need managed lifecycle to ensure Deinit (by some means)
-    BSL_SecParam_InitInt64(&ctx.param_scope_flag, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
-    BSL_SecParam_InitInt64(&ctx.param_scope_flag_7, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x7);
-    BSL_SecParam_InitInt64(&ctx.param_sha_variant_512, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
-    BSL_SecParam_InitInt64(&ctx.param_sha_variant_384, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
+    BSL_SecParam_InitUint64(&ctx.param_scope_flag, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0);
+    BSL_SecParam_InitUint64(&ctx.param_scope_flag_7, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG, 0x7);
+    BSL_SecParam_InitUint64(&ctx.param_sha_variant_512, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC512);
+    BSL_SecParam_InitUint64(&ctx.param_sha_variant_384, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
 
-    BSL_SecParam_InitInt64(&ctx.param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT,
+    BSL_SecParam_InitUint64(&ctx.param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT,
                            RFC9173_BCB_AES_VARIANT_A128GCM);
-    BSL_SecParam_InitInt64(&ctx.param_aes_variant_256, RFC9173_BCB_SECPARAM_AESVARIANT,
+    BSL_SecParam_InitUint64(&ctx.param_aes_variant_256, RFC9173_BCB_SECPARAM_AESVARIANT,
                            RFC9173_BCB_AES_VARIANT_A256GCM);
-    BSL_SecParam_InitInt64(&ctx.param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
+    BSL_SecParam_InitUint64(&ctx.param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
 
     BSL_Data_t authtag_data;
     BSL_Data_Init(&authtag_data);
@@ -164,8 +164,8 @@ void setUp(void)
     wrapkey_data.len = sizeof(ApxA2_WrappedKey);
     BSL_SecParam_InitBytestr(&ctx.param_wrapped_key, RFC9173_BCB_SECPARAM_WRAPPEDKEY, wrapkey_data);
 
-    BSL_SecParam_InitInt64(&ctx.param_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
-    BSL_SecParam_InitInt64(&ctx.param_dont_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
+    BSL_SecParam_InitUint64(&ctx.param_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 1);
+    BSL_SecParam_InitUint64(&ctx.param_dont_use_wrap_key, BSL_SECPARAM_USE_KEY_WRAP, 0);
 
     BSL_SecParam_InitTextstr(&ctx.param_test_bib_key_correct, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A1_KEY);
     BSL_SecParam_InitTextstr(&ctx.param_test_bib_key_bad, BSL_SECPARAM_TYPE_KEY_ID, RFC9173_EXAMPLE_A2_KEY);

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -141,9 +141,9 @@ void setUp(void)
     BSL_SecParam_InitUint64(&ctx.param_sha_variant_384, RFC9173_BIB_PARAMID_SHA_VARIANT, RFC9173_BIB_SHA_HMAC384);
 
     BSL_SecParam_InitUint64(&ctx.param_aes_variant_128, RFC9173_BCB_SECPARAM_AESVARIANT,
-                           RFC9173_BCB_AES_VARIANT_A128GCM);
+                            RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_SecParam_InitUint64(&ctx.param_aes_variant_256, RFC9173_BCB_SECPARAM_AESVARIANT,
-                           RFC9173_BCB_AES_VARIANT_A256GCM);
+                            RFC9173_BCB_AES_VARIANT_A256GCM);
     BSL_SecParam_InitUint64(&ctx.param_aad_scope_flag, RFC9173_BCB_SECPARAM_AADSCOPE, 0);
 
     BSL_Data_t authtag_data;


### PR DESCRIPTION
#67 seems to have been closed by another change at some point. 
This is a pretty trivial change to make naming of unsigned integer sec params consistent (before, used both int and uint interchangeably).