### PR TITLE
Clean up initializer lists in unit tests

### DIFF
--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -473,7 +473,8 @@ typedef enum
 /** @brief Calls the host interface to get a bundle primary block information.abort
  *
  * @param[in]       bundle Bundle context
- * @param[out]   result_primary_block Non-null pointer to result which gets initialized and populated on a zero return code.
+ * @param[out]   result_primary_block Non-null pointer to result which gets initialized and populated on a zero return
+ * code.
  * @return 0 on success, negative on error
  */
 int BSL_BundleCtx_GetBundleMetadata(const BSL_BundleRef_t *bundle, BSL_PrimaryBlock_t *result_primary_block);
@@ -482,7 +483,8 @@ int BSL_BundleCtx_GetBundleMetadata(const BSL_BundleRef_t *bundle, BSL_PrimaryBl
  *
  * @param[in] bundle Context bundle
  * @param[in] block_num The number of the bundle canonical block we seek information on
- * @param[out] result_block Pointer to result which gets initialized and populated on a zero return code. Contains results of the query.
+ * @param[out] result_block Pointer to result which gets initialized and populated on a zero return code. Contains
+ * results of the query.
  * @return 0 on success, negative on error
  */
 int BSL_BundleCtx_GetBlockMetadata(const BSL_BundleRef_t *bundle, uint64_t block_num,

--- a/src/BPSecLib_Private.h
+++ b/src/BPSecLib_Private.h
@@ -473,7 +473,7 @@ typedef enum
 /** @brief Calls the host interface to get a bundle primary block information.abort
  *
  * @param[in]       bundle Bundle context
- * @param[out]   result_primary_block Non-null pointer to result which gets populated on a zero return code.
+ * @param[out]   result_primary_block Non-null pointer to result which gets initialized and populated on a zero return code.
  * @return 0 on success, negative on error
  */
 int BSL_BundleCtx_GetBundleMetadata(const BSL_BundleRef_t *bundle, BSL_PrimaryBlock_t *result_primary_block);
@@ -482,7 +482,7 @@ int BSL_BundleCtx_GetBundleMetadata(const BSL_BundleRef_t *bundle, BSL_PrimaryBl
  *
  * @param[in] bundle Context bundle
  * @param[in] block_num The number of the bundle canonical block we seek information on
- * @param[out] result_block Pointer to allocated memory which contains the results of the query.
+ * @param[out] result_block Pointer to result which gets initialized and populated on a zero return code. Contains results of the query.
  * @return 0 on success, negative on error
  */
 int BSL_BundleCtx_GetBlockMetadata(const BSL_BundleRef_t *bundle, uint64_t block_num,

--- a/src/backend/PublicInterfaceImpl.c
+++ b/src/backend/PublicInterfaceImpl.c
@@ -161,7 +161,7 @@ int BSL_API_QuerySecurity(BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *output_act
     // that targets (protects) a block whose ID is `target_block_num`
     //
     // I.e., "Get me the security block whose target contains `target_block_num`"
-    BSL_PrimaryBlock_t primary_block = { 0 };
+    BSL_PrimaryBlock_t primary_block;
     if (BSL_SUCCESS != BSL_BundleCtx_GetBundleMetadata(bundle, &primary_block))
     {
         BSL_LOG_ERR("Cannot get bundle primary block");
@@ -170,7 +170,7 @@ int BSL_API_QuerySecurity(BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *output_act
 
     for (size_t ix = 0; ix < primary_block.block_count; ix++)
     {
-        BSL_CanonicalBlock_t block = { 0 };
+        BSL_CanonicalBlock_t block;
         if (BSL_SUCCESS != BSL_BundleCtx_GetBlockMetadata(bundle, primary_block.block_numbers[ix], &block))
         {
             BSL_LOG_WARNING("Failed to get block number %" PRIu64, primary_block.block_numbers[ix]);

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -146,7 +146,7 @@ int BSL_ExecBIBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *lib, BS
         return BSL_ERR_SECURITY_OPERATION_FAILED;
     }
 
-    BSL_CanonicalBlock_t sec_blk = { 0 };
+    BSL_CanonicalBlock_t sec_blk;
     if (BSL_BundleCtx_GetBlockMetadata(bundle, sec_oper->sec_block_num, &sec_blk) != BSL_SUCCESS)
     {
         BSL_LOG_ERR("Could not get BIB block (num=%" PRIu64 ")", sec_oper->sec_block_num);

--- a/src/default_sc/BCB_AES_GCM.c
+++ b/src/default_sc/BCB_AES_GCM.c
@@ -86,7 +86,7 @@ int BSLX_BCB_ComputeAAD(BSLX_BCB_t *bcb_context)
         BSLX_EncodeHeader(&bcb_context->sec_block, &aad_enc);
     }
 
-    UsefulBufC cbor_encoded_buffer = { 0 };
+    UsefulBufC cbor_encoded_buffer;
     if (QCBOR_SUCCESS != QCBOREncode_Finish(&aad_enc, &cbor_encoded_buffer))
     {
         BSL_LOG_ERR("Failed to encode AAD in BCB");

--- a/src/default_sc/BCB_AES_GCM.c
+++ b/src/default_sc/BCB_AES_GCM.c
@@ -325,7 +325,7 @@ int BSLX_BCB_Encrypt(BSLX_BCB_t *bcb_context)
 
     int retval = BSL_SUCCESS;
 
-    BSL_Cipher_t cipher = { 0 };
+    BSL_Cipher_t cipher;
     int          cipher_init =
         BSL_Cipher_Init(&cipher, BSL_CRYPTO_ENCRYPT, aes_mode, bcb_context->iv.ptr, bcb_context->iv.len, cipher_key);
     if (BSL_SUCCESS != cipher_init)

--- a/src/policy_provider/SamplePolicyProvider.c
+++ b/src/policy_provider/SamplePolicyProvider.c
@@ -127,7 +127,7 @@ static uint64_t get_target_block_id(const BSL_BundleRef_t *bundle, uint64_t targ
     {
         const uint64_t blk_num = res_prim_blk.block_numbers[ix];
 
-        BSL_CanonicalBlock_t test_block = { 0 };
+        BSL_CanonicalBlock_t test_block;
         if (BSL_SUCCESS != BSL_BundleCtx_GetBlockMetadata(bundle, blk_num, &test_block))
         {
             BSL_LOG_WARNING("Failed to lookup metadata for block number %" PRIu64, blk_num);

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -86,7 +86,8 @@ void test_PolicyProvider_InspectEmptyRuleset(void)
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.hex_bundle_bib));
 
-    BSL_SecurityActionSet_t action_set = { 0 };
+    BSL_SecurityActionSet_t action_set;
+    BSL_SecurityActionSet_Init(&action_set);
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
@@ -120,7 +121,8 @@ void test_PolicyProvider_InspectSingleBIBRuleset(void)
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.hex_bundle_bib));
 
-    BSL_SecurityActionSet_t action_set = { 0 };
+    BSL_SecurityActionSet_t action_set;
+    BSL_SecurityActionSet_Init(&action_set);
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
@@ -153,7 +155,8 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
     TEST_ASSERT_EQUAL(0,
                       BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.hex_bundle_bib));
 
-    BSL_SecurityActionSet_t action_set = { 0 };
+    BSL_SecurityActionSet_t action_set;
+    BSL_SecurityActionSet_Init(&action_set);
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));
@@ -212,7 +215,8 @@ void test_MultiplePolicyProviders(void)
     TEST_ASSERT_EQUAL(
         0, BSL_TestUtils_LoadBundleFromCBOR(&LocalTestCtx, RFC9173_TestVectors_AppendixA1.hex_bundle_original));
 
-    BSL_SecurityActionSet_t action_set = { 0 };
+    BSL_SecurityActionSet_t action_set;
+    BSL_SecurityActionSet_Init(&action_set);
     TEST_ASSERT_EQUAL(0, BSL_PolicyRegistry_InspectActions(&LocalTestCtx.bsl, &action_set,
                                                            &LocalTestCtx.mock_bpa_ctr.bundle_ref,
                                                            BSL_POLICYLOCATION_APPIN));

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -63,11 +63,12 @@ void setUp(void)
 
     policy_provider = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID);
 
-    BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = policy_provider;
-    policy_desc.query_fn         = BSLP_QueryPolicy;
-    policy_desc.finalize_fn      = BSLP_FinalizePolicy;
-    policy_desc.deinit_fn        = BSLP_Deinit;
+    BSL_PolicyDesc_t policy_desc = {
+        .user_data        = policy_provider,
+        .query_fn         = BSLP_QueryPolicy,
+        .finalize_fn      = BSLP_FinalizePolicy,
+        .deinit_fn        = BSLP_Deinit,
+    };
 
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 }
@@ -178,11 +179,12 @@ void test_MultiplePolicyProviders(void)
 {
     BSLP_PolicyProvider_t *policy_provider2 = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID_2);
 
-    BSL_PolicyDesc_t policy_desc_2 = { 0 };
-    policy_desc_2.user_data        = policy_provider2;
-    policy_desc_2.query_fn         = BSLP_QueryPolicy;
-    policy_desc_2.finalize_fn      = BSLP_FinalizePolicy;
-    policy_desc_2.deinit_fn        = BSLP_Deinit;
+    BSL_PolicyDesc_t policy_desc_2 = {
+        .user_data        = policy_provider2,
+        .query_fn         = BSLP_QueryPolicy,
+        .finalize_fn      = BSLP_FinalizePolicy,
+        .deinit_fn        = BSLP_Deinit,
+    };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID_2, policy_desc_2));
 
     BSLP_PolicyProvider_t *policy  = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -64,10 +64,10 @@ void setUp(void)
     policy_provider = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID);
 
     BSL_PolicyDesc_t policy_desc = {
-        .user_data        = policy_provider,
-        .query_fn         = BSLP_QueryPolicy,
-        .finalize_fn      = BSLP_FinalizePolicy,
-        .deinit_fn        = BSLP_Deinit,
+        .user_data   = policy_provider,
+        .query_fn    = BSLP_QueryPolicy,
+        .finalize_fn = BSLP_FinalizePolicy,
+        .deinit_fn   = BSLP_Deinit,
     };
 
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
@@ -180,10 +180,10 @@ void test_MultiplePolicyProviders(void)
     BSLP_PolicyProvider_t *policy_provider2 = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID_2);
 
     BSL_PolicyDesc_t policy_desc_2 = {
-        .user_data        = policy_provider2,
-        .query_fn         = BSLP_QueryPolicy,
-        .finalize_fn      = BSLP_FinalizePolicy,
-        .deinit_fn        = BSLP_Deinit,
+        .user_data   = policy_provider2,
+        .query_fn    = BSLP_QueryPolicy,
+        .finalize_fn = BSLP_FinalizePolicy,
+        .deinit_fn   = BSLP_Deinit,
     };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID_2, policy_desc_2));
 

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -41,8 +41,8 @@ static BSL_IdValPair_t param_aes_variant_128;
 static BSL_IdValPair_t param_use_wrap_key;
 static BSL_IdValPair_t param_test_bcb_key_correct;
 
-static BSL_TestContext_t       LocalTestCtx = { 0 };
-static BSL_SecurityActionSet_t action_set   = { 0 };
+static BSL_TestContext_t       LocalTestCtx;
+static BSL_SecurityActionSet_t action_set;
 static BSLP_PolicyProvider_t  *policy_provider;
 
 static void *malloc_test(size_t size)

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -109,10 +109,10 @@ void _setUp(void)
 
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = {
-        .user_data        = policy_provider,
-        .query_fn         = BSLP_QueryPolicy,
-        .deinit_fn        = BSLP_Deinit,
-        .finalize_fn      = BSLP_FinalizePolicy,
+        .user_data   = policy_provider,
+        .query_fn    = BSLP_QueryPolicy,
+        .deinit_fn   = BSLP_Deinit,
+        .finalize_fn = BSLP_FinalizePolicy,
     };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -108,11 +108,12 @@ void _setUp(void)
     policy_provider = BSLP_PolicyProvider_Init(1);
 
     /// Register the policy provider with some rules
-    BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = policy_provider;
-    policy_desc.query_fn         = BSLP_QueryPolicy;
-    policy_desc.deinit_fn        = BSLP_Deinit;
-    policy_desc.finalize_fn      = BSLP_FinalizePolicy;
+    BSL_PolicyDesc_t policy_desc = {
+        .user_data        = policy_provider,
+        .query_fn         = BSLP_QueryPolicy,
+        .deinit_fn        = BSLP_Deinit,
+        .finalize_fn      = BSLP_FinalizePolicy,
+    };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -103,6 +103,8 @@ void _setUp(void)
     BSL_IdValPair_Init(&param_use_wrap_key);
     BSL_IdValPair_Init(&param_test_bcb_key_correct);
 
+    BSL_SecurityActionSet_Init(&action_set);
+
     policy_provider = BSLP_PolicyProvider_Init(1);
 
     /// Register the policy provider with some rules

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -139,13 +139,14 @@ void test_bsl_mock_encode_canonical(uint64_t crc_type, const char *expecthex)
     static const uint8_t dummy_btsd[] = { 0x01, 0x02, 0x03 };
     static const size_t  dummy_size   = sizeof(dummy_btsd) / sizeof(uint8_t);
 
-    MockBPA_CanonicalBlock_t blk = { 0 };
-    blk.blk_type                 = 10;
-    blk.blk_num                  = 45;
-    blk.flags                    = 0;
-    blk.crc_type                 = crc_type;
-    blk.btsd                     = BSL_malloc(dummy_size);
-    blk.btsd_len                 = dummy_size;
+    MockBPA_CanonicalBlock_t blk = {
+        .blk_type           = 10,
+        .blk_num            = 45,
+        .flags              = 0,
+        .crc_type           = crc_type,
+        .btsd               = BSL_malloc(dummy_size),
+        .btsd_len           = dummy_size,
+    };
     memcpy(blk.btsd, dummy_btsd, dummy_size);
 
     BSL_Data_t encoded;

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -140,12 +140,12 @@ void test_bsl_mock_encode_canonical(uint64_t crc_type, const char *expecthex)
     static const size_t  dummy_size   = sizeof(dummy_btsd) / sizeof(uint8_t);
 
     MockBPA_CanonicalBlock_t blk = {
-        .blk_type           = 10,
-        .blk_num            = 45,
-        .flags              = 0,
-        .crc_type           = crc_type,
-        .btsd               = BSL_malloc(dummy_size),
-        .btsd_len           = dummy_size,
+        .blk_type = 10,
+        .blk_num  = 45,
+        .flags    = 0,
+        .crc_type = crc_type,
+        .btsd     = BSL_malloc(dummy_size),
+        .btsd_len = dummy_size,
     };
     memcpy(blk.btsd, dummy_btsd, dummy_size);
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -131,10 +131,10 @@ void setUp(void)
 
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = {
-        .user_data        = policy_provider,
-        .query_fn         = BSLP_QueryPolicy,
-        .deinit_fn        = BSLP_Deinit,
-        .finalize_fn      = BSLP_FinalizePolicy,
+        .user_data   = policy_provider,
+        .query_fn    = BSLP_QueryPolicy,
+        .deinit_fn   = BSLP_Deinit,
+        .finalize_fn = BSLP_FinalizePolicy,
     };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -130,11 +130,12 @@ void setUp(void)
     policy_provider = BSLP_PolicyProvider_Init(1);
 
     /// Register the policy provider with some rules
-    BSL_PolicyDesc_t policy_desc = { 0 };
-    policy_desc.user_data        = policy_provider;
-    policy_desc.query_fn         = BSLP_QueryPolicy;
-    policy_desc.deinit_fn        = BSLP_Deinit;
-    policy_desc.finalize_fn      = BSLP_FinalizePolicy;
+    BSL_PolicyDesc_t policy_desc = {
+        .user_data        = policy_provider,
+        .query_fn         = BSLP_QueryPolicy,
+        .deinit_fn        = BSLP_Deinit,
+        .finalize_fn      = BSLP_FinalizePolicy,
+    };
     TEST_ASSERT_EQUAL(0, BSL_API_RegisterPolicyProvider(&LocalTestCtx.bsl, BSL_SAMPLE_PP_ID, policy_desc));
 
     BSLP_PolicyProvider_t *policy = BSL_PolicyDict_get(LocalTestCtx.bsl.policy_reg, BSL_SAMPLE_PP_ID)->user_data;


### PR DESCRIPTION
In `test_BackendPolicyProvider.c` and `test_DynamicMemCbs.c`, uses of `action_set` are only initialized via `= { 0 }` and are missing an explicit `BSL_SecurityActionSet_Init` from the API.

Current:
```
BSL_SecurityActionSet_t action_set = { 0 };
```

Updated to:
```
BSL_SecurityActionSet_t action_set;
BSL_SecurityActionSet_Init(&action_set);
```

Both files do call `BSL_SecurityActionSet_Deinit(&action_set)` when it is time to deinit, so adding the explicit init makes things consistent.

I cleaned up a few other uses of  `= { 0 }` (these remaining modifications being purely stylistic). One file I modified is `BSL/src/default_sc/BCB_AES_GCM.c` where `BSL_Cipher_t cipher  = { 0 }` is immediately followed by a `BSL_Cipher_Init()` which immediately performs a memset, so `= { 0 }` can be removed. Similar examples from this file skip the `= { 0 }` as well. However, this change is out of scope given that this ticket is supposed to be for the unit tests, so we could also revert this one.

Closes #75 