### PR TITLE
Use mlib pkgconfig and secondary BSL pkgconfig

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -116,8 +116,9 @@ jobs:
         run: |
           pkg-config --print-provides --print-requires bsl
           mkdir build
-          gcc -c $(pkg-config --cflags bsl) -o build/example.o lib-user-test/main.c
-          gcc $(pkg-config --libs bsl) -o build/example build/example.o
+          PKGS="bsl bsl-sample-pp"
+          gcc -c $(pkg-config --cflags ${PKGS}) -o build/example.o lib-user-test/main.c
+          gcc $(pkg-config --libs ${PKGS}) -o build/example build/example.o
           ./build/example
       - name: Mock BPA tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,12 +199,17 @@ include(GNUInstallDirs)
 if(BUILD_LIB)
     add_subdirectory(src)
 
-    configure_file(pkg/qcbor.pc.in pkg/qcbor.pc @ONLY)
-    configure_file(pkg/bsl.pc.in pkg/bsl.pc @ONLY)
+    file(GLOB PCIN_FILES "pkg/*.pc.in")
+    set(PC_FILES "")
+    foreach(PCIN_FILE ${PCIN_FILES})
+        get_filename_component(PCOUT_FILE ${PCIN_FILE} NAME_WLE)
+        set(PCOUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/pkg/${PCOUT_FILE}")
+        configure_file(${PCIN_FILE} ${PCOUT_FILE} @ONLY)
+        list(APPEND PC_FILES ${PCOUT_FILE})
+    endforeach()
+
     install(
-        FILES
-            "${CMAKE_CURRENT_BINARY_DIR}/pkg/qcbor.pc"
-            "${CMAKE_CURRENT_BINARY_DIR}/pkg/bsl.pc"
+        FILES ${PC_FILES}
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     )
 endif(BUILD_LIB)

--- a/bsl.spec
+++ b/bsl.spec
@@ -121,7 +121,7 @@ install -m644 -D testroot/usr/lib/pkgconfig/m-lib.pc %{buildroot}%{_datadir}/pkg
 %license LICENSE
 %doc README.md
 %{_includedir}/m-lib/
-%{_datadir}/pkgconfig/qcbor.pc
+%{_datadir}/pkgconfig/m-lib.pc
 
 %{_includedir}/qcbor/
 %{_libdir}/pkgconfig/qcbor.pc

--- a/bsl.spec
+++ b/bsl.spec
@@ -97,6 +97,7 @@ do
     install -m644 -D ${FN} %{buildroot}%{_libdir}/${FN}
 done
 popd
+install -m644 -D testroot/usr/lib/pkgconfig/m-lib.pc %{buildroot}%{_datadir}/pkgconfig/m-lib.pc
 
 %cmake_install
 
@@ -120,6 +121,7 @@ popd
 %license LICENSE
 %doc README.md
 %{_includedir}/m-lib/
+%{_datadir}/pkgconfig/qcbor.pc
 
 %{_includedir}/qcbor/
 %{_libdir}/pkgconfig/qcbor.pc

--- a/bsl.spec
+++ b/bsl.spec
@@ -130,6 +130,9 @@ install -m644 -D testroot/usr/lib/pkgconfig/m-lib.pc %{buildroot}%{_datadir}/pkg
 
 %{_includedir}/bsl/
 %{_libdir}/pkgconfig/bsl.pc
+%{_libdir}/pkgconfig/bsl-default-sc.pc
+%{_libdir}/pkgconfig/bsl-cose-sc.pc
+%{_libdir}/pkgconfig/bsl-sample-pp.pc
 %{_libdir}/libbsl_front.so
 %{_libdir}/libbsl_dynamic.so
 %{_libdir}/libbsl_crypto.so

--- a/pkg/bsl-cose-sc.pc.in
+++ b/pkg/bsl-cose-sc.pc.in
@@ -5,5 +5,5 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 Name: bsl-default-sc
 Description: BSL COSE Context provider
 Version: @PROJECT_VERSION@
-Requires: bsl = ${version}
+Requires: bsl
 Libs: -L${libdir} -lbsl_cose_sc

--- a/pkg/bsl-cose-sc.pc.in
+++ b/pkg/bsl-cose-sc.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: bsl-default-sc
+Description: BSL COSE Context provider
+Version: @PROJECT_VERSION@
+Requires: bsl = ${version}
+Libs: -L${libdir} -lbsl_cose_sc

--- a/pkg/bsl-default-sc.pc.in
+++ b/pkg/bsl-default-sc.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: bsl-default-sc
+Description: BSL Default Security Context provider
+Version: @PROJECT_VERSION@
+Requires: bsl = ${version}
+Libs: -L${libdir} -lbsl_default_sc

--- a/pkg/bsl-default-sc.pc.in
+++ b/pkg/bsl-default-sc.pc.in
@@ -5,5 +5,5 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 Name: bsl-default-sc
 Description: BSL Default Security Context provider
 Version: @PROJECT_VERSION@
-Requires: bsl = ${version}
+Requires: bsl
 Libs: -L${libdir} -lbsl_default_sc

--- a/pkg/bsl-sample-pp.pc.in
+++ b/pkg/bsl-sample-pp.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: bsl-sample-pp
+Description: BSL Sample Policy Provider
+Version: @PROJECT_VERSION@
+Requires: bsl = ${version}, bsl-default-sc = ${version}, bsl-cose-sc = ${version}
+Libs: -L${libdir} -lbsl_sample_pp

--- a/pkg/bsl-sample-pp.pc.in
+++ b/pkg/bsl-sample-pp.pc.in
@@ -5,5 +5,5 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 Name: bsl-sample-pp
 Description: BSL Sample Policy Provider
 Version: @PROJECT_VERSION@
-Requires: bsl = ${version}, bsl-default-sc = ${version}, bsl-cose-sc = ${version}
+Requires: bsl, bsl-default-sc, bsl-cose-sc
 Libs: -L${libdir} -lbsl_sample_pp

--- a/pkg/bsl.pc.in
+++ b/pkg/bsl.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
-Name: @PROJECT_NAME@
+Name: bsl
 Description: The Bundle Protocol Security Library (BSL)
 Version: @PROJECT_VERSION@
 Requires: qcbor >= 1.6, m-lib >= 0.8, openssl >= 3.0, jansson >= 2.14

--- a/pkg/bsl.pc.in
+++ b/pkg/bsl.pc.in
@@ -6,6 +6,6 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 Name: @PROJECT_NAME@
 Description: The Bundle Protocol Security Library (BSL)
 Version: @PROJECT_VERSION@
-Requires: qcbor > 1.6, openssl >= 3.0, jansson >= 2.14
-Cflags: -I${includedir}/bsl -I${includedir}/m-lib
+Requires: qcbor >= 1.6, m-lib >= 0.8, openssl >= 3.0, jansson >= 2.14
+Cflags: -I${includedir}/bsl
 Libs: -L${libdir} -lbsl_front -lbsl_dynamic -lbsl_crypto

--- a/pkg/qcbor.pc.in
+++ b/pkg/qcbor.pc.in
@@ -7,3 +7,4 @@ Description: A CBOR encoder/decoder library
 Version: @qcbor_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lqcbor
+Libs.private: -lm


### PR DESCRIPTION
Related to #201 to use upstream provided `m-lib.pc` and copy of upstream not-yet-version-released [`qcbor.pc`](https://github.com/laurencelundblade/QCBOR/blob/master/cmake/qcbor.pc.in).