### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ _Note!_ BSL uses **Red Hat Enterprise Linux (RHEL 9)** as the target build envir
 The following should be installable by the system package manager:
 
 _Required: Build and Run Unit Tests_
- * CMake, GCC or Clang, OpenSSL (Development), Ninja Build, Valgrind, Memcheck.
+ * CMake, GCC or Clang, OpenSSL (Development), Ninja Build, Valgrind, Memcheck, Ruby, jansson-devel.
 
 _Optional: To Construct Docs, etc..._
- * Doxygen, Ruby, gcovr (as Python package), graphviz, plantuml, texlive-bibtex, asciidoctor.
+ * Doxygen, gcovr (as Python package), graphviz, plantuml, texlive-bibtex, asciidoctor.
 
 ## Building BSL
 


### PR DESCRIPTION
Added the two packages (`ruby` and `jansson-devel`) to the "required" list in the Readme. They are mentioned in cmake/Findunitytools.cmake and bsl.spec as being required, as discovered by @william-fei when he was walking through the README steps.