### PR TITLE
Fix documentation for Sample Policy Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ BSL/
 ├── src/                 # Source code, top level is header-only API
 ├── src/front            # Implementation of BSL frontend
 ├── src/dynamic          # Implementation of dynamic backend
-├── src/sample_pp        # Implementation of the example policy provider
+├── src/sample_pp        # Implementation of the sample policy provider
 ├── src/default_sc       # Implementation of Default Security Contexts (RFC 9173)
 ├── src/cose_sc          # Implementation of COSE Context
 ├── src/crypto           # Implementation of BSL crypto library and key store interface

--- a/docs/api/00-mainpage.md
+++ b/docs/api/00-mainpage.md
@@ -124,7 +124,7 @@ This group contains files used by the COSE Context (draft @cite draft-ietf-dtn-b
 @defgroup crypto Cryptographic Processing and Key Store API
 @brief Implementation of the BSL crypto API by a software backend and user of the BSL key store interface.
 
-This group contains files used by the Default Security Contexts (RFC 9173 @cite rfc9173) library included with the BSL.
+This group contains files used by the all of the security context implementations (@ref default-scs and @ref cose-sc) included with the BSL.
 
 
 @defgroup mock_bpa Mock BP Agent

--- a/docs/api/00-mainpage.md
+++ b/docs/api/00-mainpage.md
@@ -102,10 +102,11 @@ This is the concrete implementation of a backend using dynamic heap-allocated co
 It uses POSIX APIs to provide necessary Host functions for the BSL, and OpenSSL APIs to provide crypto functions for the BSL.
 
 
-@defgroup example_pp Example Policy Provider
+@defgroup sample_pp Sample Policy Provider
 @brief Implementation of a simple rule-based policy provider configured with JSON input.
 
 This group contains files used by the Sample Policy Provider library included with the BSL.
+The structure of the JSON configuration has heritage from the ION BPSec implementation and is documented in more detail in the BSL User Guide @cite bsl_user_guide.
 
 
 @defgroup default_sc Default Security Contexts
@@ -126,7 +127,7 @@ This group contains files used by the COSE Context (draft @cite draft-ietf-dtn-b
 This group contains files used by the Default Security Contexts (RFC 9173 @cite rfc9173) library included with the BSL.
 
 
-@defgroup mock_bpa Example/Mock BP Agent
+@defgroup mock_bpa Mock BP Agent
 @brief Files used in the Mock BPA used for testing.
 
 The Mock BPA performs whole-bundle encoding and decoding (CODEC) functions, but no other stateful bundle processing.

--- a/docs/api/00-mainpage.md
+++ b/docs/api/00-mainpage.md
@@ -74,7 +74,7 @@ digraph example {
 The BSL comes with a @ref frontend and a @ref backend_dyn implementation which uses heap-allocated, dynamically-sized data structures and run-time registration capabilities.
 For a more constrained (_e.g._, flight software) environment an alternative backend could be implemented with fixed-size data containers and constant-time registry lookup algorithms.
 
-The BSL source repository also contains @ref sample-pps and @ref example-scs to actually exercise the BSL during testing, and a @ref mock-bpa which allows as-built integration testing of the BSL using a pseudo-daemon process.
+The BSL source repository also contains @ref example-pps and @ref example-scs to actually exercise the BSL during testing, and a @ref mock-bpa which allows as-built integration testing of the BSL using a pseudo-daemon process.
 Together these use the abstract Frontend and populate the otherwise empty Dynamic Backend registries to create an out-of-the-box usable BPSec implementation.
 
 # Dependencies
@@ -102,7 +102,7 @@ This is the concrete implementation of a backend using dynamic heap-allocated co
 It uses POSIX APIs to provide necessary Host functions for the BSL, and OpenSSL APIs to provide crypto functions for the BSL.
 
 
-@defgroup sample_pp Sample Policy Provider
+@defgroup example_pp Example Policy Provider
 @brief Implementation of a simple rule-based policy provider configured with JSON input.
 
 This group contains files used by the Sample Policy Provider library included with the BSL.

--- a/docs/api/00-mainpage.md
+++ b/docs/api/00-mainpage.md
@@ -124,7 +124,7 @@ This group contains files used by the COSE Context (draft @cite draft-ietf-dtn-b
 @defgroup crypto Cryptographic Processing and Key Store API
 @brief Implementation of the BSL crypto API by a software backend and user of the BSL key store interface.
 
-This group contains files used by the all of the security context implementations (@ref default-scs and @ref cose-sc) included with the BSL.
+This group contains files used by all of the security context implementations (@ref default-scs and @ref cose-sc) included with the BSL.
 
 
 @defgroup mock_bpa Mock BP Agent

--- a/docs/api/00-mainpage.md
+++ b/docs/api/00-mainpage.md
@@ -1,6 +1,6 @@
 @mainpage Introduction
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).
@@ -74,7 +74,7 @@ digraph example {
 The BSL comes with a @ref frontend and a @ref backend_dyn implementation which uses heap-allocated, dynamically-sized data structures and run-time registration capabilities.
 For a more constrained (_e.g._, flight software) environment an alternative backend could be implemented with fixed-size data containers and constant-time registry lookup algorithms.
 
-The BSL source repository also contains @ref example-pps and @ref example-scs to actually exercise the BSL during testing, and a @ref mock-bpa which allows as-built integration testing of the BSL using a pseudo-daemon process.
+The BSL source repository also contains @ref sample-pps and @ref example-scs to actually exercise the BSL during testing, and a @ref mock-bpa which allows as-built integration testing of the BSL using a pseudo-daemon process.
 Together these use the abstract Frontend and populate the otherwise empty Dynamic Backend registries to create an out-of-the-box usable BPSec implementation.
 
 # Dependencies
@@ -102,10 +102,10 @@ This is the concrete implementation of a backend using dynamic heap-allocated co
 It uses POSIX APIs to provide necessary Host functions for the BSL, and OpenSSL APIs to provide crypto functions for the BSL.
 
 
-@defgroup example_pp Sample Policy Provider
+@defgroup sample_pp Sample Policy Provider
 @brief Implementation of a simple rule-based policy provider configured with JSON input.
 
-This group contains files used by the Example Policy Provider library included with the BSL.
+This group contains files used by the Sample Policy Provider library included with the BSL.
 
 
 @defgroup default_sc Default Security Contexts
@@ -139,7 +139,7 @@ The Mock BPA also implements an in-memory key store registered with the BSL cryp
 @brief Files used for unit testing of BSL behaviors.
 
 This exercises internal and external APIs for consistency, but not end-to-end bundle testing.
-Tests cover the BSL itself, its example security contexts and example policy provider.
+Tests cover the BSL itself, its example security contexts and sample policy provider.
 
 
 @defgroup fuzz_test Fuzz Testing

--- a/docs/api/01-bsl-sis.md
+++ b/docs/api/01-bsl-sis.md
@@ -59,7 +59,7 @@ Section 2 covers miscellaneous information about operating assumptions, includin
 
 Section 3 provides an overview of the BSL API, which application programmers should use as an introduction to using the BSL. Note that this document does not provide details of individual functions or constants within the BSL. Those may be found in referenced documents including the auto-generated source code documentation.
 
-Finally, the BSL is open-source software whose design and implementation should be expected to evolve in response to operational feedback. As such, this and related documentation may become out-of-date relative to the leading-edge of the BSL code repository. In general, the documentation (including the READMEs, auto-generated API spec, code s, etc) found in the open-source GitHub repository should be considered the ground source of truth when information appears inconsistent. 
+Finally, the BSL is open-source software whose design and implementation should be expected to evolve in response to operational feedback. As such, this and related documentation may become out-of-date relative to the leading-edge of the BSL code repository. In general, the documentation (including the READMEs, auto-generated API spec, code examples, etc) found in the open-source GitHub repository should be considered the ground source of truth when information appears inconsistent. 
 
 ## 1.3: Terminology and Notation
 
@@ -122,7 +122,7 @@ The BSL is expected to operate on a host with FIPS 140-mode enabled and SE Linux
 
 The BSL is a software library that compiles to a Linux shared or static object, which must be linked to a host binary in order to execute. The BSL does not itself produce and run any independent threads of execution.
 
-Host applications must link to the BSL object files during their build process, according to the instructions and s located in the BSL wiki page on GitHub. Host applications will call C functions directly to execute BPSec subroutines. If the host application is not programmed in C or C++, then a suitable Foreign Function Interface (FFI) for that specific programming language should be used. Note, the authors of the BSL cannot guarantee the correctness when using BSL with an FFI.
+Host applications must link to the BSL object files during their build process, according to the instructions and examples located in the BSL wiki page on GitHub. Host applications will call C functions directly to execute BPSec subroutines. If the host application is not programmed in C or C++, then a suitable Foreign Function Interface (FFI) for that specific programming language should be used. Note, the authors of the BSL cannot guarantee the correctness when using BSL with an FFI.
 
 
 ## 2.3: Standards and Protocols
@@ -143,13 +143,13 @@ There is no specific runtime initialization for the BSL. However, software devel
 
 ## 3.1: Frontend vs Backend
 
-The BSL implementation has two central notional components: The “Frontend API” and the “Dynamic Backend”. This distinction permits the existence of multiple backends that implement BPSec functionality, each potentially tailored to operational settings, to be accessed via a common interface. For , a Bundle Protocol Agent running in SWaP-constrained hardware may need an implementation using strict memory-management that fits in a small memory footprint, whereas a BPA serving as a Bundle Protocol Router on conventional hardware may choose to use a backend leveraging hardware acceleration and greater access to computing resources. The BSL ships with a default backend, written in C99 with some dynamic data structures, which balances suitability for constrained systems and overall flexibility. 
+The BSL implementation has two central notional components: The “Frontend API” and the “Dynamic Backend”. This distinction permits the existence of multiple backends that implement BPSec functionality, each potentially tailored to operational settings, to be accessed via a common interface. For example, a Bundle Protocol Agent running in SWaP-constrained hardware may need an implementation using strict memory-management that fits in a small memory footprint, whereas a BPA serving as a Bundle Protocol Router on conventional hardware may choose to use a backend leveraging hardware acceleration and greater access to computing resources. The BSL ships with a default backend, written in C99 with some dynamic data structures, which balances suitability for constrained systems and overall flexibility. 
 
 The “Frontend API” defines the stable public interface for the BSL, which the host application uses to invoke BPSec functionality. The “Frontend API” is mostly abstract, containing forward-declared data structures, function prototypes, and limited compiled artifacts. Application programmers for a BPA generally need to be familiar only with the frontend API – its functions and structures. Adhering to this API permits the BPA to be agnostic to the implementation details of any backend.
 
 The “Dynamic Backend” is the default implementation of a backend implementing the Frontend API and contains the functionality detailed in RFC 9172. It uses the term “Dynamic” since it supports since it permits the use of dynamic data structures with flexible memory consumption (as opposed to statically allocated memory).
 
-Backends may be swapped out with another implementation that implements the front-end API. Since BPSec may be deployed in many types of systems with different resources and different operational environments, there is unlikely to be a one-size-fits-all backend implementation. The backend provided here should be understood as an  and reference for more tailored mission-specific implementations.
+Backends may be swapped out with another implementation that implements the front-end API. Since BPSec may be deployed in many types of systems with different resources and different operational environments, there is unlikely to be a one-size-fits-all backend implementation. The backend provided here should be understood as an example and reference for more tailored mission-specific implementations.
 
 
 ## 3.2: Instructions for Building Documentation

--- a/docs/api/01-bsl-sis.md
+++ b/docs/api/01-bsl-sis.md
@@ -1,6 +1,6 @@
 @page bsl-sis BSL Interface Specification (SIS)
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).
@@ -31,6 +31,7 @@ Bundle Protocol Security Library (BPSec Lib) Software Interface Specification (S
 | Revision | Submission Date | Affection Sections or Pages | Change Summary            |
 |----------|-----------------|-----------------------------|---------------------------|
 | Initial  | 10/2/2024       | All                         | Initial issue of document |
+| A        | 7/29/2026       | All                         | Updating copyright year and instances of "example policy provider" |
 
 
 
@@ -58,7 +59,7 @@ Section 2 covers miscellaneous information about operating assumptions, includin
 
 Section 3 provides an overview of the BSL API, which application programmers should use as an introduction to using the BSL. Note that this document does not provide details of individual functions or constants within the BSL. Those may be found in referenced documents including the auto-generated source code documentation.
 
-Finally, the BSL is open-source software whose design and implementation should be expected to evolve in response to operational feedback. As such, this and related documentation may become out-of-date relative to the leading-edge of the BSL code repository. In general, the documentation (including the READMEs, auto-generated API spec, code examples, etc) found in the open-source GitHub repository should be considered the ground source of truth when information appears inconsistent. 
+Finally, the BSL is open-source software whose design and implementation should be expected to evolve in response to operational feedback. As such, this and related documentation may become out-of-date relative to the leading-edge of the BSL code repository. In general, the documentation (including the READMEs, auto-generated API spec, code s, etc) found in the open-source GitHub repository should be considered the ground source of truth when information appears inconsistent. 
 
 ## 1.3: Terminology and Notation
 
@@ -121,7 +122,7 @@ The BSL is expected to operate on a host with FIPS 140-mode enabled and SE Linux
 
 The BSL is a software library that compiles to a Linux shared or static object, which must be linked to a host binary in order to execute. The BSL does not itself produce and run any independent threads of execution.
 
-Host applications must link to the BSL object files during their build process, according to the instructions and examples located in the BSL wiki page on GitHub. Host applications will call C functions directly to execute BPSec subroutines. If the host application is not programmed in C or C++, then a suitable Foreign Function Interface (FFI) for that specific programming language should be used. Note, the authors of the BSL cannot guarantee the correctness when using BSL with an FFI.
+Host applications must link to the BSL object files during their build process, according to the instructions and s located in the BSL wiki page on GitHub. Host applications will call C functions directly to execute BPSec subroutines. If the host application is not programmed in C or C++, then a suitable Foreign Function Interface (FFI) for that specific programming language should be used. Note, the authors of the BSL cannot guarantee the correctness when using BSL with an FFI.
 
 
 ## 2.3: Standards and Protocols
@@ -142,13 +143,13 @@ There is no specific runtime initialization for the BSL. However, software devel
 
 ## 3.1: Frontend vs Backend
 
-The BSL implementation has two central notional components: The “Frontend API” and the “Dynamic Backend”. This distinction permits the existence of multiple backends that implement BPSec functionality, each potentially tailored to operational settings, to be accessed via a common interface. For example, a Bundle Protocol Agent running in SWaP-constrained hardware may need an implementation using strict memory-management that fits in a small memory footprint, whereas a BPA serving as a Bundle Protocol Router on conventional hardware may choose to use a backend leveraging hardware acceleration and greater access to computing resources. The BSL ships with a default backend, written in C99 with some dynamic data structures, which balances suitability for constrained systems and overall flexibility. 
+The BSL implementation has two central notional components: The “Frontend API” and the “Dynamic Backend”. This distinction permits the existence of multiple backends that implement BPSec functionality, each potentially tailored to operational settings, to be accessed via a common interface. For , a Bundle Protocol Agent running in SWaP-constrained hardware may need an implementation using strict memory-management that fits in a small memory footprint, whereas a BPA serving as a Bundle Protocol Router on conventional hardware may choose to use a backend leveraging hardware acceleration and greater access to computing resources. The BSL ships with a default backend, written in C99 with some dynamic data structures, which balances suitability for constrained systems and overall flexibility. 
 
 The “Frontend API” defines the stable public interface for the BSL, which the host application uses to invoke BPSec functionality. The “Frontend API” is mostly abstract, containing forward-declared data structures, function prototypes, and limited compiled artifacts. Application programmers for a BPA generally need to be familiar only with the frontend API – its functions and structures. Adhering to this API permits the BPA to be agnostic to the implementation details of any backend.
 
 The “Dynamic Backend” is the default implementation of a backend implementing the Frontend API and contains the functionality detailed in RFC 9172. It uses the term “Dynamic” since it supports since it permits the use of dynamic data structures with flexible memory consumption (as opposed to statically allocated memory).
 
-Backends may be swapped out with another implementation that implements the front-end API. Since BPSec may be deployed in many types of systems with different resources and different operational environments, there is unlikely to be a one-size-fits-all backend implementation. The backend provided here should be understood as an example and reference for more tailored mission-specific implementations.
+Backends may be swapped out with another implementation that implements the front-end API. Since BPSec may be deployed in many types of systems with different resources and different operational environments, there is unlikely to be a one-size-fits-all backend implementation. The backend provided here should be understood as an  and reference for more tailored mission-specific implementations.
 
 
 ## 3.2: Instructions for Building Documentation
@@ -157,7 +158,7 @@ The most up-to-date documentation will be found in the BSL’s GitHub page, and 
 
 Instructions to build the documentation using doxygen as HTML (and/or PDF, among other formats) may be found in the README.md file. Assuming a RHEL9 platform, the Linux tool xdg-open may be used to open the index.html found under build/default/docs/doxygen/html/index.html.
 
-The menu on the left-hand side includes this overview, as well as links to the top-level modules in the repository. These include the Frontend API, Dynamic Backend, the default security context, the example Security Policy Provider, and a “mock” BPA required to exercise the Frontend. Delving further into each of these shows the relevant files, functions, and data structures.
+The menu on the left-hand side includes this overview, as well as links to the top-level modules in the repository. These include the Frontend API, Dynamic Backend, the default security context, the Sample Security Policy Provider, and a “mock” BPA required to exercise the Frontend. Delving further into each of these shows the relevant files, functions, and data structures.
 
 Links will be found in Table 3 above.
 
@@ -168,14 +169,14 @@ As indicated in the prior section, the BSL has four main components. The princip
 
  * The **Frontend API** defines the software interface between host Bundle Protocol Agents and the underlying security operations implemented in a Dynamic Backend. The API remains an invariant regardless of which backend is selected.
  * The **Dynamic Backend** is an implementation of the BPSec security operations that adheres to the Frontend API. The BSL’s design and implementation facilitate “swapping” backend implementations tailored for mission-specific constraints. The BSL ships with a default backend, which may not be suitable for all operational environments.
- * The **Example Security Policy Provider** is a library used internally by the BSL to query which security operations need to be applied to a given Bundle, and what those security parameters are (such as key, hash type, etc). The BSL provides an example security provider exercising the policy provider interface.
+ * The **Sample Security Policy Provider** is a library used internally by the BSL to query which security operations need to be applied to a given Bundle, and what those security parameters are (such as key, hash type, etc). The BSL provides a sample security provider exercising the policy provider interface.
  * The **Example Default Security Contexts** perform the actual cryptographic functionality. The Default Security Context is detailed in RFC 9173. The BSL implements this via the security context interface, and uses OpenSSL as the underlying cryptographic software.
 
 ## 3.4: BSL Context Initialization
 
 The BSL requires the existence of a Security Policy Provider (commonly referred to as the “Policy Provider” throughout subsequent documentation), which governs what security actions should be performed upon a particular bundle, and a Security Context, which handles all cryptographic material and safely performs the cryptographic functionality.
 
-An example Policy Provider is included in the repository, as well as an implementation of the Default Security Context (as specified in RFC 9173).
+An sample Policy Provider is included in the repository, as well as an implementation of the Default Security Context (as specified in RFC 9173).
 
 Refer to the doxygen-generated documentation in the repository for the relevant BSL initialization functions, that provision the library with the appropriate policy provider and security context.
 

--- a/docs/api/01-bsl-sis.md
+++ b/docs/api/01-bsl-sis.md
@@ -176,7 +176,7 @@ As indicated in the prior section, the BSL has four main components. The princip
 
 The BSL requires the existence of a Security Policy Provider (commonly referred to as the “Policy Provider” throughout subsequent documentation), which governs what security actions should be performed upon a particular bundle, and a Security Context, which handles all cryptographic material and safely performs the cryptographic functionality.
 
-An sample Policy Provider is included in the repository, as well as an implementation of the Default Security Context (as specified in RFC 9173).
+A sample Policy Provider is included in the repository, as well as an implementation of the Default Security Context (as specified in RFC 9173).
 
 Refer to the doxygen-generated documentation in the repository for the relevant BSL initialization functions, that provision the library with the appropriate policy provider and security context.
 

--- a/docs/api/02-bpa-integrators.md
+++ b/docs/api/02-bpa-integrators.md
@@ -1,6 +1,6 @@
 @page bpa-integrators BPA Integrator Topics
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).

--- a/docs/api/03-policy-providers.md
+++ b/docs/api/03-policy-providers.md
@@ -1,6 +1,6 @@
 @page policy-providers Policy Provider Topics
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).

--- a/docs/api/03-security-contexts.md
+++ b/docs/api/03-security-contexts.md
@@ -1,6 +1,6 @@
 @page security-contexts Security Context Topics
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).

--- a/docs/api/04-examples-and-mocks.md
+++ b/docs/api/04-examples-and-mocks.md
@@ -1,6 +1,6 @@
 @page examples-and-mocks Example PPs, SCs, and Mock BPA
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).
@@ -21,7 +21,7 @@ the prime contract 80NM0018D0004 between the Caltech and NASA under
 subcontract 1700763.
 -->
 
-This page discusses example Policy Providers (PPs), Security Contexts (SCs), and a mock BPA used for testing the BSL proper.
+This page discusses examples of Policy Providers (PPs), Security Contexts (SCs), and a mock BPA used for testing the BSL proper.
 The BSL proper is associated with the @ref frontend and @ref backend_dyn groups.
 
 # Example Policy Providers {#example-pps}
@@ -48,7 +48,7 @@ The COSE Context defined in an internet draft @cite draft-ietf-dtn-bpsec-cose of
 An implementation of each of these SCs is maintained as part of the BSL source and uses the BSL crypto library as an wrapper for the OpenSSL library @cite lib:openssl from the host OS and a key store registered with the crypto library (part of the @ref bpa-callback-api).
 These SCs are registered and used by the @ref mock-bpa for BSL testing.
 
-Sources related to these example SCs are associated with the @ref default_sc group.
+Sources related to these  SCs are associated with the @ref default_sc group.
 
 # Mock BPA {#mock-bpa}
 
@@ -63,7 +63,7 @@ Sources related to the Mock BPA are associated with the @ref mock_bpa group.
 
 ## Policy Management
 
-The policies used by the Mock BPA example policy providers can be provided with two different methods.
+The policies used by the Mock BPA sample policy providers can be provided with two different methods.
 
 ### Policy Bit Fields
 

--- a/docs/api/04-examples-and-mocks.md
+++ b/docs/api/04-examples-and-mocks.md
@@ -48,7 +48,7 @@ The COSE Context defined in an internet draft @cite draft-ietf-dtn-bpsec-cose of
 An implementation of each of these SCs is maintained as part of the BSL source and uses the BSL crypto library as an wrapper for the OpenSSL library @cite lib:openssl from the host OS and a key store registered with the crypto library (part of the @ref bpa-callback-api).
 These SCs are registered and used by the @ref mock-bpa for BSL testing.
 
-Sources related to these  SCs are associated with the @ref default_sc group.
+Sources related to these example SCs are associated with the @ref default_sc group.
 
 # Mock BPA {#mock-bpa}
 

--- a/docs/api/04-examples-and-mocks.md
+++ b/docs/api/04-examples-and-mocks.md
@@ -28,27 +28,44 @@ The BSL proper is associated with the @ref frontend and @ref backend_dyn groups.
 
 The unit tests of the BSL use, where necessary, very minimal implementations of a PP to set up preconditons for test cases.
 
+## Bit Field Policy
+
 The Mock BPA uses a PP implementation tailored to meet the needs of the BSL acceptance tests.
 This PP uses a set of bit fields within an integer program argument to control policy options; the fields are documented on ::BSLP_PolicyParser_BitstringConfig_t.
 It also allows multiple integer policy values to be configured in a single running Mock BPA.
 This PP is registered and used by the @ref mock-bpa for many BSL testing cases.
 
+Sources for this policy provider are internal to the @ref mock_bpa group and its library used for unit testing.
+
+## ION-Heritage Sample Policy Provider {#sample-pp}
+
 A more full-featured draft PP maintained as part of the BSL source is based on the JSON-encoded policy structure used in the earlier ION implementation of the Default Security Contexts @cite ion-bpsec-policy.
 This PP parses an ION-Like JSON structure to configure policy rules within a running Mock BPA. See the _BSL User Guide_ @cite bsl_user_guide for details on specific JSON structure and attributes.
 This PP is registered and used by the @ref mock-bpa for many BSL testing cases.
 
-Sources related to these example PPs are associated with the @ref example_pp group.
+Sources related to this provider are associated with the @ref sample_pp group.
 
 # Example Security Contexts {#example-scs}
 
+The BSL source contains example implementations of three security contexts which all use the @ref bsl-crypto for their cryptographic processing.
+
+These SCs are registered and used by the @ref mock-bpa for BSL testing.
+
+## Default Contexts {#default-scs}
+
 The two Default Security Contexts defined in RFC 9173 @cite rfc9173 offer minimal, interoperable, and pre-shared-key-focused integrity and confidentiality operations.
+
+Sources related to these example SCs are associated with the @ref default_sc group.
+
+## COSE Context {#cose-sc}
 
 The COSE Context defined in an internet draft @cite draft-ietf-dtn-bpsec-cose offers more full-featured, layered symmetric key options including key wrapping and key derivation.
 
-An implementation of each of these SCs is maintained as part of the BSL source and uses the BSL crypto library as an wrapper for the OpenSSL library @cite lib:openssl from the host OS and a key store registered with the crypto library (part of the @ref bpa-callback-api).
-These SCs are registered and used by the @ref mock-bpa for BSL testing.
+Sources related to the COSE SC are associated with the @ref cose_sc group.
 
-Sources related to these example SCs are associated with the @ref default_sc group.
+## BSL Crypto Library {#bsl-crypto}
+
+This is a wrapper for the OpenSSL library @cite lib:openssl from the host OS and an API to access a shared key store (part of the @ref bpa-callback-api).
 
 # Mock BPA {#mock-bpa}
 
@@ -57,7 +74,7 @@ The Mock BPA uses an un-framed UDPCL-like interface for its underlayer and also 
 
 The Mock BPA is limited to a single registered endpoint, and does no other handling normally required by RFC 9171 @cite rfc9171. So for this reason it is not a true BPA and must not be treated as one.
 
-Upon startup, the Mock BPA registers a single [ION-based Example Policy Provider](@ref example-pps) and all of the [example Security Contexts](@ref example-scs).
+Upon startup, the Mock BPA registers a single @ref sample-pp and all of the @ref example-scs.
 
 Sources related to the Mock BPA are associated with the @ref mock_bpa group.
 
@@ -78,6 +95,7 @@ The path to the JSON file should be passed to the Mock BPA with the `-j` command
 ## Key Management
 
 The keys used by the example SCs registered in the Mock BPA's key store are obtained from a file using either the JSON Web Key (JWK) Set format of RFC 7517 @cite rfc7517 or the COSE Key Set format of RFC 9052 @cite rfc9052.
+This key store is accessed via the @ref bsl-crypto APIs for use by the policy providers registered with the Mock BPA.
 
 The implementation to support these SCs only handles symmetric keys and only the minimal header parameters needed for key ID ("kid") and symmetric key material itself ("k").
 

--- a/docs/api/10-bsl-developers.md
+++ b/docs/api/10-bsl-developers.md
@@ -1,6 +1,6 @@
 @page bsl-developers BSL Developer Topics
 <!--
-Copyright (c) 2025 The Johns Hopkins University Applied Physics
+Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.
 
 This file is part of the Bundle Protocol Security Library (BSL).

--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -62,7 +62,9 @@ ciphertext
 CLA
 clin
 codebase
+codec
 CODEC
+codecs
 config
 CONOPs
 const

--- a/resources/check_format.sh
+++ b/resources/check_format.sh
@@ -37,9 +37,8 @@ echo "Check format from root: $SELFDIR"
 
 if ! git diff --quiet
 then
+    git status
     echo "Error: Files changed after formatting:"
     git diff
     exit 1
 fi
-
-exit 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,7 +147,7 @@ target_link_libraries(bsl_cose_sc PRIVATE bsl_crypto)
 target_link_libraries(bsl_cose_sc PRIVATE MLIB::mlib)
 target_link_libraries(bsl_cose_sc PRIVATE qcbor::qcbor)
 
-# Example Policy Provider library
+# Sample Policy Provider library
 add_library(bsl_sample_pp)
 target_sources(bsl_sample_pp
     PUBLIC

--- a/src/bsl/crypto/KeyLoader.c
+++ b/src/bsl/crypto/KeyLoader.c
@@ -21,7 +21,7 @@
  */
 /** @file
  * @ingroup crypto
- * Implementation of the key loader logic for JWT Set and COSE Key Set.
+ * Implementation of the key loader logic for JWK Set and COSE Key Set.
  */
 #include "KeyLoader.h"
 

--- a/src/bsl/crypto/KeyLoader.c
+++ b/src/bsl/crypto/KeyLoader.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup crypto
+ * Implementation of the key loader logic for JWT Set and COSE Key Set.
+ */
 #include "KeyLoader.h"
 
 #include <bsl/front/TextUtil.h>

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -19,6 +19,11 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/**
+ * @file
+ * @ingroup sample_pp
+ * Implementation of the JSON parser for this policy.
+ */
 #include "PolicyParser.h"
 
 #include "bsl/front/TextUtil.h"

--- a/src/bsl/sample_pp/PolicyParser.h
+++ b/src/bsl/sample_pp/PolicyParser.h
@@ -22,7 +22,7 @@
 
 /**
  * @file
- * @ingroup example_pp
+ * @ingroup sample_pp
  * Entry point for the sample policy provider of the BSL.
  * Configuration input is handled by @ref PolicyParser.h functions.
  */

--- a/src/bsl/sample_pp/PolicyParser.h
+++ b/src/bsl/sample_pp/PolicyParser.h
@@ -19,7 +19,6 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
-
 /**
  * @file
  * @ingroup sample_pp

--- a/src/bsl/sample_pp/SamplePolicyProvider.c
+++ b/src/bsl/sample_pp/SamplePolicyProvider.c
@@ -23,7 +23,7 @@
 /**
  * @file
  * @brief Local implementation of locally-defined data structures.
- * @ingroup example_pp
+ * @ingroup sample_pp
  */
 #include "SamplePolicyProvider.h"
 

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -23,7 +23,7 @@
 /**
  * @file
  * @brief Spec of locally-defined data structures.
- * @ingroup example_pp
+ * @ingroup sample_pp
  */
 #ifndef BSLP_SAMPLE_POLICY_PROVIDER_H
 #define BSLP_SAMPLE_POLICY_PROVIDER_H

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -22,8 +22,8 @@
 
 /**
  * @file
- * @brief Spec of locally-defined data structures.
  * @ingroup sample_pp
+ * @brief Spec of locally-defined data structures.
  */
 #ifndef BSLP_SAMPLE_POLICY_PROVIDER_H
 #define BSLP_SAMPLE_POLICY_PROVIDER_H

--- a/test/DefaultScUtils.c
+++ b/test/DefaultScUtils.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Common functions for testing Default Security Contexts.
+ */
 #undef NDEBUG // force assertions
 #include "DefaultScUtils.h"
 

--- a/test/DefaultScUtils.h
+++ b/test/DefaultScUtils.h
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Common functions for testing Default Security Contexts.
+ */
 #ifndef _BSL_DEFAULTSCUTILS_H_
 #define _BSL_DEFAULTSCUTILS_H_
 

--- a/test/TestUtils.c
+++ b/test/TestUtils.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Common unit test utility definitions.
+ */
 #undef NDEBUG // force assertions
 #include "TestUtils.h"
 

--- a/test/TestUtils.h
+++ b/test/TestUtils.h
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Common unit test utility declarations.
+ */
 #ifndef _BSL_TESTUTILS_H_
 #define _BSL_TESTUTILS_H_
 

--- a/test/test_AbsSecBlock.c
+++ b/test/test_AbsSecBlock.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the abstract security block (ASB) codec of the BSL.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -26,7 +26,7 @@
  * Notes:
  *  - There is one leaky abstraction (it does import SamplePolicyProvider.h) for concrete struct def size.
  *
- * @ingroup unit-tests
+ * @ingroup unit_test
  */
 
 #include "DefaultScUtils.h"

--- a/test/test_BackendSecurityContext.c
+++ b/test/test_BackendSecurityContext.c
@@ -29,7 +29,7 @@
  *  - They test correctness mostly by verifying that operations modify the bundle as intended
  *  - They are checked against test vectors in Appendix A of RFC9173.
  *
- * @ingroup unit-tests
+ * @ingroup unit_test
  */
 #include "DefaultScUtils.h"
 

--- a/test/test_CoseContext.c
+++ b/test/test_CoseContext.c
@@ -20,7 +20,7 @@
  * subcontract 1700763.
  */
 /** @file
- * @ingroup unit-tests
+ * @ingroup unit_test
  *
  * @brief Specific low-level tests of the COSE Context
  *

--- a/test/test_CryptoInterface.c
+++ b/test/test_CryptoInterface.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the BSL crypto API.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>

--- a/test/test_DefaultSecurityContext.c
+++ b/test/test_DefaultSecurityContext.c
@@ -20,7 +20,7 @@
  * subcontract 1700763.
  */
 /** @file
- * @ingroup unit-tests
+ * @ingroup unit_test
  *
  * @brief Specific low-level tests of the Default Security Context
  *

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the heap memory callback APIs.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Public.h>

--- a/test/test_MockBPA_Codecs.c
+++ b/test/test_MockBPA_Codecs.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the Bundle codecs of the Mock BPA.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Private.h>

--- a/test/test_MockBPA_EID.c
+++ b/test/test_MockBPA_EID.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the EID codecs of the Mock BPA.
+ */
 #include <bsl/mock_bpa/agent.h>
 #include <bsl/mock_bpa/eid.h>
 #include <bsl/mock_bpa/eidpat.h>

--- a/test/test_PolicyParser.c
+++ b/test/test_PolicyParser.c
@@ -20,7 +20,7 @@
  * subcontract 1700763.
  */
 /** @file
- * @ingroup unit-tests
+ * @ingroup unit_test
  *
  * @brief Test the config reader of the Sample Policy Provider.
  */

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the dynamic backend interface behavior.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/BPSecLib_Public.h>

--- a/test/test_SamplePolicyProvider.c
+++ b/test/test_SamplePolicyProvider.c
@@ -25,7 +25,7 @@
  *
  * Notes:
  *
- * @ingroup unit-tests
+ * @ingroup unit_test
  */
 #include "DefaultScUtils.h"
 

--- a/test/test_TextUtil.c
+++ b/test/test_TextUtil.c
@@ -20,6 +20,7 @@
  * subcontract 1700763.
  */
 /** @file
+ * @ingroup unit_test
  * Test the TextUtil.h interfaces.
  */
 #include <bsl/front/TextUtil.h>

--- a/test/test_mock_bpa_crc.c
+++ b/test/test_mock_bpa_crc.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the CRC calculations of the Mock BPA.
+ */
 #include "TestUtils.h"
 
 #include <bsl/mock_bpa/crc.h>

--- a/test/test_mock_bpa_ctr.c
+++ b/test/test_mock_bpa_ctr.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the Bundle container API of the Mock BPA.
+ */
 #include "DefaultScUtils.h"
 
 #include <bsl/mock_bpa/agent.h>

--- a/test/test_qcbor.c
+++ b/test/test_qcbor.c
@@ -19,6 +19,10 @@
  * the prime contract 80NM0018D0004 between the Caltech and NASA under
  * subcontract 1700763.
  */
+/** @file
+ * @ingroup unit_test
+ * Test the QCBOR library behavior for BSL needs.
+ */
 #include "TestUtils.h"
 
 #include <bsl/BPSecLib_Public.h>


### PR DESCRIPTION
Finding instances of "example policy provider" and replacing "example" with "sample (at my own discretion), as well as other editorial changes