### PR TITLE
Use sonar without build wrapper

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -30,8 +30,6 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
-    env:
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
       - uses: actions/checkout@v6
         with:
@@ -47,12 +45,9 @@ jobs:
               python3 python3-pip python3-wheel
           pip3 install gcovr
           ./build.sh deps
-          ./build.sh prep -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=ON -DBUILD_DOCS_API=OFF -DBUILD_DOCS_MAN=OFF
-      - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7
-      - name: Run Build Wrapper
-        run: |
-          build-wrapper-linux-x86-64 --out-dir ${{env.BUILD_WRAPPER_OUT_DIR}} ./build.sh
+          ./build.sh prep -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=ON -DBUILD_DOCS_API=OFF -DBUILD_DOCS_MAN=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Build
+        run: ./build.sh
       - name: Install
         run: ./build.sh install
       - name: Test
@@ -70,5 +65,5 @@ jobs:
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
         with:
           args: >
+            --define sonar.cfamily.compile-commands=build/default/compile_commands.json
             --define sonar.coverageReportPaths=build/default/coverage-sonarqube.xml
-            --define "sonar.cfamily.compile-commands=${{env.BUILD_WRAPPER_OUT_DIR}}/compile_commands.json"

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -29,13 +29,11 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          submodules: recursive
-      - name: Prep
+      - name: Set up OS
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: 1
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -44,15 +42,27 @@ jobs:
               xmlstarlet \
               python3 python3-pip python3-wheel
           pip3 install gcovr
-          ./build.sh deps
-          ./build.sh prep -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=ON -DBUILD_DOCS_API=OFF -DBUILD_DOCS_MAN=OFF -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          submodules: recursive
+      - name: Dependencies
+        run: ./build.sh deps
+      - name: Prep
+        run: >
+          ./build.sh prep
+          -DBUILD_DOCS_API=OFF -DBUILD_DOCS_MAN=OFF
+          -DBUILD_UNITTEST=ON
+          -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=ON
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Build
         run: ./build.sh
       - name: Install
         run: ./build.sh install
-      - name: Test
+      - name: Unit Test
+        run: ./build.sh check
+      - name: Mock BPA Test
         run: |
-          ./build.sh check
           pip3 install --upgrade pip
           pip3 install -r mock-bpa-test/requirements.txt
           python3 -m pytest mock-bpa-test
@@ -60,7 +70,7 @@ jobs:
         run: |
           ./build.sh --target coverage-sonarqube -v
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         env:
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,8 @@ if(BUILD_LIB)
 endif(BUILD_LIB)
 
 include(CheckSymbolExists)
-set(CMAKE_REQUIRED_DEFINITIONS "-D_POSIX_C_SOURCE=200809L")
 check_symbol_exists(timespec_get "time.h" HAVE_TIMESPEC_GET)
 check_symbol_exists(clock_gettime "time.h" HAVE_CLOCK_GETTIME)
-
-include(CheckTypeSize)
-check_type_size("int" SIZE_INT LANGUAGE C)
-check_type_size("size_t" SIZE_SIZET LANGUAGE C)
 
 if(BUILD_UNITTEST)
   if(TEST_MEMCHECK)
@@ -142,6 +137,7 @@ if(BUILD_UNITTEST)
       "--track-origins=yes"
       "--leak-check=full" "--show-leak-kinds=all"
       "--suppressions=${CMAKE_CURRENT_SOURCE_DIR}/resources/memcheck.supp"
+      "--gen-suppressions=all"
       "--error-exitcode=2"
     )
     # Arguments as list into global scope for Findunitytools.cmake
@@ -158,6 +154,7 @@ if(BUILD_COVERAGE)
   set(COVERAGE_EXCLUDES
     "${CMAKE_CURRENT_SOURCE_DIR}/deps/*"
     "${CMAKE_CURRENT_SOURCE_DIR}/testroot/*"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/"
     "${CMAKE_CURRENT_BINARY_DIR}/test/*"
   )
   set(GCOVR_ADDITIONAL_ARGS
@@ -193,9 +190,12 @@ if(BUILD_LIB)
 endif(BUILD_LIB)
 
 set(TEST_INSTALL_PREFIX "${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}")
-add_subdirectory(test)
-add_subdirectory(docs)
-
+if(BUILD_UNITTEST OR BUILD_FUZZING)
+    add_subdirectory(test)
+endif(BUILD_UNITTEST OR BUILD_FUZZING)
+if(BUILD_DOCS_API OR BUILD_DOCS_MAN)
+    add_subdirectory(docs)
+endif(BUILD_DOCS_API OR BUILD_DOCS_MAN)
 
 add_custom_command(
     DEPENDS CMakeGraphVizOptions.cmake

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=nasa-ammos
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=BSL
-#sonar.projectVersion=1.0
+sonar.projectVersion=1.1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
@@ -13,3 +13,6 @@ sonar.exclusions=**/*.cbor,**/*.cborseq
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
+
+# Python used for testing from ubuntu-22.04
+sonar.python.version=3.12

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,9 @@ sonar.projectName=BSL
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
-sonar.tests=test
+sonar.tests=test,mock-bpa-test
+# ignore test sources
+sonar.exclusions=**/*.cbor
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,5 +16,5 @@ sonar.coverage.exclusions=test/**/*
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
 
-# Python used for testing from ubuntu-22.04
+# Python used for testing from ubuntu-24.04
 sonar.python.version=3.12

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.projectName=BSL
 sonar.sources=src
 sonar.tests=test,mock-bpa-test
 # ignore test sources
-sonar.exclusions=**/*.cbor
+sonar.exclusions=**/*.cbor,**/*.cborseq
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,8 +8,10 @@ sonar.projectVersion=1.1.0
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src
 sonar.tests=test,mock-bpa-test
-# ignore test sources
+# ignore binary test data
 sonar.exclusions=**/*.cbor,**/*.cborseq
+# ignore test sources
+sonar.coverage.exclusions=test/**/*
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This can speed up and commonize scanning.

This change also does not consider unit test files for coverage, only library and mock BPA.