### PR TITLE
Do not install texlive or build PDF docs on PR changes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,22 +47,24 @@ jobs:
               cmake ninja-build ruby build-essential \
               libssl-dev libjansson-dev \
               doxygen graphviz plantuml \
-              dblatex texlive texlive-latex-extra texlive-font-utils \
+              ${{github.event_name != 'pull_request' && 'dblatex texlive texlive-latex-extra texlive-font-utils' || ''}} \
               xmlstarlet aspell
       - name: Dependency build
         run: ./build.sh deps
       - name: Prep
         run: >
           ./build.sh prep
-          -DBUILD_TESTING=OFF -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=OFF
+          -DBUILD_LIB=OFF
+          -DBUILD_TESTING=OFF -DBUILD_UNITTEST=OFF -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=OFF
           -DBUILD_DOCS_API=ON
       - name: Build
-        run: ./build.sh --target docs-api-html docs-api-pdf docs-api-misspelling
+        run: ./build.sh --target docs-api
       - name: Misspelling
         env:
           MISSPELLING_TXT: 'build/default/docs/api/misspelling.txt'
+          MISSPELLING_CTX_TXT: 'build/default/docs/api/misspelling-ctx.txt'
         # success means file is present and empty
-        run: test -f "${MISSPELLING_TXT}" -a ! -s "${MISSPELLING_TXT}" || (cat "${MISSPELLING_TXT}"; exit 1)
+        run: test -f "${MISSPELLING_TXT}" -a ! -s "${MISSPELLING_TXT}" || (cat "${MISSPELLING_TXT}"; printf "\nIn context:\n"; cat "${MISSPELLING_CTX_TXT}"; exit 1)
       - name: Install
         run: ./build.sh install --component docs-api
       - name: Compress
@@ -91,7 +93,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: apidoc
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4
@@ -104,11 +106,11 @@ jobs:
           tar -xf html.tar
           rm html.tar
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: testroot/usr/share/doc/bsl/
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
               cmake ninja-build ruby build-essential \
               libssl-dev libjansson-dev \
               doxygen graphviz plantuml \
-              ${{github.event_name != 'pull_request' && 'dblatex texlive texlive-latex-extra texlive-font-utils' || ''}} \
+              ${{github.event_name != 'pull_request' && 'dblatex texlive texlive-latex-extra texlive-font-utils' || 'texlive-binaries'}} \
               xmlstarlet aspell
       - name: Dependency build
         run: ./build.sh deps

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -54,7 +54,6 @@ jobs:
       - name: Prep
         run: >
           ./build.sh prep
-          -DBUILD_LIB=OFF
           -DBUILD_TESTING=OFF -DBUILD_UNITTEST=OFF -DTEST_MEMCHECK=OFF -DBUILD_COVERAGE=OFF
           -DBUILD_DOCS_API=ON
       - name: Build

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -58,6 +58,10 @@ add_custom_target(
     COMMENT "Generating API documentation with Doxygen"
     USES_TERMINAL
 )
+add_custom_target(
+    docs-api
+    DEPENDS docs-api-html
+)
 install(
     FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/index.html
@@ -74,7 +78,6 @@ if(XMLSTARLET_EXECUTABLE AND ASPELL_EXECUTABLE)
     # spellcheck on combined XML output
     set(DICTIONARY_TXT "${CMAKE_CURRENT_SOURCE_DIR}/dictionary.txt")
     set(SPELLCHECK_XSL "${CMAKE_CURRENT_SOURCE_DIR}/spellcheck.xsl")
-    set(MISSPELLING_TXT "misspelling.txt")
     add_custom_command(
         OUTPUT "dictionary.cwl"
         DEPENDS ${DICTIONARY_TXT}
@@ -82,19 +85,36 @@ if(XMLSTARLET_EXECUTABLE AND ASPELL_EXECUTABLE)
             ${ASPELL_EXECUTABLE} --lang=en create master "./dictionary.cwl"
     )
     add_custom_command(
-        OUTPUT ${MISSPELLING_TXT}
+        OUTPUT "spellcheck-combined.xml"
         DEPENDS
-            ${XML_COMBINE} ${XML_INDEX}
-            ${SPELLCHECK_XSL} "dictionary.cwl"
+            ${XML_COMBINE} ${XML_INDEX} ${SPELLCHECK_XSL}
         COMMAND
             ${XMLSTARLET_EXECUTABLE} tr "${XML_COMBINE}" "${XML_INDEX}" |
-            ${XMLSTARLET_EXECUTABLE} tr "${SPELLCHECK_XSL}" |
+            ${XMLSTARLET_EXECUTABLE} tr "${SPELLCHECK_XSL}" >"spellcheck-combined.xml"
+    )
+    add_custom_command(
+        OUTPUT "misspelling.txt"
+        DEPENDS
+            "spellcheck-combined.xml" "dictionary.cwl"
+        COMMAND
+            cat "spellcheck-combined.xml" |
             ${ASPELL_EXECUTABLE} --mode=html --lang=EN_US --extra-dicts=./dictionary.cwl list |
-            sort | uniq > "${MISSPELLING_TXT}"
+            sort -u >"misspelling.txt"
+    )
+    add_custom_command(
+        OUTPUT "misspelling-ctx.txt"
+        DEPENDS
+            "spellcheck-combined.xml" "misspelling.txt"
+        COMMAND
+            grep --file "misspelling.txt" "spellcheck-combined.xml" >"misspelling-ctx.txt" || true
     )
     add_custom_target(
         docs-api-misspelling
-        DEPENDS "${MISSPELLING_TXT}"
+        DEPENDS "misspelling.txt" "misspelling-ctx.txt"
+    )
+    add_dependencies(
+        docs-api
+        docs-api-misspelling
     )
 endif(XMLSTARLET_EXECUTABLE AND ASPELL_EXECUTABLE)
 
@@ -109,6 +129,10 @@ if(MAKE_EXECUTABLE AND DBLATEX_EXECUTABLE)
         COMMAND ${MAKE_EXECUTABLE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex
         COMMENT "Generating API documentation PDF"
+    )
+    add_dependencies(
+        docs-api
+        docs-api-pdf
     )
     install(
         FILES


### PR DESCRIPTION
This improves CI run times significantly and still tests api-docs building and spellchecking.