### PR TITLE
Cleanup and constrain includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -48,14 +48,27 @@ ExperimentalAutoDetectBinPacking: false
 ForEachMacros: []
 IncludeBlocks: Regroup
 IncludeCategories:
+ - Regex: '^["<]bsl/front/'
+   Priority: 20
+   SortPriority: 21
+ - Regex: '^["<]bsl/dynamic/'
+   Priority: 20
+   SortPriority: 22
+ - Regex: '^["<]bsl/(default_sc|cose_sc|sample_pp)/'
+   Priority: 20
+   SortPriority: 23
+ - Regex: '^["<]bsl/mock_bpa/'
+   Priority: 20
+   SortPriority: 24
  - Regex: '^["<]bsl/'
-   Priority: 2
+   Priority: 20
+   SortPriority: 20
  - Regex: '^".*'
-   Priority: 1
+   Priority: 10
  - Regex: '^<(m-|qcbor|openssl/|jansson)'
-   Priority: 3
+   Priority: 30
  - Regex: '^<'
-   Priority: 4
+   Priority: 40
 IncludeIsMainRegex: '$'
 IndentCaseLabels: true
 IndentExternBlock: NoIndent

--- a/.clang-format
+++ b/.clang-format
@@ -46,8 +46,16 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros: []
-IncludeBlocks:   Preserve
-IncludeCategories:  []
+IncludeBlocks: Regroup
+IncludeCategories:
+ - Regex: '^["<]bsl/'
+   Priority: 2
+ - Regex: '^".*'
+   Priority: 1
+ - Regex: '^<(m-|qcbor|openssl/|jansson)'
+   Priority: 3
+ - Regex: '^<'
+   Priority: 4
 IncludeIsMainRegex: '$'
 IndentCaseLabels: true
 IndentExternBlock: NoIndent
@@ -68,7 +76,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  true
-SortIncludes:    false # more strict than cFS
+SortIncludes: CaseInsensitive
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements

--- a/resources/check_format.sh
+++ b/resources/check_format.sh
@@ -35,8 +35,7 @@ echo "Check format from root: $SELFDIR"
 ./resources/apply_format.sh
 ./resources/apply_license.sh
 
-changed=$(git status --porcelain=1)
-if [[ -n "${changed}" ]]; then
+if ! git diff -q; then
   echo "Error: Files changed after formatting:"
   git diff
   exit 1

--- a/src/bsl/BPSecLib_Private.h
+++ b/src/bsl/BPSecLib_Private.h
@@ -34,17 +34,17 @@
 #ifndef BSL_BPSECLIB_PRIVATE_H_
 #define BSL_BPSECLIB_PRIVATE_H_
 
+#include "BPSecLib_Public.h"
+
 #include <inttypes.h>
-#include <stdio.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 #include <syslog.h>
 #include <time.h>
-#include <sys/types.h>
-
-#include "BPSecLib_Public.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/BPSecLib_Public.h
+++ b/src/bsl/BPSecLib_Public.h
@@ -31,16 +31,16 @@
 #ifndef BSL_BPSECLIB_PUBLIC_H_
 #define BSL_BPSECLIB_PUBLIC_H_
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdarg.h>
-#include <time.h>
-
 #include "bsl/BSLConfig.h"
 #include "bsl/front/Data.h"
 #include "bsl/front/SeqReader.h"
 #include "bsl/front/SeqWriter.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/cose_sc/CoseContext.c
+++ b/src/bsl/cose_sc/CoseContext.c
@@ -24,22 +24,23 @@
  * @ingroup cose_sc
  * Implementation of the COSE context @cite draft-ietf-dtn-bpsec-cose.
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include "CoseContext.h"
 
-#include <m-bstring.h>
-#include <m-variant.h>
-#include <m-deque.h>
-#include <m-bptree.h>
+#include "CoseContext_Private.h"
+#include "CoseMsg.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/crypto/CryptoInterface.h"
 #include "bsl/dynamic/CBOR.h"
 
-#include "CoseContext.h"
-#include "CoseContext_Private.h"
-#include "CoseMsg.h"
+#include <m-bptree.h>
+#include <m-bstring.h>
+#include <m-deque.h>
+#include <m-variant.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 /** Acceptable target algorithms for MAC.
  * @note These must be sorted for @c bsearch() to work.

--- a/src/bsl/cose_sc/CoseContext.c
+++ b/src/bsl/cose_sc/CoseContext.c
@@ -33,9 +33,9 @@
 #include <m-deque.h>
 #include <m-bptree.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/crypto/CryptoInterface.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/crypto/CryptoInterface.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include "CoseContext.h"
 #include "CoseContext_Private.h"

--- a/src/bsl/cose_sc/CoseContext.h
+++ b/src/bsl/cose_sc/CoseContext.h
@@ -28,9 +28,9 @@
 #ifndef BSLX_COSECONTEXT_H_
 #define BSLX_COSECONTEXT_H_
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include <m-bptree.h>
 

--- a/src/bsl/cose_sc/CoseContext_Private.h
+++ b/src/bsl/cose_sc/CoseContext_Private.h
@@ -28,7 +28,7 @@
 #ifndef BSLX_COSECONTEXT_PRIVATE_H_
 #define BSLX_COSECONTEXT_PRIVATE_H_
 
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Public.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/cose_sc/CoseMsg.c
+++ b/src/bsl/cose_sc/CoseMsg.c
@@ -25,8 +25,8 @@
  * Implementation of COSE structures @cite rfc9052.
  */
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include "CoseMsg.h"
 

--- a/src/bsl/cose_sc/CoseMsg.c
+++ b/src/bsl/cose_sc/CoseMsg.c
@@ -25,10 +25,10 @@
  * Implementation of COSE structures @cite rfc9052.
  */
 
+#include "CoseMsg.h"
+
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/dynamic/CBOR.h"
-
-#include "CoseMsg.h"
 
 void BSLX_CoseMsg_HdrMapTree_update(BSLX_CoseMsg_HdrMapTree_t base, const BSLX_CoseMsg_HdrMapTree_t addl)
 {

--- a/src/bsl/cose_sc/CoseMsg.h
+++ b/src/bsl/cose_sc/CoseMsg.h
@@ -28,12 +28,13 @@
 #ifndef BSLX_COSEMSG_H_
 #define BSLX_COSEMSG_H_
 
-#include "bsl/front/BSLMemory.h"
 #include "bsl/dynamic/CBOR.h"
 #include "bsl/dynamic/IdValPair.h"
+#include "bsl/front/BSLMemory.h"
+
+#include <m-array.h>
 #include <m-bptree.h>
 #include <m-shared-ptr.h>
-#include <m-array.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/cose_sc/CoseMsg.h
+++ b/src/bsl/cose_sc/CoseMsg.h
@@ -28,9 +28,9 @@
 #ifndef BSLX_COSEMSG_H_
 #define BSLX_COSEMSG_H_
 
+#include "bsl/front/BSLMemory.h"
 #include "bsl/dynamic/CBOR.h"
 #include "bsl/dynamic/IdValPair.h"
-#include "bsl/front/BSLMemory.h"
 
 #include <m-array.h>
 #include <m-bptree.h>

--- a/src/bsl/cose_sc/CoseMsg.h
+++ b/src/bsl/cose_sc/CoseMsg.h
@@ -28,9 +28,9 @@
 #ifndef BSLX_COSEMSG_H_
 #define BSLX_COSEMSG_H_
 
-#include <bsl/front/BSLMemory.h>
-#include <bsl/dynamic/CBOR.h>
-#include <bsl/dynamic/IdValPair.h>
+#include "bsl/front/BSLMemory.h"
+#include "bsl/dynamic/CBOR.h"
+#include "bsl/dynamic/IdValPair.h"
 #include <m-bptree.h>
 #include <m-shared-ptr.h>
 #include <m-array.h>

--- a/src/bsl/crypto/CryptoInterface.c
+++ b/src/bsl/crypto/CryptoInterface.c
@@ -24,18 +24,19 @@
  * @ingroup backend_dyn
  */
 #include "CryptoInterface.h"
-#include "bsl/BPSecLib_Private.h"
-#include "bsl/front/TextUtil.h"
-#include "bsl/dynamic/IdValPair.h"
 
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/IdValPair.h"
+#include "bsl/front/TextUtil.h"
+
+#include <m-bstring.h>
 #include <m-dict.h>
 #include <m-shared-ptr.h>
-#include <m-bstring.h>
 #include <openssl/core_names.h>
-#include <openssl/evp.h>
 #include <openssl/err.h>
-#include <openssl/rand.h>
+#include <openssl/evp.h>
 #include <openssl/kdf.h>
+#include <openssl/rand.h>
 
 #if defined(HAVE_VALGRIND)
 #include <valgrind/memcheck.h>

--- a/src/bsl/crypto/CryptoInterface.c
+++ b/src/bsl/crypto/CryptoInterface.c
@@ -26,8 +26,8 @@
 #include "CryptoInterface.h"
 
 #include "bsl/BPSecLib_Private.h"
-#include "bsl/dynamic/IdValPair.h"
 #include "bsl/front/TextUtil.h"
+#include "bsl/dynamic/IdValPair.h"
 
 #include <m-bstring.h>
 #include <m-dict.h>

--- a/src/bsl/crypto/CryptoInterface.c
+++ b/src/bsl/crypto/CryptoInterface.c
@@ -24,9 +24,9 @@
  * @ingroup backend_dyn
  */
 #include "CryptoInterface.h"
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/front/TextUtil.h>
-#include <bsl/dynamic/IdValPair.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/front/TextUtil.h"
+#include "bsl/dynamic/IdValPair.h"
 
 #include <m-dict.h>
 #include <m-shared-ptr.h>

--- a/src/bsl/crypto/CryptoInterface.h
+++ b/src/bsl/crypto/CryptoInterface.h
@@ -27,13 +27,13 @@
 #ifndef BSL_FRONTEND_CRYPTO_INTERFACE_H_
 #define BSL_FRONTEND_CRYPTO_INTERFACE_H_
 
-#include <stdint.h>
-
+#include "bsl/BPSecLib_Private.h" // TODO replace with Variant.h
 #include "bsl/BSLConfig.h"
 #include "bsl/front/Data.h"
 #include "bsl/front/SeqReader.h"
 #include "bsl/front/SeqWriter.h"
-#include "bsl/BPSecLib_Private.h" // TODO replace with Variant.h
+
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/default_sc/BCB_AES_GCM.c
+++ b/src/bsl/default_sc/BCB_AES_GCM.c
@@ -30,9 +30,9 @@
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_spiffy_decode.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/crypto/CryptoInterface.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/crypto/CryptoInterface.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include "DefaultSecContext.h"
 #include "DefaultSecContext_Private.h"

--- a/src/bsl/default_sc/BCB_AES_GCM.c
+++ b/src/bsl/default_sc/BCB_AES_GCM.c
@@ -25,18 +25,18 @@
  * Contains functionality and data structures to implement BCB using security context in RFC9173.
  *
  */
-#include <stdlib.h>
-
-#include <qcbor/qcbor_encode.h>
-#include <qcbor/qcbor_spiffy_decode.h>
+#include "DefaultSecContext.h"
+#include "DefaultSecContext_Private.h"
+#include "rfc9173.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/crypto/CryptoInterface.h"
 #include "bsl/dynamic/CBOR.h"
 
-#include "DefaultSecContext.h"
-#include "DefaultSecContext_Private.h"
-#include "rfc9173.h"
+#include <qcbor/qcbor_encode.h>
+#include <qcbor/qcbor_spiffy_decode.h>
+
+#include <stdlib.h>
 
 bool BSLX_BCB_Validate(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, BSL_SecOper_t *sec_oper) // NOSONAR
 {

--- a/src/bsl/default_sc/BIB_HMAC_SHA2.c
+++ b/src/bsl/default_sc/BIB_HMAC_SHA2.c
@@ -32,9 +32,9 @@
 #include <sys/types.h>
 #include <time.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/crypto/CryptoInterface.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/crypto/CryptoInterface.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include "DefaultSecContext.h"
 #include "DefaultSecContext_Private.h"

--- a/src/bsl/default_sc/BIB_HMAC_SHA2.c
+++ b/src/bsl/default_sc/BIB_HMAC_SHA2.c
@@ -26,19 +26,20 @@
  * Note the prefix "xdefsc" means "Example Default Security Context".
  */
 
-#include <qcbor/qcbor_encode.h>
-#include <qcbor/qcbor_spiffy_decode.h>
-#include <stdio.h>
-#include <sys/types.h>
-#include <time.h>
+#include "DefaultSecContext.h"
+#include "DefaultSecContext_Private.h"
+#include "rfc9173.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/crypto/CryptoInterface.h"
 #include "bsl/dynamic/CBOR.h"
 
-#include "DefaultSecContext.h"
-#include "DefaultSecContext_Private.h"
-#include "rfc9173.h"
+#include <qcbor/qcbor_encode.h>
+#include <qcbor/qcbor_spiffy_decode.h>
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <time.h>
 
 bool BSLX_BIB_Validate(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, BSL_SecOper_t *sec_oper) // NOSONAR
 {

--- a/src/bsl/default_sc/DefaultSecContext.c
+++ b/src/bsl/default_sc/DefaultSecContext.c
@@ -24,19 +24,20 @@
  * @ingroup default_sc
  * Header for the implementation of an example default security context (RFC 9173).
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include "DefaultSecContext.h"
 
-#include <qcbor/qcbor_encode.h>
-#include <qcbor/qcbor_spiffy_decode.h>
+#include "DefaultSecContext_Private.h"
+#include "rfc9173.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/crypto/CryptoInterface.h"
 
-#include "DefaultSecContext.h"
-#include "DefaultSecContext_Private.h"
-#include "rfc9173.h"
+#include <qcbor/qcbor_encode.h>
+#include <qcbor/qcbor_spiffy_decode.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 void BSLX_EncodeHeader(const BSL_CanonicalBlock_t *block, QCBOREncodeContext *encoder)
 {

--- a/src/bsl/default_sc/DefaultSecContext.c
+++ b/src/bsl/default_sc/DefaultSecContext.c
@@ -31,8 +31,8 @@
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_spiffy_decode.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/crypto/CryptoInterface.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/crypto/CryptoInterface.h"
 
 #include "DefaultSecContext.h"
 #include "DefaultSecContext_Private.h"

--- a/src/bsl/default_sc/DefaultSecContext.h
+++ b/src/bsl/default_sc/DefaultSecContext.h
@@ -28,10 +28,10 @@
 #ifndef BSLX_SECCTXERR_H_
 #define BSLX_SECCTXERR_H_
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 // for option values
-#include <bsl/default_sc/rfc9173.h>
+#include "bsl/default_sc/rfc9173.h"
 
 /// Internal BIB option enumerations
 enum BSLX_BIB_Options_e

--- a/src/bsl/default_sc/DefaultSecContext_Private.h
+++ b/src/bsl/default_sc/DefaultSecContext_Private.h
@@ -32,9 +32,9 @@
 
 #include <qcbor/qcbor_encode.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/crypto/CryptoInterface.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/crypto/CryptoInterface.h"
 
 #include "rfc9173.h"
 

--- a/src/bsl/default_sc/DefaultSecContext_Private.h
+++ b/src/bsl/default_sc/DefaultSecContext_Private.h
@@ -28,15 +28,15 @@
 #ifndef BSLB_DEFAULT_SECURITY_CONTEXT_PRIVATE_H_
 #define BSLB_DEFAULT_SECURITY_CONTEXT_PRIVATE_H_
 
-#include <stdint.h>
-
-#include <qcbor/qcbor_encode.h>
+#include "rfc9173.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BPSecLib_Public.h"
 #include "bsl/crypto/CryptoInterface.h"
 
-#include "rfc9173.h"
+#include <qcbor/qcbor_encode.h>
+
+#include <stdint.h>
 
 /*
  * Convenience struct containing metadata as a block.

--- a/src/bsl/dynamic/AbsSecBlock.c
+++ b/src/bsl/dynamic/AbsSecBlock.c
@@ -26,8 +26,8 @@
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_spiffy_decode.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/front/TextUtil.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/front/TextUtil.h"
 
 #include "AbsSecBlock.h"
 #include "CBOR.h"

--- a/src/bsl/dynamic/AbsSecBlock.c
+++ b/src/bsl/dynamic/AbsSecBlock.c
@@ -23,14 +23,15 @@
  * @brief Concrete implementation of the Abstract Security Block defined in RFC 9172.
  * @ingroup backend_dyn
  */
-#include <qcbor/qcbor_encode.h>
-#include <qcbor/qcbor_spiffy_decode.h>
+#include "AbsSecBlock.h"
+
+#include "CBOR.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/front/TextUtil.h"
 
-#include "AbsSecBlock.h"
-#include "CBOR.h"
+#include <qcbor/qcbor_encode.h>
+#include <qcbor/qcbor_spiffy_decode.h>
 
 void BSL_AbsSecBlock_Target_Init(BSL_AbsSecBlock_Target_t *self)
 {

--- a/src/bsl/dynamic/AbsSecBlock.h
+++ b/src/bsl/dynamic/AbsSecBlock.h
@@ -31,17 +31,17 @@
 #ifndef BSLB_ABSSECBLOCK_IMPL_H_
 #define BSLB_ABSSECBLOCK_IMPL_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
-#include <m-shared-ptr.h>
-#include <m-array.h>
-#include <qcbor/qcbor_encode.h>
-#include <qcbor/qcbor_decode.h>
+#include "IdValPair.h"
 
 #include "bsl/BPSecLib_Public.h"
 
-#include "IdValPair.h"
+#include <m-array.h>
+#include <m-shared-ptr.h>
+#include <qcbor/qcbor_decode.h>
+#include <qcbor/qcbor_encode.h>
+
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/AbsSecBlock.h
+++ b/src/bsl/dynamic/AbsSecBlock.h
@@ -39,7 +39,7 @@
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_decode.h>
 
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Public.h"
 
 #include "IdValPair.h"
 

--- a/src/bsl/dynamic/CBOR.c
+++ b/src/bsl/dynamic/CBOR.c
@@ -24,8 +24,10 @@
  * @brief Definition of CBOR CODEC wrapper functions.
  */
 #include "CBOR.h"
-#include "bsl/front/TextUtil.h"
+
 #include "bsl/BPSecLib_Private.h"
+#include "bsl/front/TextUtil.h"
+
 #include <m-core.h>
 
 int BSL_CBOR_Encode_GetSize(size_t *needlen, BSL_CBOR_Encode_f func, const void *obj)

--- a/src/bsl/dynamic/CBOR.c
+++ b/src/bsl/dynamic/CBOR.c
@@ -24,8 +24,8 @@
  * @brief Definition of CBOR CODEC wrapper functions.
  */
 #include "CBOR.h"
-#include <bsl/front/TextUtil.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/front/TextUtil.h"
+#include "bsl/BPSecLib_Private.h"
 #include <m-core.h>
 
 int BSL_CBOR_Encode_GetSize(size_t *needlen, BSL_CBOR_Encode_f func, const void *obj)

--- a/src/bsl/dynamic/CBOR.h
+++ b/src/bsl/dynamic/CBOR.h
@@ -26,7 +26,7 @@
 #ifndef BSLB_CBOR_H_
 #define BSLB_CBOR_H_
 
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Public.h"
 
 #include <qcbor/qcbor_encode.h>
 #include <qcbor/qcbor_spiffy_decode.h>

--- a/src/bsl/dynamic/HostInterface.c
+++ b/src/bsl/dynamic/HostInterface.c
@@ -23,11 +23,13 @@
  * @brief Implementation of the host BPA and its callback functions.
  * @ingroup backend_dyn
  */
-#include <stdarg.h>
-#include <pthread.h>
-#include <sys/time.h>
-#include "bsl/BPSecLib_Private.h"
 #include "SeqReadWrite.h"
+
+#include "bsl/BPSecLib_Private.h"
+
+#include <pthread.h>
+#include <stdarg.h>
+#include <sys/time.h>
 
 // NOLINTNEXTLINE
 /// Initialized to library default

--- a/src/bsl/dynamic/HostInterface.c
+++ b/src/bsl/dynamic/HostInterface.c
@@ -26,7 +26,7 @@
 #include <stdarg.h>
 #include <pthread.h>
 #include <sys/time.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include "SeqReadWrite.h"
 
 // NOLINTNEXTLINE

--- a/src/bsl/dynamic/IdValPair.h
+++ b/src/bsl/dynamic/IdValPair.h
@@ -56,15 +56,15 @@
 #ifndef BSLB_IDVALPAIR_H_
 #define BSLB_IDVALPAIR_H_
 
-#include <stdint.h>
-
-#include <m-bstring.h>
-#include <m-shared-ptr.h>
-#include <m-array.h>
-#include <m-bptree.h>
-
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/dynamic/CBOR.h"
+
+#include <m-array.h>
+#include <m-bptree.h>
+#include <m-bstring.h>
+#include <m-shared-ptr.h>
+
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/IdValPair.h
+++ b/src/bsl/dynamic/IdValPair.h
@@ -63,8 +63,8 @@
 #include <m-array.h>
 #include <m-bptree.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/CBOR.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/PolicyProvider.c
+++ b/src/bsl/dynamic/PolicyProvider.c
@@ -24,10 +24,10 @@
  * @ingroup backend_dyn
  * @brief Defines interactions with an external Policy Provider.
  */
-#include "bsl/BPSecLib_Private.h"
-
 #include "PublicInterfaceImpl.h"
 #include "SecurityActionSet.h"
+
+#include "bsl/BPSecLib_Private.h"
 
 int BSL_PolicyRegistry_InspectActions(const BSL_LibCtx_t *bsl, BSL_SecurityActionSet_t *output_action_set,
                                       const BSL_BundleRef_t *bundle, BSL_PolicyLocation_e location)

--- a/src/bsl/dynamic/PolicyProvider.c
+++ b/src/bsl/dynamic/PolicyProvider.c
@@ -24,7 +24,7 @@
  * @ingroup backend_dyn
  * @brief Defines interactions with an external Policy Provider.
  */
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "PublicInterfaceImpl.h"
 #include "SecurityActionSet.h"

--- a/src/bsl/dynamic/PublicInterfaceImpl.c
+++ b/src/bsl/dynamic/PublicInterfaceImpl.c
@@ -27,8 +27,8 @@
  */
 #include <inttypes.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 
 #include "PublicInterfaceImpl.h"
 #include "AbsSecBlock.h"

--- a/src/bsl/dynamic/PublicInterfaceImpl.c
+++ b/src/bsl/dynamic/PublicInterfaceImpl.c
@@ -25,15 +25,16 @@
  *
  * @todo MAJOR Complete implementation for ApplySecurity so it can drop blocks or bundles as-needed.
  */
-#include <inttypes.h>
+#include "PublicInterfaceImpl.h"
+
+#include "AbsSecBlock.h"
+#include "CBOR.h"
+#include "SecurityActionSet.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BPSecLib_Public.h"
 
-#include "PublicInterfaceImpl.h"
-#include "AbsSecBlock.h"
-#include "CBOR.h"
-#include "SecurityActionSet.h"
+#include <inttypes.h>
 
 size_t BSL_LibCtx_Sizeof(void)
 {

--- a/src/bsl/dynamic/PublicInterfaceImpl.h
+++ b/src/bsl/dynamic/PublicInterfaceImpl.h
@@ -29,8 +29,8 @@
 #include <m-dict.h>
 #include <m-bptree.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/PublicInterfaceImpl.h
+++ b/src/bsl/dynamic/PublicInterfaceImpl.h
@@ -26,11 +26,11 @@
 #ifndef BSL_CTX_DYN_H_
 #define BSL_CTX_DYN_H_
 
-#include <m-dict.h>
-#include <m-bptree.h>
-
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BPSecLib_Public.h"
+
+#include <m-bptree.h>
+#include <m-dict.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/SecOperation.c
+++ b/src/bsl/dynamic/SecOperation.c
@@ -25,6 +25,7 @@
  * @brief Defines a security operation.
  */
 #include "SecOperation.h"
+
 #include "IdValPair.h"
 
 size_t BSL_SecOper_Sizeof(void)

--- a/src/bsl/dynamic/SecOperation.h
+++ b/src/bsl/dynamic/SecOperation.h
@@ -27,9 +27,11 @@
 #ifndef BSLB_SECOPERATIONS_H_
 #define BSLB_SECOPERATIONS_H_
 
-#include <stdint.h>
-#include "bsl/BPSecLib_Private.h"
 #include "IdValPair.h"
+
+#include "bsl/BPSecLib_Private.h"
+
+#include <stdint.h>
 
 struct BSL_SecOper_s
 {

--- a/src/bsl/dynamic/SecOperation.h
+++ b/src/bsl/dynamic/SecOperation.h
@@ -28,7 +28,7 @@
 #define BSLB_SECOPERATIONS_H_
 
 #include <stdint.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include "IdValPair.h"
 
 struct BSL_SecOper_s

--- a/src/bsl/dynamic/SecurityAction.h
+++ b/src/bsl/dynamic/SecurityAction.h
@@ -20,7 +20,7 @@
  * subcontract 1700763.
  */
 #include <m-array.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include "SecOperation.h"
 
 /// OPLIST for ::BSL_SecOper_s

--- a/src/bsl/dynamic/SecurityAction.h
+++ b/src/bsl/dynamic/SecurityAction.h
@@ -19,9 +19,11 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <m-array.h>
-#include "bsl/BPSecLib_Private.h"
 #include "SecOperation.h"
+
+#include "bsl/BPSecLib_Private.h"
+
+#include <m-array.h>
 
 /// OPLIST for ::BSL_SecOper_s
 #define M_OPL_BSL_SecOper_t()                                                                          \

--- a/src/bsl/dynamic/SecurityActionSet.h
+++ b/src/bsl/dynamic/SecurityActionSet.h
@@ -26,8 +26,9 @@
 #ifndef BSLB_SECACTIONSET_H_
 #define BSLB_SECACTIONSET_H_
 
-#include "bsl/BPSecLib_Private.h"
 #include "SecurityAction.h"
+
+#include "bsl/BPSecLib_Private.h"
 
 /** @struct BSL_SecActionList_t
  * Defines a basic list of ::BSL_SecurityAction_s.

--- a/src/bsl/dynamic/SecurityActionSet.h
+++ b/src/bsl/dynamic/SecurityActionSet.h
@@ -26,7 +26,7 @@
 #ifndef BSLB_SECACTIONSET_H_
 #define BSLB_SECACTIONSET_H_
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include "SecurityAction.h"
 
 /** @struct BSL_SecActionList_t

--- a/src/bsl/dynamic/SecurityContext.c
+++ b/src/bsl/dynamic/SecurityContext.c
@@ -25,7 +25,7 @@
  * @ingroup backend_dyn
  *
  */
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "AbsSecBlock.h"
 #include "CBOR.h"

--- a/src/bsl/dynamic/SecurityContext.c
+++ b/src/bsl/dynamic/SecurityContext.c
@@ -25,13 +25,13 @@
  * @ingroup backend_dyn
  *
  */
-#include "bsl/BPSecLib_Private.h"
-
 #include "AbsSecBlock.h"
 #include "CBOR.h"
 #include "PublicInterfaceImpl.h"
 #include "SecOperation.h"
 #include "SecurityActionSet.h"
+
+#include "bsl/BPSecLib_Private.h"
 
 static int Encode_ASB(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, uint64_t blk_num, const BSL_AbsSecBlock_t *asb)
 {

--- a/src/bsl/dynamic/SeqReadWrite.c
+++ b/src/bsl/dynamic/SeqReadWrite.c
@@ -24,14 +24,14 @@
  * Implementation of flat-buffer sequential access.
  */
 
+#include "SeqReadWrite.h"
+
+#include "bsl/BPSecLib_Private.h"
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "bsl/BPSecLib_Private.h"
-
-#include "SeqReadWrite.h"
 
 void BSL_SeqReader_Destroy(BSL_SeqReader_t *obj)
 {

--- a/src/bsl/dynamic/SeqReadWrite.c
+++ b/src/bsl/dynamic/SeqReadWrite.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "SeqReadWrite.h"
 

--- a/src/bsl/dynamic/SeqReadWrite.h
+++ b/src/bsl/dynamic/SeqReadWrite.h
@@ -26,12 +26,12 @@
 #ifndef BSL_SEQ_DATA_FLAT_H_
 #define BSL_SEQ_DATA_FLAT_H_
 
+#include "bsl/front/SeqReader.h"
+#include "bsl/front/SeqWriter.h"
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-
-#include "bsl/front/SeqReader.h"
-#include "bsl/front/SeqWriter.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/SeqReadWrite.h
+++ b/src/bsl/dynamic/SeqReadWrite.h
@@ -30,8 +30,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include <bsl/front/SeqReader.h>
-#include <bsl/front/SeqWriter.h>
+#include "bsl/front/SeqReader.h"
+#include "bsl/front/SeqWriter.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/dynamic/TelemetryCounters.c
+++ b/src/bsl/dynamic/TelemetryCounters.c
@@ -24,7 +24,7 @@
  * @ingroup backend_dyn
  * @brief Defines interactions with an external Policy Provider.
  */
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "PublicInterfaceImpl.h"
 

--- a/src/bsl/dynamic/TelemetryCounters.c
+++ b/src/bsl/dynamic/TelemetryCounters.c
@@ -24,9 +24,9 @@
  * @ingroup backend_dyn
  * @brief Defines interactions with an external Policy Provider.
  */
-#include "bsl/BPSecLib_Private.h"
-
 #include "PublicInterfaceImpl.h"
+
+#include "bsl/BPSecLib_Private.h"
 
 int BSL_TlmCounters_IncrementCounter(BSL_LibCtx_t *bsl, BSL_TlmCounterIndex_e tlm_index, uint64_t count)
 {

--- a/src/bsl/dynamic/TextUtil.c
+++ b/src/bsl/dynamic/TextUtil.c
@@ -19,8 +19,8 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <bsl/front/TextUtil.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/front/TextUtil.h"
+#include "bsl/BPSecLib_Private.h"
 #include <string.h>
 #include <strings.h>
 #include <inttypes.h>

--- a/src/bsl/dynamic/TextUtil.c
+++ b/src/bsl/dynamic/TextUtil.c
@@ -20,13 +20,15 @@
  * subcontract 1700763.
  */
 #include "bsl/front/TextUtil.h"
+
 #include "bsl/BPSecLib_Private.h"
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <inttypes.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
 
 int BSL_TextUtil_Base16_Encode(BSL_Data_t *out, const BSL_Data_t *in, bool uppercase)
 {

--- a/src/bsl/front/Data.c
+++ b/src/bsl/front/Data.c
@@ -24,7 +24,9 @@
  * Implementation of the data containers for handling variable-sized buffers and ownership.
  */
 #include "Data.h"
+
 #include "bsl/BPSecLib_Private.h"
+
 #include <string.h>
 
 static void bsl_data_int_reset(BSL_Data_t *data)

--- a/src/bsl/front/Data.h
+++ b/src/bsl/front/Data.h
@@ -27,8 +27,8 @@
 #define BSL_DATA_H_
 
 #include <stdbool.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/front/SeqReader.h
+++ b/src/bsl/front/SeqReader.h
@@ -26,8 +26,8 @@
 #ifndef BSL_SEQREADER_H_
 #define BSL_SEQREADER_H_
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/front/SeqWriter.h
+++ b/src/bsl/front/SeqWriter.h
@@ -26,8 +26,9 @@
 #ifndef BSL_SEQWRITER_H_
 #define BSL_SEQWRITER_H_
 
-#include <stdint.h>
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/front/TextUtil.h
+++ b/src/bsl/front/TextUtil.h
@@ -27,6 +27,7 @@
 #define BSLB_TEXTUTIL_H_
 
 #include "Data.h"
+
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/src/bsl/mock_bpa/MockBPA.h
+++ b/src/bsl/mock_bpa/MockBPA.h
@@ -22,11 +22,11 @@
 #ifndef _BSL_MockBPA_MockBPA_H_
 #define _BSL_MockBPA_MockBPA_H_
 
+#include "agent.h"
 #include "crc.h"
-#include "encode.h"
 #include "decode.h"
 #include "eidpat.h"
+#include "encode.h"
 #include "log.h"
-#include "agent.h"
 
 #endif //_BSL_MockBPA_MockBPA_H_

--- a/src/bsl/mock_bpa/agent.c
+++ b/src/bsl/mock_bpa/agent.c
@@ -34,10 +34,10 @@
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BPSecLib_Public.h"
+#include "bsl/dynamic/SeqReadWrite.h"
 #include "bsl/cose_sc/CoseContext.h"
 #include "bsl/default_sc/DefaultSecContext.h"
 #include "bsl/default_sc/rfc9173.h"
-#include "bsl/dynamic/SeqReadWrite.h"
 #include "bsl/sample_pp/SamplePolicyProvider.h"
 
 #include <errno.h>

--- a/src/bsl/mock_bpa/agent.c
+++ b/src/bsl/mock_bpa/agent.c
@@ -24,23 +24,26 @@
  * Definitions for Agent initialization.
  * @ingroup mock_bpa
  */
-#include "bsl/BPSecLib_Public.h"
+#include "agent.h"
+
+#include "decode.h"
+#include "eid.h"
+#include "eidpat.h"
+#include "encode.h"
+#include "log.h"
+
 #include "bsl/BPSecLib_Private.h"
-#include "bsl/dynamic/SeqReadWrite.h"
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/cose_sc/CoseContext.h"
 #include "bsl/default_sc/DefaultSecContext.h"
 #include "bsl/default_sc/rfc9173.h"
-#include "bsl/cose_sc/CoseContext.h"
+#include "bsl/dynamic/SeqReadWrite.h"
 #include "bsl/sample_pp/SamplePolicyProvider.h"
+
 #include <errno.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
-#include "agent.h"
-#include "log.h"
-#include "eid.h"
-#include "eidpat.h"
-#include "encode.h"
-#include "decode.h"
 
 static const char *sec_src_envar = "BSL_TEST_LOCAL_IPN_EID";
 

--- a/src/bsl/mock_bpa/agent.c
+++ b/src/bsl/mock_bpa/agent.c
@@ -24,13 +24,13 @@
  * Definitions for Agent initialization.
  * @ingroup mock_bpa
  */
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/dynamic/SeqReadWrite.h>
-#include <bsl/default_sc/DefaultSecContext.h>
-#include <bsl/default_sc/rfc9173.h>
-#include <bsl/cose_sc/CoseContext.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/SeqReadWrite.h"
+#include "bsl/default_sc/DefaultSecContext.h"
+#include "bsl/default_sc/rfc9173.h"
+#include "bsl/cose_sc/CoseContext.h"
+#include "bsl/sample_pp/SamplePolicyProvider.h"
 #include <errno.h>
 #include <netinet/in.h>
 #include <poll.h>

--- a/src/bsl/mock_bpa/agent.h
+++ b/src/bsl/mock_bpa/agent.h
@@ -31,9 +31,9 @@
 
 #include "ctr.h"
 
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/sample_pp/SamplePolicyProvider.h"
 
 #include <m-atomic.h>
 #include <m-shared-ptr.h>

--- a/src/bsl/mock_bpa/agent.h
+++ b/src/bsl/mock_bpa/agent.h
@@ -27,22 +27,21 @@
 #ifndef BSL_MOCK_BPA_AGENT_H_
 #define BSL_MOCK_BPA_AGENT_H_
 
-#include <netinet/in.h>
-
 #include "ctr.h"
 
-#include "bsl/BPSecLib_Public.h"
 #include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 #include "bsl/sample_pp/SamplePolicyProvider.h"
 
 #include <m-atomic.h>
-#include <m-shared-ptr.h>
 #include <m-buffer.h>
+#include <m-shared-ptr.h>
 #include <m-string.h>
 
 #include <arpa/inet.h>
-#include <pthread.h>
 #include <inttypes.h>
+#include <netinet/in.h>
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/bundle.h
+++ b/src/bsl/mock_bpa/bundle.h
@@ -30,8 +30,8 @@
 #include "eid.h"
 
 #include <m-algo.h>
-#include <m-deque.h>
 #include <m-bptree.h>
+#include <m-deque.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/crc.c
+++ b/src/bsl/mock_bpa/crc.c
@@ -28,7 +28,7 @@
 #include "crc.h"
 #include <arpa/inet.h>
 #include <inttypes.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 static void mock_bpa_crc_crc16_init(void *state)
 {

--- a/src/bsl/mock_bpa/crc.c
+++ b/src/bsl/mock_bpa/crc.c
@@ -26,9 +26,11 @@
  */
 
 #include "crc.h"
+
+#include "bsl/BPSecLib_Private.h"
+
 #include <arpa/inet.h>
 #include <inttypes.h>
-#include "bsl/BPSecLib_Private.h"
 
 static void mock_bpa_crc_crc16_init(void *state)
 {

--- a/src/bsl/mock_bpa/crc.h
+++ b/src/bsl/mock_bpa/crc.h
@@ -28,7 +28,9 @@
 #define BSL_MOCK_BPA_CRC_H_
 
 #include "bsl/BPSecLib_Public.h"
+
 #include <qcbor/UsefulBuf.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/bsl/mock_bpa/crc.h
+++ b/src/bsl/mock_bpa/crc.h
@@ -27,7 +27,7 @@
 #ifndef BSL_MOCK_BPA_CRC_H_
 #define BSL_MOCK_BPA_CRC_H_
 
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Public.h"
 #include <qcbor/UsefulBuf.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/bsl/mock_bpa/ctr.c
+++ b/src/bsl/mock_bpa/ctr.c
@@ -23,12 +23,13 @@
  * @ingroup mock_bpa
  * Container structs for BPv7 data.
  */
-#include "bsl/BPSecLib_Private.h"
-#include "bsl/dynamic/CBOR.h"
-
 #include "ctr.h"
+
 #include "decode.h"
 #include "encode.h"
+
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/CBOR.h"
 
 void mock_bpa_ctr_init(mock_bpa_ctr_t *ctr)
 {

--- a/src/bsl/mock_bpa/ctr.c
+++ b/src/bsl/mock_bpa/ctr.c
@@ -23,8 +23,8 @@
  * @ingroup mock_bpa
  * Container structs for BPv7 data.
  */
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/dynamic/CBOR.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/CBOR.h"
 
 #include "ctr.h"
 #include "decode.h"

--- a/src/bsl/mock_bpa/ctr.h
+++ b/src/bsl/mock_bpa/ctr.h
@@ -27,8 +27,8 @@
 #define BSL_MOCK_BPA_CTR_H_
 
 #include "bundle.h"
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 
 #include <m-core.h>
 

--- a/src/bsl/mock_bpa/ctr.h
+++ b/src/bsl/mock_bpa/ctr.h
@@ -27,6 +27,7 @@
 #define BSL_MOCK_BPA_CTR_H_
 
 #include "bundle.h"
+
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BPSecLib_Public.h"
 

--- a/src/bsl/mock_bpa/decode.c
+++ b/src/bsl/mock_bpa/decode.c
@@ -29,8 +29,8 @@
 #include "decode.h"
 #include "agent.h"
 #include "crc.h"
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/BPSecLib_Private.h"
 
 #include <qcbor/qcbor_spiffy_decode.h>
 

--- a/src/bsl/mock_bpa/decode.c
+++ b/src/bsl/mock_bpa/decode.c
@@ -24,15 +24,17 @@
  * Definitions for bundle and block decoding.
  * @ingroup mock_bpa
  */
-#include <netinet/in.h>
-
 #include "decode.h"
+
 #include "agent.h"
 #include "crc.h"
-#include "bsl/BPSecLib_Public.h"
+
 #include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
 
 #include <qcbor/qcbor_spiffy_decode.h>
+
+#include <netinet/in.h>
 
 int bsl_mock_decode_eid(const BSL_Data_t *encoded_bytes, BSL_HostEID_t *eid)
 {

--- a/src/bsl/mock_bpa/decode.h
+++ b/src/bsl/mock_bpa/decode.h
@@ -27,8 +27,9 @@
 #ifndef BSL_MOCK_BPA_DECODE_H_
 #define BSL_MOCK_BPA_DECODE_H_
 
-#include "eid.h"
 #include "bundle.h"
+#include "eid.h"
+
 #include <qcbor/qcbor_decode.h>
 
 #ifdef __cplusplus

--- a/src/bsl/mock_bpa/eid.c
+++ b/src/bsl/mock_bpa/eid.c
@@ -25,8 +25,8 @@
  * Definitions for EID handling.
  */
 #include "eid.h"
-#include <bsl/BSLConfig.h>
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BSLConfig.h"
+#include "bsl/BPSecLib_Private.h"
 
 #include <string.h>
 #include <strings.h>

--- a/src/bsl/mock_bpa/eid.c
+++ b/src/bsl/mock_bpa/eid.c
@@ -25,12 +25,13 @@
  * Definitions for EID handling.
  */
 #include "eid.h"
-#include "bsl/BSLConfig.h"
-#include "bsl/BPSecLib_Private.h"
 
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BSLConfig.h"
+
+#include <stdio.h>
 #include <string.h>
 #include <strings.h>
-#include <stdio.h>
 #include <sys/types.h>
 
 void bsl_mock_eid_init(bsl_mock_eid_t *eid)

--- a/src/bsl/mock_bpa/eid.h
+++ b/src/bsl/mock_bpa/eid.h
@@ -27,10 +27,11 @@
 #ifndef BSL_MOCK_BPA_EID_H_
 #define BSL_MOCK_BPA_EID_H_
 
-#include <inttypes.h>
+#include "bsl/BPSecLib_Private.h"
+
 #include <m-string.h>
 
-#include "bsl/BPSecLib_Private.h"
+#include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/eid.h
+++ b/src/bsl/mock_bpa/eid.h
@@ -30,7 +30,7 @@
 #include <inttypes.h>
 #include <m-string.h>
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/eidpat.c
+++ b/src/bsl/mock_bpa/eidpat.c
@@ -20,7 +20,7 @@
  * subcontract 1700763.
  */
 #include "eidpat.h"
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include <strings.h>
 
 int bsl_eidpat_numrange_seg_cmp(const bsl_eidpat_numrange_seg_t *left, const bsl_eidpat_numrange_seg_t *right)

--- a/src/bsl/mock_bpa/eidpat.c
+++ b/src/bsl/mock_bpa/eidpat.c
@@ -20,7 +20,9 @@
  * subcontract 1700763.
  */
 #include "eidpat.h"
+
 #include "bsl/BPSecLib_Private.h"
+
 #include <strings.h>
 
 int bsl_eidpat_numrange_seg_cmp(const bsl_eidpat_numrange_seg_t *left, const bsl_eidpat_numrange_seg_t *right)

--- a/src/bsl/mock_bpa/eidpat.h
+++ b/src/bsl/mock_bpa/eidpat.h
@@ -28,13 +28,14 @@
 #ifndef BSL_MOCK_BPA_EIDPAT_H_
 #define BSL_MOCK_BPA_EIDPAT_H_
 
-#include <inttypes.h>
-#include <m-bptree.h>
-#include <m-deque.h>
+#include "eid.h"
 
 #include "bsl/BPSecLib_Private.h"
 
-#include "eid.h"
+#include <m-bptree.h>
+#include <m-deque.h>
+
+#include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/eidpat.h
+++ b/src/bsl/mock_bpa/eidpat.h
@@ -32,7 +32,7 @@
 #include <m-bptree.h>
 #include <m-deque.h>
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "eid.h"
 

--- a/src/bsl/mock_bpa/encode.c
+++ b/src/bsl/mock_bpa/encode.c
@@ -24,13 +24,14 @@
  * Definitions for bundle and block encoding.
  * @ingroup mock_bpa
  */
-#include <netinet/in.h>
+#include "encode.h"
+
+#include "agent.h"
+#include "crc.h"
 
 #include "bsl/BPSecLib_Private.h"
 
-#include "encode.h"
-#include "agent.h"
-#include "crc.h"
+#include <netinet/in.h>
 
 /// Match ::BSL_CBOR_Encode_f signature.
 static int bsl_mock_encode_eid_internal(QCBOREncodeContext *enc, const bsl_mock_eid_t *obj)

--- a/src/bsl/mock_bpa/encode.c
+++ b/src/bsl/mock_bpa/encode.c
@@ -26,7 +26,7 @@
  */
 #include <netinet/in.h>
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 
 #include "encode.h"
 #include "agent.h"

--- a/src/bsl/mock_bpa/encode.h
+++ b/src/bsl/mock_bpa/encode.h
@@ -27,8 +27,9 @@
 #ifndef BSL_MOCK_BPA_ENCODE_H_
 #define BSL_MOCK_BPA_ENCODE_H_
 
-#include "eid.h"
 #include "bundle.h"
+#include "eid.h"
+
 #include <qcbor/qcbor_encode.h>
 
 #ifdef __cplusplus

--- a/src/bsl/mock_bpa/key_registry.c
+++ b/src/bsl/mock_bpa/key_registry.c
@@ -25,9 +25,9 @@
  */
 
 #include "key_registry.h"
-#include <bsl/front/TextUtil.h>
-#include <bsl/dynamic/CBOR.h>
-#include <bsl/cose_sc/CoseMsg.h>
+#include "bsl/front/TextUtil.h"
+#include "bsl/dynamic/CBOR.h"
+#include "bsl/cose_sc/CoseMsg.h"
 #include <m-string.h>
 #include <jansson.h>
 #include <fcntl.h>

--- a/src/bsl/mock_bpa/key_registry.c
+++ b/src/bsl/mock_bpa/key_registry.c
@@ -26,9 +26,9 @@
 
 #include "key_registry.h"
 
-#include "bsl/cose_sc/CoseMsg.h"
-#include "bsl/dynamic/CBOR.h"
 #include "bsl/front/TextUtil.h"
+#include "bsl/dynamic/CBOR.h"
+#include "bsl/cose_sc/CoseMsg.h"
 
 #include <jansson.h>
 #include <m-string.h>

--- a/src/bsl/mock_bpa/key_registry.c
+++ b/src/bsl/mock_bpa/key_registry.c
@@ -25,15 +25,18 @@
  */
 
 #include "key_registry.h"
-#include "bsl/front/TextUtil.h"
-#include "bsl/dynamic/CBOR.h"
+
 #include "bsl/cose_sc/CoseMsg.h"
-#include <m-string.h>
+#include "bsl/dynamic/CBOR.h"
+#include "bsl/front/TextUtil.h"
+
 #include <jansson.h>
+#include <m-string.h>
+
 #include <fcntl.h>
-#include <unistd.h>
-#include <sys/stat.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 int mock_bpa_key_registry_init_jwk(int fd)
 {

--- a/src/bsl/mock_bpa/key_registry.h
+++ b/src/bsl/mock_bpa/key_registry.h
@@ -27,9 +27,9 @@
 #ifndef BSL_MOCK_BPA_KEY_REGISTRY_H_
 #define BSL_MOCK_BPA_KEY_REGISTRY_H_
 
-#include <inttypes.h>
-
 #include "bsl/crypto/CryptoInterface.h"
+
+#include <inttypes.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/key_registry.h
+++ b/src/bsl/mock_bpa/key_registry.h
@@ -29,7 +29,7 @@
 
 #include <inttypes.h>
 
-#include <bsl/crypto/CryptoInterface.h>
+#include "bsl/crypto/CryptoInterface.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/mock_bpa/log.c
+++ b/src/bsl/mock_bpa/log.c
@@ -26,8 +26,8 @@
  * safety of event sources.
  */
 #include "log.h"
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BSLConfig.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BSLConfig.h"
 
 #include <pthread.h>
 #include <stdarg.h>

--- a/src/bsl/mock_bpa/log.c
+++ b/src/bsl/mock_bpa/log.c
@@ -26,8 +26,14 @@
  * safety of event sources.
  */
 #include "log.h"
+
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/BSLConfig.h"
+
+#include <m-atomic.h>
+#include <m-buffer.h>
+#include <m-shared-ptr.h>
+#include <m-string.h>
 
 #include <pthread.h>
 #include <stdarg.h>
@@ -35,11 +41,6 @@
 #include <strings.h>
 #include <syslog.h>
 #include <time.h>
-
-#include <m-shared-ptr.h>
-#include <m-buffer.h>
-#include <m-string.h>
-#include <m-atomic.h>
 
 /// Number of events to buffer to I/O thread
 #define MOCK_BPA_LOG_QUEUE_SIZE 100

--- a/src/bsl/mock_bpa/log.h
+++ b/src/bsl/mock_bpa/log.h
@@ -27,8 +27,8 @@
 #ifndef BSL_MOCK_BPA_LOG_H_
 #define BSL_MOCK_BPA_LOG_H_
 
-#include <stdbool.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <time.h>
 
 #ifdef __cplusplus

--- a/src/bsl/mock_bpa/mock_bpa.c
+++ b/src/bsl/mock_bpa/mock_bpa.c
@@ -24,6 +24,15 @@
  * This is the main entry for a mock BPA daemon that communicates through
  * unix domain sockets.
  */
+#include "agent.h"
+#include "key_registry.h"
+#include "log.h"
+
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/crypto/CryptoInterface.h"
+#include "bsl/sample_pp/PolicyParser.h"
+
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -32,15 +41,6 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-
-#include "bsl/BPSecLib_Private.h"
-#include "bsl/BPSecLib_Public.h"
-#include "bsl/crypto/CryptoInterface.h"
-#include "bsl/sample_pp/PolicyParser.h"
-
-#include "agent.h"
-#include "log.h"
-#include "key_registry.h"
 
 // Configuration
 static BSL_HostEID_t app_eid;

--- a/src/bsl/mock_bpa/mock_bpa.c
+++ b/src/bsl/mock_bpa/mock_bpa.c
@@ -33,10 +33,10 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/BPSecLib_Public.h>
-#include <bsl/crypto/CryptoInterface.h>
-#include <bsl/sample_pp/PolicyParser.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/BPSecLib_Public.h"
+#include "bsl/crypto/CryptoInterface.h"
+#include "bsl/sample_pp/PolicyParser.h"
 
 #include "agent.h"
 #include "log.h"

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -21,9 +21,9 @@
  */
 #include "PolicyParser.h"
 
+#include "bsl/front/TextUtil.h"
 #include "bsl/cose_sc/CoseContext.h"
 #include "bsl/default_sc/DefaultSecContext.h"
-#include "bsl/front/TextUtil.h"
 
 #include <errno.h>
 #include <strings.h>

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -20,9 +20,9 @@
  * subcontract 1700763.
  */
 #include "PolicyParser.h"
-#include <bsl/front/TextUtil.h>
-#include <bsl/default_sc/DefaultSecContext.h>
-#include <bsl/cose_sc/CoseContext.h>
+#include "bsl/front/TextUtil.h"
+#include "bsl/default_sc/DefaultSecContext.h"
+#include "bsl/cose_sc/CoseContext.h"
 #include <strings.h>
 #include <errno.h>
 

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -20,11 +20,13 @@
  * subcontract 1700763.
  */
 #include "PolicyParser.h"
-#include "bsl/front/TextUtil.h"
-#include "bsl/default_sc/DefaultSecContext.h"
+
 #include "bsl/cose_sc/CoseContext.h"
-#include <strings.h>
+#include "bsl/default_sc/DefaultSecContext.h"
+#include "bsl/front/TextUtil.h"
+
 #include <errno.h>
+#include <strings.h>
 
 /** Read a text value as long integer.
  * The entire text must be consumed to be valid.

--- a/src/bsl/sample_pp/PolicyParser.h
+++ b/src/bsl/sample_pp/PolicyParser.h
@@ -29,14 +29,15 @@
 #ifndef BSLP_POLICY_PARSER_H_
 #define BSLP_POLICY_PARSER_H_
 
-#include <inttypes.h>
-#include <stdio.h>
-#include <jansson.h>
+#include "SamplePolicyProvider.h"
 
 #include "bsl/BPSecLib_Private.h"
 #include "bsl/default_sc/rfc9173.h"
 
-#include "SamplePolicyProvider.h"
+#include <jansson.h>
+
+#include <inttypes.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/sample_pp/PolicyParser.h
+++ b/src/bsl/sample_pp/PolicyParser.h
@@ -33,8 +33,8 @@
 #include <stdio.h>
 #include <jansson.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/default_sc/rfc9173.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/default_sc/rfc9173.h"
 
 #include "SamplePolicyProvider.h"
 

--- a/src/bsl/sample_pp/SamplePolicyProvider.c
+++ b/src/bsl/sample_pp/SamplePolicyProvider.c
@@ -25,14 +25,16 @@
  * @brief Local implementation of locally-defined data structures.
  * @ingroup example_pp
  */
+#include "SamplePolicyProvider.h"
+
+#include "bsl/BPSecLib_Private.h"
+
+#include <m-array.h>
+
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#include <m-array.h>
-
-#include "bsl/BPSecLib_Private.h"
-#include "SamplePolicyProvider.h"
 
 /** @struct BSLP_SecOperPtrList_t
  * Defines a basic list of ::BSL_SecOper_s pointers.

--- a/src/bsl/sample_pp/SamplePolicyProvider.c
+++ b/src/bsl/sample_pp/SamplePolicyProvider.c
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 #include <m-array.h>
 
-#include <bsl/BPSecLib_Private.h>
+#include "bsl/BPSecLib_Private.h"
 #include "SamplePolicyProvider.h"
 
 /** @struct BSLP_SecOperPtrList_t

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -28,14 +28,14 @@
 #ifndef BSLP_SAMPLE_POLICY_PROVIDER_H
 #define BSLP_SAMPLE_POLICY_PROVIDER_H
 
-#include <stdint.h>
-#include <pthread.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/IdValPair.h"
 
 #include <m-array.h>
 #include <m-string.h>
 
-#include "bsl/BPSecLib_Private.h"
-#include "bsl/dynamic/IdValPair.h"
+#include <pthread.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -34,8 +34,8 @@
 #include <m-array.h>
 #include <m-string.h>
 
-#include <bsl/BPSecLib_Private.h>
-#include <bsl/dynamic/IdValPair.h>
+#include "bsl/BPSecLib_Private.h"
+#include "bsl/dynamic/IdValPair.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/DefaultScUtils.c
+++ b/test/DefaultScUtils.c
@@ -24,12 +24,12 @@
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/dynamic/SeqReadWrite.h>
-#include <bsl/mock_bpa/MockBPA.h>
+#include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
 #include <m-string.h>
 

--- a/test/DefaultScUtils.c
+++ b/test/DefaultScUtils.c
@@ -20,21 +20,20 @@
  * subcontract 1700763.
  */
 #undef NDEBUG // force assertions
-#include <assert.h>
-
-#include <m-string.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/mock_bpa/MockBPA.h>
-
+#include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/dynamic/SeqReadWrite.h>
+#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
-#include <bsl/default_sc/DefaultSecContext.h>
 
-#include "DefaultScUtils.h"
+#include <m-string.h>
+
+#include <assert.h>
 
 #define quick_data(field, tgt) BSL_Data_InitView(&(field), sizeof(tgt), (BSL_DataPtr_t)(tgt))
 

--- a/test/DefaultScUtils.h
+++ b/test/DefaultScUtils.h
@@ -22,16 +22,16 @@
 #ifndef _BSL_DEFAULTSCUTILS_H_
 #define _BSL_DEFAULTSCUTILS_H_
 
-#include <m-string.h>
+#include "TestUtils.h"
 
 #include <bsl/crypto/CryptoInterface.h>
+#include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/dynamic/SecOperation.h>
-#include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/mock_bpa/ctr.h>
 
-#include "TestUtils.h"
+#include <m-string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/TestUtils.c
+++ b/test/TestUtils.c
@@ -24,12 +24,12 @@
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
+#include <bsl/front/TextUtil.h>
 #include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/dynamic/SeqReadWrite.h>
-#include <bsl/front/TextUtil.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
 #include <m-string.h>
 

--- a/test/TestUtils.c
+++ b/test/TestUtils.c
@@ -20,21 +20,20 @@
  * subcontract 1700763.
  */
 #undef NDEBUG // force assertions
-#include <assert.h>
-
-#include <m-string.h>
+#include "TestUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/front/TextUtil.h>
-#include <bsl/mock_bpa/MockBPA.h>
-
 #include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/dynamic/SeqReadWrite.h>
+#include <bsl/front/TextUtil.h>
+#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
 
-#include "TestUtils.h"
+#include <m-string.h>
+
+#include <assert.h>
 
 int BSL_TestContext_Init(BSL_TestContext_t *ctx)
 {

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -22,13 +22,13 @@
 #ifndef _BSL_TESTUTILS_H_
 #define _BSL_TESTUTILS_H_
 
-#include <m-string.h>
-
+#include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/dynamic/SecOperation.h>
-#include <bsl/dynamic/IdValPair.h>
 #include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/mock_bpa/ctr.h>
+
+#include <m-string.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/fuzz_CoseMsg_Encrypt0_cbor.cpp
+++ b/test/fuzz_CoseMsg_Encrypt0_cbor.cpp
@@ -25,8 +25,8 @@
  */
 #include "TestUtils.h"
 
-#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <cinttypes>

--- a/test/fuzz_CoseMsg_Encrypt0_cbor.cpp
+++ b/test/fuzz_CoseMsg_Encrypt0_cbor.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the COSE Context result decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
+
 #include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv);

--- a/test/fuzz_CoseMsg_Encrypt_cbor.cpp
+++ b/test/fuzz_CoseMsg_Encrypt_cbor.cpp
@@ -25,8 +25,8 @@
  */
 #include "TestUtils.h"
 
-#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <cinttypes>

--- a/test/fuzz_CoseMsg_Encrypt_cbor.cpp
+++ b/test/fuzz_CoseMsg_Encrypt_cbor.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the COSE Context result decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
+
 #include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv);

--- a/test/fuzz_CoseMsg_Mac0_cbor.cpp
+++ b/test/fuzz_CoseMsg_Mac0_cbor.cpp
@@ -25,8 +25,8 @@
  */
 #include "TestUtils.h"
 
-#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <cinttypes>

--- a/test/fuzz_CoseMsg_Mac0_cbor.cpp
+++ b/test/fuzz_CoseMsg_Mac0_cbor.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the COSE Context result decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
+
 #include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_CoseMsg_Mac_cbor.cpp
+++ b/test/fuzz_CoseMsg_Mac_cbor.cpp
@@ -25,8 +25,8 @@
  */
 #include "TestUtils.h"
 
-#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <cinttypes>

--- a/test/fuzz_CoseMsg_Mac_cbor.cpp
+++ b/test/fuzz_CoseMsg_Mac_cbor.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the COSE Context result decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
+
 #include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv);

--- a/test/fuzz_dynamic_asb_cbor.cpp
+++ b/test/fuzz_dynamic_asb_cbor.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the BPSec ASB decoding from CBOR.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
+
 #include <bsl/dynamic/AbsSecBlock.h>
 #include <bsl/dynamic/CBOR.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_bpv7_cbor.cpp
+++ b/test/fuzz_mock_bpa_bpv7_cbor.cpp
@@ -24,7 +24,9 @@
  * @brief Fuzz the BPv7 bundle decoding from CBOR.
  */
 #include "TestUtils.h"
+
 #include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_eid_cbor.cpp
+++ b/test/fuzz_mock_bpa_eid_cbor.cpp
@@ -24,7 +24,9 @@
  * @brief Fuzz the BPv7 EID decoding from CBOR.
  */
 #include "TestUtils.h"
+
 #include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_eid_uri.cpp
+++ b/test/fuzz_mock_bpa_eid_uri.cpp
@@ -24,9 +24,12 @@
  * @brief Fuzz the BPv7 EID decoding from URI.
  */
 #include "TestUtils.h"
+
 #include <bsl/mock_bpa/MockBPA.h>
+
 #include <m-bstring.h>
 #include <m-string.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_eidpat_text.cpp
+++ b/test/fuzz_mock_bpa_eidpat_text.cpp
@@ -24,9 +24,12 @@
  * @brief Fuzz the BPv7 EID Pattern decoding from text.
  */
 #include "TestUtils.h"
+
 #include <bsl/mock_bpa/MockBPA.h>
+
 #include <m-bstring.h>
 #include <m-string.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_keyregistry_cosekey.cpp
+++ b/test/fuzz_mock_bpa_keyregistry_cosekey.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the simplified @c COSE_KeySet file decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
-#include <bsl/mock_bpa/key_registry.h>
+
 #include <bsl/crypto/CryptoInterface.h>
+#include <bsl/mock_bpa/key_registry.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/fuzz_mock_bpa_keyregistry_jwk.cpp
+++ b/test/fuzz_mock_bpa_keyregistry_jwk.cpp
@@ -24,9 +24,11 @@
  * @brief Fuzz the simplified JWK file decoding.
  */
 #include "TestUtils.h"
-#include <bsl/mock_bpa/MockBPA.h>
-#include <bsl/mock_bpa/key_registry.h>
+
 #include <bsl/crypto/CryptoInterface.h>
+#include <bsl/mock_bpa/key_registry.h>
+#include <bsl/mock_bpa/MockBPA.h>
+
 #include <cinttypes>
 
 #define EXPECT_EQ(expect, got)          \

--- a/test/test_AbsSecBlock.c
+++ b/test/test_AbsSecBlock.c
@@ -19,9 +19,7 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <stdlib.h>
-#include <stdio.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
@@ -30,7 +28,9 @@
 #include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
-#include "DefaultScUtils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unity.h>
 
 void suiteSetUp(void)
 {

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -29,16 +29,15 @@
  * @ingroup unit-tests
  */
 
-#include <inttypes.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/BPSecLib_Public.h>
 #include <bsl/mock_bpa/MockBPA.h>
-
 #include <bsl/sample_pp/SamplePolicyProvider.h>
 
-#include "DefaultScUtils.h"
+#include <inttypes.h>
+#include <unity.h>
 
 static BSL_TestContext_t      LocalTestCtx;
 static BSLP_PolicyProvider_t *policy_provider;

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -33,8 +33,8 @@
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/BPSecLib_Public.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
 #include <inttypes.h>
 #include <unity.h>

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -31,16 +31,16 @@
  *
  * @ingroup unit-tests
  */
-#include <stdlib.h>
-#include <stdio.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/crypto/CryptoInterface.h>
 #include <bsl/default_sc/DefaultSecContext.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
-#include "DefaultScUtils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unity.h>
 
 static BSL_TestContext_t LocalTestCtx;
 

--- a/test/test_CoseContext.c
+++ b/test/test_CoseContext.c
@@ -32,10 +32,10 @@
 #include "TestUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/cose_sc/CoseContext.h>
-#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/crypto/CryptoInterface.h>
 #include <bsl/dynamic/PublicInterfaceImpl.h>
+#include <bsl/cose_sc/CoseContext.h>
+#include <bsl/cose_sc/CoseMsg.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <stdio.h>

--- a/test/test_CoseContext.c
+++ b/test/test_CoseContext.c
@@ -29,19 +29,18 @@
  *  - It uses test inputs and vectors from the COSE Context draft @cite draft-ietf-dtn-bpsec-cose.
  *  - It does NOT use any of the "Plumbing" inside the BSL.
  */
-#include <stdlib.h>
-#include <stdio.h>
-#include <unity.h>
+#include "TestUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/MockBPA.h>
-#include <bsl/crypto/CryptoInterface.h>
-
-#include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/cose_sc/CoseContext.h>
 #include <bsl/cose_sc/CoseMsg.h>
+#include <bsl/crypto/CryptoInterface.h>
+#include <bsl/dynamic/PublicInterfaceImpl.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
-#include "TestUtils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unity.h>
 
 static BSL_TestContext_t LocalTestCtx;
 

--- a/test/test_CryptoInterface.c
+++ b/test/test_CryptoInterface.c
@@ -19,20 +19,19 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <inttypes.h>
-
-#include <openssl/err.h>
-#include <openssl/rand.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
-
 #include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/log.h>
 
-#include "DefaultScUtils.h"
+#include <openssl/err.h>
+#include <openssl/rand.h>
+
+#include <inttypes.h>
+#include <unity.h>
 
 static BSL_LibCtx_t bsl;
 

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -30,19 +30,18 @@
  *  - It does NOT use any of the "Plumbing" inside the BSL.
  *  - It only directly calls the interfaces exposed by the Default Security Context.
  */
-#include <stdlib.h>
-#include <stdio.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/crypto/CryptoInterface.h>
-
-#include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/default_sc/DefaultSecContext_Private.h>
+#include <bsl/dynamic/PublicInterfaceImpl.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
-#include "DefaultScUtils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unity.h>
 
 static const char *ApxA2_AuthTag     = "efa4b5ac0108e3816c5606479801bc04";
 static const char *ApxA2_Ciphertext  = "3a09c1e63fe23a7f66a59c7303837241e070b02619fc59c5214a22f08cd70795e73e9a";

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -34,9 +34,9 @@
 
 #include <bsl/BPSecLib_Private.h>
 #include <bsl/crypto/CryptoInterface.h>
+#include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/default_sc/DefaultSecContext_Private.h>
-#include <bsl/dynamic/PublicInterfaceImpl.h>
 #include <bsl/mock_bpa/MockBPA.h>
 
 #include <stdio.h>

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -23,11 +23,11 @@
 
 #include <bsl/BPSecLib_Public.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/dynamic/SecurityActionSet.h>
+#include <bsl/default_sc/DefaultSecContext.h>
+#include <bsl/sample_pp/SamplePolicyProvider.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/log.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
 
 #include <unity.h>
 

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -19,17 +19,17 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Public.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/dynamic/SecurityActionSet.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
 #include <bsl/default_sc/DefaultSecContext.h>
+#include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/log.h>
+#include <bsl/sample_pp/SamplePolicyProvider.h>
 
-#include "DefaultScUtils.h"
+#include <unity.h>
 
 static int malloc_cnt  = 0;
 static int realloc_cnt = 0;

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -19,16 +19,16 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <inttypes.h>
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/log.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/decode.h>
 #include <bsl/mock_bpa/encode.h>
+#include <bsl/mock_bpa/log.h>
 
-#include "DefaultScUtils.h"
+#include <inttypes.h>
+#include <unity.h>
 
 static BSL_LibCtx_t bsl;
 

--- a/test/test_MockBPA_EID.c
+++ b/test/test_MockBPA_EID.c
@@ -19,12 +19,12 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <unity.h>
-
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/eid.h>
 #include <bsl/mock_bpa/eidpat.h>
 #include <bsl/mock_bpa/log.h>
+
+#include <unity.h>
 
 #define TEST_CASE(...)
 

--- a/test/test_PolicyParser.c
+++ b/test/test_PolicyParser.c
@@ -24,14 +24,13 @@
  *
  * @brief Test the config reader of the Sample Policy Provider.
  */
-#include <unity.h>
-
-#include <bsl/BPSecLib_Private.h>
-
-#include <bsl/mock_bpa/MockBPA.h>
 #include "DefaultScUtils.h"
 
+#include <bsl/BPSecLib_Private.h>
+#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/PolicyParser.h>
+
+#include <unity.h>
 
 static BSL_TestContext_t      LocalTestCtx;
 static BSLP_PolicyProvider_t *policy;

--- a/test/test_PolicyParser.c
+++ b/test/test_PolicyParser.c
@@ -27,8 +27,8 @@
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/PolicyParser.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
 #include <unity.h>
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -23,11 +23,11 @@
 
 #include <bsl/BPSecLib_Public.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/default_sc/DefaultSecContext.h>
 #include <bsl/dynamic/SecurityActionSet.h>
+#include <bsl/default_sc/DefaultSecContext.h>
+#include <bsl/sample_pp/SamplePolicyProvider.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/log.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
 
 #include <unity.h>
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -19,17 +19,17 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <unity.h>
+#include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Public.h>
 #include <bsl/crypto/CryptoInterface.h>
-#include <bsl/dynamic/SecurityActionSet.h>
-#include <bsl/sample_pp/SamplePolicyProvider.h>
 #include <bsl/default_sc/DefaultSecContext.h>
+#include <bsl/dynamic/SecurityActionSet.h>
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/log.h>
+#include <bsl/sample_pp/SamplePolicyProvider.h>
 
-#include "DefaultScUtils.h"
+#include <unity.h>
 
 void suiteSetUp(void)
 {

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -30,8 +30,8 @@
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>
-#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
+#include <bsl/mock_bpa/MockBPA.h>
 
 #include <unity.h>
 

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -27,14 +27,13 @@
  *
  * @ingroup unit-tests
  */
-#include <unity.h>
-
-#include <bsl/BPSecLib_Private.h>
-
-#include <bsl/mock_bpa/MockBPA.h>
 #include "DefaultScUtils.h"
 
+#include <bsl/BPSecLib_Private.h>
+#include <bsl/mock_bpa/MockBPA.h>
 #include <bsl/sample_pp/SamplePolicyProvider.h>
+
+#include <unity.h>
 
 static BSL_TestContext_t LocalTestCtx;
 

--- a/test/test_TextUtil.c
+++ b/test/test_TextUtil.c
@@ -23,8 +23,9 @@
  * Test the TextUtil.h interfaces.
  */
 #include <bsl/front/TextUtil.h>
-#include <unity.h>
+
 #include <string.h>
+#include <unity.h>
 
 #define TEST_CASE(...)
 

--- a/test/test_mock_bpa_crc.c
+++ b/test/test_mock_bpa_crc.c
@@ -19,11 +19,13 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <inttypes.h>
-#include <unity.h>
 #include "TestUtils.h"
+
 #include <bsl/mock_bpa/crc.h>
 #include <bsl/mock_bpa/log.h>
+
+#include <inttypes.h>
+#include <unity.h>
 
 void suiteSetUp(void)
 {

--- a/test/test_mock_bpa_ctr.c
+++ b/test/test_mock_bpa_ctr.c
@@ -19,12 +19,14 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+#include "DefaultScUtils.h"
+
+#include <bsl/mock_bpa/agent.h>
+#include <bsl/mock_bpa/ctr.h>
+#include <bsl/mock_bpa/log.h>
+
 #include <inttypes.h>
 #include <unity.h>
-#include "DefaultScUtils.h"
-#include <bsl/mock_bpa/ctr.h>
-#include <bsl/mock_bpa/agent.h>
-#include <bsl/mock_bpa/log.h>
 
 void suiteSetUp(void)
 {

--- a/test/test_qcbor.c
+++ b/test/test_qcbor.c
@@ -19,12 +19,15 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-#include <inttypes.h>
-#include <unity.h>
+#include "TestUtils.h"
+
+#include <bsl/BPSecLib_Public.h>
+
 #include <m-string.h>
 #include <qcbor/qcbor_spiffy_decode.h>
-#include <bsl/BPSecLib_Public.h>
-#include "TestUtils.h"
+
+#include <inttypes.h>
+#include <unity.h>
 
 void test_qcbor_decode_without_head(void)
 {


### PR DESCRIPTION
Follow-on to #239 and #240 based on feedback of #228.

To change the include bracket style under src dir, I used
```bash
find src/ -name '*.h' -o -name '*.c' | xargs sed -i -E 's/include <(bsl.+)>/include "\1"/g'
```