### PR TITLE
Call security context validators during action-set validation

### DIFF
--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -531,8 +531,32 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
 bool BSL_SecCtx_ValidatePolicyActionSet(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle,
                                         const BSL_SecurityActionSet_t *action_set)
 {
-    (void)lib;
-    (void)bundle;
-    (void)action_set;
+    if (lib == NULL || bundle == NULL || action_set == NULL)
+    {
+        return false;
+    }
+
+    for (size_t action_index = 0; action_index < BSL_SecurityActionSet_CountActions(action_set); action_index++)
+    {
+        const BSL_SecurityAction_t *action = BSL_SecurityActionSet_GetActionAtIndex(action_set, action_index);
+        for (size_t oper_index = 0; oper_index < BSL_SecurityAction_CountSecOpers(action); oper_index++)
+        {
+            const BSL_SecOper_t    *sec_oper = BSL_SecurityAction_GetSecOperAtIndex(action, oper_index);
+            const BSL_SecCtxDesc_t *sec_ctx  = BSL_SecCtxDict_cget(lib->sc_reg, sec_oper->context_id);
+            if (sec_ctx == NULL || sec_ctx->validate == NULL)
+            {
+                BSL_LOG_WARNING("No security context validator registered for context ID %" PRId64,
+                                sec_oper->context_id);
+                return false;
+            }
+
+            if (!sec_ctx->validate(lib, bundle, sec_oper))
+            {
+                BSL_LOG_WARNING("Security context validator failed for context ID %" PRId64, sec_oper->context_id);
+                return false;
+            }
+        }
+    }
+
     return true;
 }

--- a/src/security_context/BIB_HMAC_SHA2.c
+++ b/src/security_context/BIB_HMAC_SHA2.c
@@ -44,18 +44,12 @@ bool BSLX_BIB_Validate(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const B
     // Note: Internal API distinction.
     // Called before the `_execute` function. This checks ahead of time whether it contains the necessary info in order
     // to perform the execution.
-    (void)lib;
-    (void)bundle;
-    (void)sec_oper;
-    return false;
+    return lib != NULL && bundle != NULL && sec_oper != NULL;
 }
 
 bool BSLX_BCB_Validate(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const BSL_SecOper_t *sec_oper)
 {
-    (void)lib;
-    (void)bundle;
-    (void)sec_oper;
-    return false;
+    return lib != NULL && bundle != NULL && sec_oper != NULL;
 }
 
 /**

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -44,6 +44,31 @@
 
 static BSL_TestContext_t LocalTestCtx;
 
+static size_t   TestSecCtxValidateCallCount = 0;
+static uint64_t TestSecCtxValidatedTarget   = 0;
+static bool     TestSecCtxValidateResult    = true;
+
+static bool BSL_TestSecCtx_Validate(BSL_LibCtx_t *lib, const BSL_BundleRef_t *bundle, const BSL_SecOper_t *sec_oper)
+{
+    TEST_ASSERT_NOT_NULL(lib);
+    TEST_ASSERT_NOT_NULL(bundle);
+    TEST_ASSERT_NOT_NULL(sec_oper);
+
+    TestSecCtxValidateCallCount++;
+    TestSecCtxValidatedTarget = BSL_SecOper_GetTargetBlockNum(sec_oper);
+    return TestSecCtxValidateResult;
+}
+
+static int BSL_TestSecCtx_Execute(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, const BSL_SecOper_t *sec_oper,
+                                  BSL_SecOutcome_t *sec_outcome)
+{
+    (void)lib;
+    (void)bundle;
+    (void)sec_oper;
+    (void)sec_outcome;
+    return BSL_SUCCESS;
+}
+
 void suiteSetUp(void)
 {
     TEST_ASSERT_EQUAL_INT(0, BSL_HostDescriptors_Set(MockBPA_Agent_Descriptors(NULL)));
@@ -68,6 +93,38 @@ void tearDown(void)
 {
     BSL_CryptoDeinit();
     TEST_ASSERT_EQUAL(0, BSL_TestContext_Deinit(&LocalTestCtx));
+}
+
+void test_SecurityContext_ValidatePolicyActionSet_UsesRegisteredValidator(void)
+{
+    TestSecCtxValidateCallCount = 0;
+    TestSecCtxValidatedTarget   = 0;
+    TestSecCtxValidateResult    = false;
+
+    BSL_SecCtxDesc_t sec_ctx_desc = { 0 };
+    sec_ctx_desc.validate         = BSL_TestSecCtx_Validate;
+    sec_ctx_desc.execute          = BSL_TestSecCtx_Execute;
+    TEST_ASSERT_EQUAL(BSL_SUCCESS, BSL_API_RegisterSecurityContext(&LocalTestCtx.bsl, 99, sec_ctx_desc));
+
+    BSL_SecOper_t sec_oper;
+    BSL_SecOper_Init(&sec_oper);
+    BSL_SecOper_Populate(&sec_oper, 99, 1, 2, BSL_SECBLOCKTYPE_BIB, BSL_SECROLE_SOURCE, BSL_POLICYACTION_NOTHING);
+
+    BSL_SecurityAction_t action;
+    BSL_SecurityAction_Init(&action);
+    TEST_ASSERT_EQUAL(BSL_SUCCESS, BSL_SecurityAction_AppendSecOper(&action, &sec_oper));
+
+    BSL_SecurityActionSet_t action_set;
+    BSL_SecurityActionSet_Init(&action_set);
+    TEST_ASSERT_EQUAL(BSL_SUCCESS, BSL_SecurityActionSet_AppendAction(&action_set, &action));
+
+    TEST_ASSERT_FALSE(
+        BSL_SecCtx_ValidatePolicyActionSet(&LocalTestCtx.bsl, &LocalTestCtx.mock_bpa_ctr.bundle_ref, &action_set));
+    TEST_ASSERT_EQUAL_UINT(1, TestSecCtxValidateCallCount);
+    TEST_ASSERT_EQUAL_UINT64(1, TestSecCtxValidatedTarget);
+
+    BSL_SecurityAction_Deinit(&action);
+    BSL_SecurityActionSet_Deinit(&action_set);
 }
 
 /**


### PR DESCRIPTION
## Summary

- iterate through security actions and security operations in `BSL_SecCtx_ValidatePolicyActionSet`
- dispatch validation to the registered security context descriptor for each operation
- preserve the current default BIB/BCB permissive behavior until their validators implement deeper checks
- add a regression test proving a registered validator is called and its failure is propagated

Closes #184.

## Validation

- `git diff --check`
- `clang-format --style=file -i src/backend/SecurityContext.c src/security_context/BIB_HMAC_SHA2.c test/test_BackendSecurityContext.c`
- `./build.sh deps`
- `./build.sh prep -DBUILD_DOCS_API=OFF -DBUILD_DOCS_MAN=OFF -DBUILD_UNITTEST=ON -DBUILD_COVERAGE=OFF -DTEST_MEMCHECK=OFF`
- `cmake --build build/default --target src/CMakeFiles/bsl_dynamic.dir/backend/SecurityContext.c.o`
- `cmake --build build/default --target src/CMakeFiles/bsl_default_sc.dir/security_context/BIB_HMAC_SHA2.c.o`
- syntax-checked `test/test_BackendSecurityContext.c` with the generated CMake compile flags

Full local `./build.sh`/test execution is blocked on macOS by existing unrelated build issues: `tv_usec` format warnings promoted to errors, missing OpenSSL include path for `bsl_crypto`, and unresolved `bsl_front` symbols. The modified production objects and new test source compile/syntax-check locally; CI should exercise the Linux matrix.