### PR TITLE
Use more modern OpenSSL API for HMAC

### DIFF
--- a/src/CryptoInterface.h
+++ b/src/CryptoInterface.h
@@ -122,8 +122,6 @@ typedef struct BSL_AuthCtx_s
 {
     /// pointer to library specific data
     BSL_Crypto_LibHandle_t libhandle;
-    /// SHA variant of context
-    BSL_CryptoCipherSHAVariant_e SHA_variant;
     /// Key handle used by context
     BSL_Crypto_KeyHandle_t keyhandle;
     /**
@@ -248,20 +246,17 @@ bool BSL_Crypto_Compare(const void *data1, size_t size1, const void *data2, size
 void BSL_Crypto_ClearGeneratedKeyHandle(BSL_Crypto_KeyHandle_t keyhandle);
 
 /**
- * Perform key wrap
- * KEK and CEK sizes must match
+ * Perform key wrap.
+ * KEK and CEK sizes must match.
  * @param[in] kek_handle key encryption key handle (encryption key)
  * @param[in] cek_handle content encryption key handle (encryption data)
  * @param[in,out] wrapped_key output wrapped key (ciphertext) bytes
- * @param[in,out] wrapped_key_handle output wrapped key (ciphertext) handle, allocated with ::BSL_malloc(). Set to NULL
- * if handle not needed.
  */
-int BSL_Crypto_WrapKey(BSL_Crypto_KeyHandle_t kek_handle, BSL_Crypto_KeyHandle_t cek_handle, BSL_Data_t *wrapped_key,
-                       BSL_Crypto_KeyHandle_t *wrapped_key_handle);
+int BSL_Crypto_WrapKey(BSL_Crypto_KeyHandle_t kek_handle, BSL_Crypto_KeyHandle_t cek_handle, BSL_Data_t *wrapped_key);
 
 /**
- * Perform key unwrap
- * CEK size expected to match size of KEK
+ * Perform key unwrap.
+ * CEK size expected to match size of KEK.
  * @param[in] kek_handle key encryption key handle (decryption key)
  * @param[in] wrapped_key input wrapped key (ciphertext) bytes
  * @param[in,out] cek_handle output content encryption key (plaintext) handle.

--- a/src/cose_sc/CoseContext.c
+++ b/src/cose_sc/CoseContext.c
@@ -1354,7 +1354,7 @@ static void BSLX_CoseSc_GenerateContentKey(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Reci
                 ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
             }
 
-            res = BSL_Crypto_WrapKey(ctx->keyhandle, ctx->cekhandle, &recip->ciphertext, NULL);
+            res = BSL_Crypto_WrapKey(ctx->keyhandle, ctx->cekhandle, &recip->ciphertext);
             if (BSL_SUCCESS != res)
             {
                 BSL_LOG_ERR("Failed to wrap content key");

--- a/src/crypto/CryptoInterface.c
+++ b/src/crypto/CryptoInterface.c
@@ -30,6 +30,8 @@
 #include <m-dict.h>
 #include <m-shared-ptr.h>
 #include <m-bstring.h>
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
@@ -252,8 +254,7 @@ int BSL_Crypto_UnwrapKey(BSL_Crypto_KeyHandle_t kek_handle, const BSL_Data_t *wr
     return 0;
 }
 
-int BSL_Crypto_WrapKey(BSL_Crypto_KeyHandle_t kek_handle, BSL_Crypto_KeyHandle_t cek_handle, BSL_Data_t *wrapped_key,
-                       BSL_Crypto_KeyHandle_t *wrapped_key_handle)
+int BSL_Crypto_WrapKey(BSL_Crypto_KeyHandle_t kek_handle, BSL_Crypto_KeyHandle_t cek_handle, BSL_Data_t *wrapped_key)
 {
     CHK_ARG_NONNULL(kek_handle);
     CHK_ARG_NONNULL(cek_handle);
@@ -334,28 +335,6 @@ int BSL_Crypto_WrapKey(BSL_Crypto_KeyHandle_t kek_handle, BSL_Crypto_KeyHandle_t
     EVP_CIPHER_CTX_free(ctx);
     BSL_LOG_PLAINTEXT_PTR("wrapped key", cek_handle, wrapped_key->ptr, wrapped_key->len);
 
-    if (wrapped_key_handle != NULL)
-    {
-        EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HMAC, NULL);
-        int           res  = EVP_PKEY_keygen_init(pctx);
-        CHK_PROPERTY(res == 1);
-
-        BSL_CryptoKey_t *new_wrapped_key_handle = BSL_malloc(sizeof(BSL_CryptoKey_t));
-        BSL_CryptoKey_Init(new_wrapped_key_handle);
-        new_wrapped_key_handle->pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, wrapped_key->ptr, wrapped_key->len);
-        BSL_Data_Init(&new_wrapped_key_handle->raw);
-
-        int ecode = 0;
-        if ((ecode = BSL_Data_CopyFrom(&new_wrapped_key_handle->raw, wrapped_key->len, wrapped_key->ptr)) < 0)
-        {
-            BSL_LOG_ERR("Failed to copy key");
-            return ecode;
-        }
-
-        *wrapped_key_handle = new_wrapped_key_handle;
-        EVP_PKEY_CTX_free(pctx);
-    }
-
     return 0;
 }
 
@@ -364,36 +343,46 @@ int BSL_AuthCtx_Init(BSL_AuthCtx_t *hmac_ctx, BSL_Crypto_KeyHandle_t keyhandle, 
     CHK_ARG_NONNULL(hmac_ctx);
     CHK_ARG_NONNULL(keyhandle);
 
-    hmac_ctx->keyhandle       = keyhandle;
-    BSL_CryptoKey_t *key_info = (BSL_CryptoKey_t *)hmac_ctx->keyhandle;
-
-    hmac_ctx->libhandle = EVP_MD_CTX_new();
-    CHK_PRECONDITION(hmac_ctx->libhandle != NULL);
-
-    hmac_ctx->SHA_variant = sha_var;
-
-    const EVP_MD *sha = NULL;
-    switch (hmac_ctx->SHA_variant)
+    char *digest_name;
+    switch (sha_var)
     {
         case BSL_CRYPTO_SHA_256:
-            sha = EVP_sha256();
+            digest_name = SN_sha256;
             break;
         case BSL_CRYPTO_SHA_384:
-            sha = EVP_sha384();
+            digest_name = SN_sha384;
             break;
         case BSL_CRYPTO_SHA_512:
-            sha = EVP_sha512();
+            digest_name = SN_sha512;
             break;
         default:
             BSL_LOG_ERR("Invalid SHA variant %d", sha_var);
-            return BSL_ERR_FAILURE;
+            return BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+    }
+
+    hmac_ctx->keyhandle       = keyhandle;
+    BSL_CryptoKey_t *key_info = (BSL_CryptoKey_t *)hmac_ctx->keyhandle;
+    CHK_PRECONDITION(key_info->raw.len > 0);
+
+    EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    CHK_PRECONDITION(mac != NULL);
+
+    hmac_ctx->libhandle = EVP_MAC_CTX_new(mac);
+    EVP_MAC_free(mac);
+    CHK_PRECONDITION(hmac_ctx->libhandle != NULL);
+
+    OSSL_PARAM params[2];
+    {
+        OSSL_PARAM *par = params;
+        *par++          = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, digest_name, strlen(digest_name));
+        *par++          = OSSL_PARAM_construct_end();
     }
 
     BSL_LOG_PLAINTEXT_PTR("using key", hmac_ctx, key_info->raw.ptr, key_info->raw.len);
-    int res = EVP_DigestSignInit(hmac_ctx->libhandle, NULL, sha, NULL, key_info->pkey);
+    int res = EVP_MAC_init(hmac_ctx->libhandle, key_info->raw.ptr, key_info->raw.len, params);
     CHK_PROPERTY(res == 1);
 
-    hmac_ctx->block_size = (size_t)EVP_MD_CTX_block_size(hmac_ctx->libhandle);
+    hmac_ctx->block_size = (size_t)EVP_MAC_CTX_get_block_size(hmac_ctx->libhandle);
     if (hmac_ctx->block_size == 0)
     {
         hmac_ctx->block_size = 1024;
@@ -416,7 +405,8 @@ int BSL_AuthCtx_DigestBuffer(BSL_AuthCtx_t *hmac_ctx, const void *data, size_t d
     CHK_PRECONDITION(data_len <= INT_MAX);
 
     BSL_LOG_PLAINTEXT_PTR("data in", hmac_ctx, data, data_len);
-    int res = EVP_DigestSignUpdate(hmac_ctx->libhandle, data, (int)data_len);
+    int res = EVP_MAC_update(hmac_ctx->libhandle, data, data_len);
+    BSL_LOG_DEBUG("EVP_MAC_update took %zu bytes, return %d", data_len, res);
     CHK_PROPERTY(res == 1);
 
     BSL_CryptoKey_t *key_info = (BSL_CryptoKey_t *)hmac_ctx->keyhandle;
@@ -443,7 +433,9 @@ int BSL_AuthCtx_DigestSeq(BSL_AuthCtx_t *hmac_ctx, BSL_SeqReader_t *reader)
         }
 
         BSL_LOG_PLAINTEXT_PTR("data in", hmac_ctx, hmac_ctx->in_buf.ptr, block_size);
-        EVP_DigestSignUpdate(hmac_ctx->libhandle, hmac_ctx->in_buf.ptr, block_size);
+        int res = EVP_MAC_update(hmac_ctx->libhandle, hmac_ctx->in_buf.ptr, block_size);
+        BSL_LOG_DEBUG("EVP_MAC_update took %zu bytes, return %d", block_size, res);
+        CHK_PROPERTY(res == 1);
 
         key_info->stats.stats[BSL_CRYPTO_KEYSTATS_BYTES_PROCESSED] += block_size;
     }
@@ -457,15 +449,15 @@ int BSL_AuthCtx_Finalize(BSL_AuthCtx_t *hmac_ctx, BSL_Data_t *tag)
     ASSERT_ARG_NONNULL(tag);
 
     // get the needed tag size
-    size_t size = EVP_MD_CTX_get_size(hmac_ctx->libhandle);
+    size_t size = EVP_MAC_CTX_get_mac_size(hmac_ctx->libhandle);
     CHK_PROPERTY(size > 0);
     CHK_PROPERTY(size <= INT_MAX);
     BSL_Data_Resize(tag, size);
 
-    int res = EVP_DigestSignFinal(hmac_ctx->libhandle, tag->ptr, &size);
-    BSL_LOG_DEBUG("EVP_DigestSignFinal gave %zu bytes, return %d", size, res);
-    BSL_LOG_PLAINTEXT_PTR("tag out", hmac_ctx, tag->ptr, size);
+    int res = EVP_MAC_final(hmac_ctx->libhandle, tag->ptr, &size, tag->len);
+    BSL_LOG_DEBUG("EVP_MAC_final gave %zu bytes, return %d", size, res);
     CHK_PROPERTY(res == 1);
+    BSL_LOG_PLAINTEXT_PTR("tag out", hmac_ctx, tag->ptr, size);
 
     return 0;
 }
@@ -475,7 +467,7 @@ void BSL_AuthCtx_Deinit(BSL_AuthCtx_t *hmac_ctx)
     ASSERT_ARG_NONNULL(hmac_ctx);
 
     BSL_Data_Deinit(&hmac_ctx->in_buf);
-    EVP_MD_CTX_free(hmac_ctx->libhandle);
+    EVP_MAC_CTX_free(hmac_ctx->libhandle);
     memset(hmac_ctx, 0, sizeof(BSL_AuthCtx_t));
 }
 

--- a/src/crypto/CryptoInterface.c
+++ b/src/crypto/CryptoInterface.c
@@ -362,7 +362,7 @@ int BSL_AuthCtx_Init(BSL_AuthCtx_t *hmac_ctx, BSL_Crypto_KeyHandle_t keyhandle, 
     int res = EVP_MAC_init(hmac_ctx->libhandle, key_info->raw.ptr, key_info->raw.len, params);
     CHK_PROPERTY(res == 1);
 
-    hmac_ctx->block_size = (size_t)EVP_MAC_CTX_get_block_size(hmac_ctx->libhandle);
+    hmac_ctx->block_size = EVP_MAC_CTX_get_block_size(hmac_ctx->libhandle);
     if (hmac_ctx->block_size == 0)
     {
         hmac_ctx->block_size = 1024;

--- a/src/crypto/CryptoInterface.c
+++ b/src/crypto/CryptoInterface.c
@@ -697,6 +697,7 @@ int BSL_Crypto_GenKey(size_t key_length, BSL_Crypto_KeyHandle_t *key_out)
     BSL_Data_Resize(&new_key->raw, key_length);
     if (rand_bytes_generator(new_key->raw.ptr, (int)new_key->raw.len) != 1)
     {
+        BSL_CryptoKey_Deinit(new_key);
         return BSL_ERR_FAILURE;
     }
 

--- a/src/crypto/CryptoInterface.c
+++ b/src/crypto/CryptoInterface.c
@@ -44,9 +44,7 @@
  */
 typedef struct BSL_CryptoKey_s
 {
-    /// Pointer to OpenSSL PKEY struct (used in hmac ctx)
-    EVP_PKEY *pkey;
-    /// Pointer to raw key information (used in cipher ctx)
+    /// Pointer to raw key information
     BSL_Data_t raw;
     /// Additional parameter dictionary
     BSLB_IdValPairPtrMap_t params;
@@ -58,7 +56,6 @@ static void BSL_CryptoKey_Init(BSL_CryptoKey_t *key)
 {
     ASSERT_ARG_NONNULL(key);
 
-    key->pkey = NULL;
     BSL_Data_Init(&(key->raw));
     BSLB_IdValPairPtrMap_init(key->params);
 
@@ -72,11 +69,6 @@ static void BSL_CryptoKey_Deinit(BSL_CryptoKey_t *key)
 {
     ASSERT_ARG_NONNULL(key);
 
-    if (key->pkey)
-    {
-        EVP_PKEY_free(key->pkey);
-        key->pkey = NULL;
-    }
     BSL_Data_Deinit(&(key->raw));
     BSLB_IdValPairPtrMap_clear(key->params);
 
@@ -237,18 +229,6 @@ int BSL_Crypto_UnwrapKey(BSL_Crypto_KeyHandle_t kek_handle, const BSL_Data_t *wr
 
     EVP_CIPHER_CTX_free(ctx);
     BSL_LOG_PLAINTEXT_PTR("unwrapped key", cek, cek->raw.ptr, cek->raw.len);
-
-    EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HMAC, NULL);
-    res                = EVP_PKEY_keygen_init(pctx);
-    if (res != 1)
-    {
-        BSL_CryptoKey_Deinit(cek);
-        BSL_free(cek);
-        return BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
-    }
-
-    cek->pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, cek->raw.ptr, cek->raw.len);
-    EVP_PKEY_CTX_free(pctx);
 
     *cek_handle = cek;
     return 0;
@@ -717,16 +697,8 @@ int BSL_Crypto_GenKey(size_t key_length, BSL_Crypto_KeyHandle_t *key_out)
     BSL_Data_Resize(&new_key->raw, key_length);
     if (rand_bytes_generator(new_key->raw.ptr, (int)new_key->raw.len) != 1)
     {
-        return -2;
+        return BSL_ERR_FAILURE;
     }
-
-    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HMAC, NULL);
-    CHK_PROPERTY(ctx);
-    int res = EVP_PKEY_keygen_init(ctx);
-    CHK_PROPERTY(res == 1);
-
-    new_key->pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, new_key->raw.ptr, (int)new_key->raw.len);
-    EVP_PKEY_CTX_free(ctx);
 
     *key_out = new_key;
     return BSL_SUCCESS;
@@ -752,8 +724,6 @@ int BSL_Crypto_AddRegistryKey(const BSL_Data_t *keyid, const uint8_t *secret, si
     CHK_PROPERTY(key_ptr != NULL);
     // actual key struct
     BSL_CryptoKey_t *key = BSL_CryptoKeyPtr_ref(key_ptr);
-
-    key->pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, secret, (int)secret_len);
 
     int ecode = 0;
     if ((ecode = BSL_Data_CopyFrom(&key->raw, secret_len, secret)) < 0)

--- a/src/default_sc/BCB_AES_GCM.c
+++ b/src/default_sc/BCB_AES_GCM.c
@@ -290,7 +290,7 @@ int BSLX_BCB_Encrypt(BSLX_BCB_t *bcb_context)
             return BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
         }
 
-        int wrap_result = BSL_Crypto_WrapKey(key_id_handle, cipher_key, &bcb_context->wrapped_key, NULL);
+        int wrap_result = BSL_Crypto_WrapKey(key_id_handle, cipher_key, &bcb_context->wrapped_key);
 
         if (BSL_SUCCESS != wrap_result)
         {

--- a/src/default_sc/BIB_HMAC_SHA2.c
+++ b/src/default_sc/BIB_HMAC_SHA2.c
@@ -324,7 +324,7 @@ int BSLX_BIB_GenHMAC(BSLX_BIB_t *self, const BSL_Data_t *ippt_data)
                 return BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
             }
 
-            int wrap_result = BSL_Crypto_WrapKey(key_id_handle, cipher_key, &self->wrapped_key, NULL);
+            int wrap_result = BSL_Crypto_WrapKey(key_id_handle, cipher_key, &self->wrapped_key);
 
             if (BSL_SUCCESS != wrap_result)
             {

--- a/test/DefaultScUtils.c
+++ b/test/DefaultScUtils.c
@@ -329,10 +329,10 @@ void BSL_TestUtils_SetupDefaultSecurityContext(BSL_LibCtx_t *bsl_lib)
     uint8_t rfc9173A4_BCB_key[] = { 0x71, 0x77, 0x65, 0x72, 0x74, 0x79, 0x75, 0x69, 0x6f, 0x70, 0x61,
                                     0x73, 0x64, 0x66, 0x67, 0x68, 0x71, 0x77, 0x65, 0x72, 0x74, 0x79,
                                     0x75, 0x69, 0x6f, 0x70, 0x61, 0x73, 0x64, 0x66, 0x67, 0x68 };
-    BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A1_KEY, rfc9173A1_key, sizeof(rfc9173A1_key));
-    BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A2_KEY, rfc9173A2_key, sizeof(rfc9173A2_key));
-    BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A3_KEY, rfc9173A3_key, sizeof(rfc9173A3_key));
-    BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A4_BCB_KEY, rfc9173A4_BCB_key, sizeof(rfc9173A4_BCB_key));
+    assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A1_KEY, rfc9173A1_key, sizeof(rfc9173A1_key)));
+    assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A2_KEY, rfc9173A2_key, sizeof(rfc9173A2_key)));
+    assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A3_KEY, rfc9173A3_key, sizeof(rfc9173A3_key)));
+    assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A4_BCB_KEY, rfc9173A4_BCB_key, sizeof(rfc9173A4_BCB_key)));
 
     BSL_SecCtxDesc_t sec_desc;
     int              res;

--- a/test/DefaultScUtils.c
+++ b/test/DefaultScUtils.c
@@ -332,7 +332,8 @@ void BSL_TestUtils_SetupDefaultSecurityContext(BSL_LibCtx_t *bsl_lib)
     assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A1_KEY, rfc9173A1_key, sizeof(rfc9173A1_key)));
     assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A2_KEY, rfc9173A2_key, sizeof(rfc9173A2_key)));
     assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A3_KEY, rfc9173A3_key, sizeof(rfc9173A3_key)));
-    assert(0 == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A4_BCB_KEY, rfc9173A4_BCB_key, sizeof(rfc9173A4_BCB_key)));
+    assert(0
+           == BSL_Crypto_AddRegistryKeyName(RFC9173_EXAMPLE_A4_BCB_KEY, rfc9173A4_BCB_key, sizeof(rfc9173A4_BCB_key)));
 
     BSL_SecCtxDesc_t sec_desc;
     int              res;

--- a/test/test_CryptoInterface.c
+++ b/test/test_CryptoInterface.c
@@ -650,25 +650,25 @@ void test_key_unwrap(const char *kek, const char *expected_cek, const char *wrap
     string_clear(in_text);
 
     // convert bytedata to keyhandles
-    BSL_Crypto_AddRegistryKeyName("kek", kek_data.ptr, kek_data.len);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("kek", kek_data.ptr, kek_data.len));
     void *kek_handle;
-    BSL_Crypto_GetRegistryKeyName("kek", &kek_handle);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_GetRegistryKeyName("kek", &kek_handle));
 
-    BSL_Crypto_AddRegistryKeyName("cek", cek_data.ptr, cek_data.len);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("cek", cek_data.ptr, cek_data.len));
     void *expected_cek_handle;
-    BSL_Crypto_GetRegistryKeyName("cek", &expected_cek_handle);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_GetRegistryKeyName("cek", &expected_cek_handle));
 
     void *cek_handle;
-    BSL_Crypto_UnwrapKey(kek_handle, &wrapped_key_data, &cek_handle);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_UnwrapKey(kek_handle, &wrapped_key_data, &cek_handle));
 
     // test our unwrapped key
     BSL_Data_t wrapped_key1;
-    BSL_Data_InitBuffer(&wrapped_key1, cek_data.len + 8);
-    BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key1);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Data_InitBuffer(&wrapped_key1, cek_data.len + 8));
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key1));
 
     BSL_Data_t wrapped_key2;
-    BSL_Data_InitBuffer(&wrapped_key2, cek_data.len + 8);
-    BSL_Crypto_WrapKey(kek_handle, expected_cek_handle, &wrapped_key2);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Data_InitBuffer(&wrapped_key2, cek_data.len + 8));
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_WrapKey(kek_handle, expected_cek_handle, &wrapped_key2));
 
     TEST_ASSERT_EQUAL_MEMORY(wrapped_key1.ptr, wrapped_key_data.ptr, wrapped_key_data.len);
     TEST_ASSERT_EQUAL_MEMORY(wrapped_key1.ptr, wrapped_key2.ptr, wrapped_key2.len);

--- a/test/test_CryptoInterface.c
+++ b/test/test_CryptoInterface.c
@@ -362,7 +362,7 @@ void test_hmac_in(int input_case, const char *keyid, BSL_CryptoCipherSHAVariant_
             TEST_ABORT();
     }
     int expect_hmac_sz = 0;
-    switch (hmac.SHA_variant)
+    switch (sha_var)
     {
         case BSL_CRYPTO_SHA_256:
             expect_hmac_sz = 32;
@@ -600,10 +600,9 @@ void test_key_wrap(const char *kek, const char *cek, const char *expected)
     void *cek_handle;
     BSL_Crypto_GetRegistryKeyName("cek", &cek_handle);
 
-    void      *wrapped_key_handle;
     BSL_Data_t wrapped_key;
     BSL_Data_InitBuffer(&wrapped_key, cek_data.len + 8);
-    BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key, &wrapped_key_handle);
+    TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key));
 
     TEST_ASSERT_EQUAL_MEMORY(wrapped_key.ptr, expected_data.ptr, wrapped_key.len);
 
@@ -611,7 +610,6 @@ void test_key_wrap(const char *kek, const char *cek, const char *expected)
     BSL_Data_Deinit(&cek_data);
     BSL_Data_Deinit(&expected_data);
     BSL_Data_Deinit(&wrapped_key);
-    BSL_Crypto_ClearGeneratedKeyHandle((void *)wrapped_key_handle);
     BSL_Crypto_RemoveRegistryKeyName("kek");
     BSL_Crypto_RemoveRegistryKeyName("cek");
 }
@@ -664,15 +662,13 @@ void test_key_unwrap(const char *kek, const char *expected_cek, const char *wrap
     BSL_Crypto_UnwrapKey(kek_handle, &wrapped_key_data, &cek_handle);
 
     // test our unwrapped key
-    void      *wrapped_key_handle1;
     BSL_Data_t wrapped_key1;
     BSL_Data_InitBuffer(&wrapped_key1, cek_data.len + 8);
-    BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key1, &wrapped_key_handle1);
+    BSL_Crypto_WrapKey(kek_handle, cek_handle, &wrapped_key1);
 
-    void      *wrapped_key_handle2;
     BSL_Data_t wrapped_key2;
     BSL_Data_InitBuffer(&wrapped_key2, cek_data.len + 8);
-    BSL_Crypto_WrapKey(kek_handle, expected_cek_handle, &wrapped_key2, &wrapped_key_handle2);
+    BSL_Crypto_WrapKey(kek_handle, expected_cek_handle, &wrapped_key2);
 
     TEST_ASSERT_EQUAL_MEMORY(wrapped_key1.ptr, wrapped_key_data.ptr, wrapped_key_data.len);
     TEST_ASSERT_EQUAL_MEMORY(wrapped_key1.ptr, wrapped_key2.ptr, wrapped_key2.len);
@@ -683,8 +679,6 @@ void test_key_unwrap(const char *kek, const char *expected_cek, const char *wrap
     BSL_Data_Deinit(&wrapped_key1);
     BSL_Data_Deinit(&wrapped_key2);
     BSL_Crypto_ClearGeneratedKeyHandle((void *)cek_handle);
-    BSL_Crypto_ClearGeneratedKeyHandle((void *)wrapped_key_handle1);
-    BSL_Crypto_ClearGeneratedKeyHandle((void *)wrapped_key_handle2);
     BSL_Crypto_RemoveRegistryKeyName("kek");
     BSL_Crypto_RemoveRegistryKeyName("cek");
 }

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -313,14 +313,14 @@ void test_sec_source_keywrap(bool wrap, bool bib)
     {
         if (wrap)
         {
-            BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len);
+            TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len));
             BSL_IdValPair_SetTextstr(&bibcontext.opt_test_key, BSLX_BIB_OPT_KEY_ID, "kek_wrap");
             BSL_IdValPair_SetInt64(&bibcontext.opt_use_key_wrap, BSLX_BIB_OPT_USE_KEY_WRAP, 1);
             BSL_Crypto_SetRngGenerator(rfc3394_cek);
         }
         else
         {
-            BSL_Crypto_AddRegistryKeyName("cek_wrap", cek_data.ptr, cek_data.len);
+            TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("cek_wrap", cek_data.ptr, cek_data.len));
             BSL_IdValPair_SetTextstr(&bibcontext.opt_test_key, BSLX_BIB_OPT_KEY_ID, "cek_wrap");
             BSL_IdValPair_SetInt64(&bibcontext.opt_use_key_wrap, BSLX_BIB_OPT_USE_KEY_WRAP, 0);
         }
@@ -350,13 +350,13 @@ void test_sec_source_keywrap(bool wrap, bool bib)
         BSL_Crypto_SetRngGenerator(rfc3394_cek);
         if (wrap)
         {
-            BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len);
+            TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len));
             BSL_IdValPair_SetTextstr(&bcbcontext.opt_test_key_id, BSLX_BCB_OPT_KEY_ID, "kek_wrap");
             BSL_IdValPair_SetInt64(&bcbcontext.opt_use_key_wrap, BSLX_BCB_OPT_USE_KEY_WRAP, 1);
         }
         else
         {
-            BSL_Crypto_AddRegistryKeyName("cek_wrap", cek_data.ptr, cek_data.len);
+            TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("cek_wrap", cek_data.ptr, cek_data.len));
             BSL_IdValPair_SetTextstr(&bcbcontext.opt_test_key_id, BSLX_BCB_OPT_KEY_ID, "cek_wrap");
             BSL_IdValPair_SetInt64(&bcbcontext.opt_use_key_wrap, BSLX_BCB_OPT_USE_KEY_WRAP, 0);
         }
@@ -511,7 +511,7 @@ void test_sec_accept_keyunwrap(bool bib)
     BCBTestContext_Init(&bcbcontext);
     if (bib)
     {
-        BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len);
+        TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len));
         BSL_IdValPair_SetTextstr(&bibcontext.opt_test_key, BSLX_BIB_OPT_KEY_ID, "kek_wrap");
         BSL_IdValPair_SetInt64(&bibcontext.opt_use_key_wrap, BSLX_BIB_OPT_USE_KEY_WRAP, 1);
         BSL_IdValPair_SetInt64(&bibcontext.opt_scope_flags, BSLX_BIB_OPT_SCOPE, 0);
@@ -534,7 +534,7 @@ void test_sec_accept_keyunwrap(bool bib)
     {
         BSL_Crypto_SetRngGenerator(rfc3394_cek);
 
-        BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len);
+        TEST_ASSERT_EQUAL_INT(0, BSL_Crypto_AddRegistryKeyName("kek_wrap", kek_data.ptr, kek_data.len));
         BSL_IdValPair_SetTextstr(&bcbcontext.opt_test_key_id, BSLX_BCB_OPT_KEY_ID, "kek_wrap");
         BSL_IdValPair_SetInt64(&bcbcontext.opt_use_key_wrap, BSLX_BCB_OPT_USE_KEY_WRAP, 1);
         BSL_IdValPair_SetInt64(&bcbcontext.opt_scope_flags, BSLX_BCB_OPT_SCOPE, RFC9173_BCB_AADSCOPEFLAGID_INC_NONE);


### PR DESCRIPTION
This avoids using a deprecated API for BSLv2.

This is a precursor for #230 