### PR TITLE
Fix CI formatting to pin versions

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Test Prep
         run: |
           pip3 install --upgrade pip
-          pip3 install -r mock-bpa-test/requirements.txt
+          pip3 install -e mock-bpa-test
       - name: Test
         env:
           TEST_EXEC_WRAP: 'memcheck'

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Test Prep
         run: |
           pip3 install --upgrade pip
-          pip3 install -e mock-bpa-test
+          pip3 install -e mock-bpa-test/
       - name: Test
         env:
           TEST_EXEC_WRAP: 'memcheck'

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -37,15 +37,20 @@ jobs:
       contents: read
       actions: write
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Set up OS
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+              clang-format jq
+          pip3 install -e mock-bpa-test[format] # for formatting
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: false
-      - name: Set up OS
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-              clang-format jq python3-pip python3-wheel
-          pip3 install -e mock-bpa-test[format] # for formatting
       - name: Check code formatting
         run: ./build.sh check-format

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -46,6 +46,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
               clang-format jq python3-pip python3-wheel
-          pip3 install ruff licenseheaders
+          pip3 install 'ruff==0.16.0' licenseheaders
       - name: Check code formatting
         run: ./build.sh check-format

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -41,15 +41,15 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.9"
-      - name: Set up OS
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-              clang-format jq
-          pip3 install -e mock-bpa-test[format] # for formatting
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: false
+      - name: Set up OS
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+              clang-format jq
+          pip3 install -e mock-bpa-test[format] # for formatting
       - name: Check code formatting
         run: ./build.sh check-format

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -41,7 +41,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.9"
-          cache: "pip"
       - name: Set up OS
         run: |
           sudo apt-get update && sudo apt-get install -y \

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -46,6 +46,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y \
               clang-format jq python3-pip python3-wheel
-          pip3 install 'ruff==0.16.0' licenseheaders
+          pip3 install -e mock-bpa-test[format] # for formatting
       - name: Check code formatting
         run: ./build.sh check-format

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -118,5 +118,5 @@ jobs:
         run: DESTDIR="" ./build.sh check-install
       - name: Mock BPA tests
         run: |
-          pip3 install -r mock-bpa-test/requirements.txt
+          pip3 install -e mock-bpa-test/
           python3 -m pytest mock-bpa-test

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Mock BPA Test
         run: |
           pip3 install --upgrade pip
-          pip3 install -r mock-bpa-test/requirements.txt
+          pip3 install -e mock-bpa-test/
           python3 -m pytest --junitxml=build/default/mock-bpa-test.xml mock-bpa-test || true
       - name: Collect coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /.ccache/
 __pycache__/
 .pytest_cache/
+*.egg-info/
 mock-bpa-test/ccsds_bpsec_redbook_requirements_modified.yaml
 /deps/
 /lib-user-test/build/

--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -19,8 +19,8 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from enum import IntEnum, unique
 from dataclasses import dataclass
+from enum import IntEnum, unique
 from typing import Any, Optional
 
 

--- a/mock-bpa-test/helpers/__init__.py
+++ b/mock-bpa-test/helpers/__init__.py
@@ -23,8 +23,8 @@
 from .runner import CmdRunner, compose_args
 from .timer import Timer
 
-__all__ = {
-    CmdRunner,
-    compose_args,
-    Timer,
-}
+__all__ = (
+    "CmdRunner",
+    "Timer",
+    "compose_args",
+)

--- a/mock-bpa-test/helpers/runner.py
+++ b/mock-bpa-test/helpers/runner.py
@@ -22,12 +22,13 @@
 
 import logging
 import os
+import queue
 import re
 import signal
 import subprocess
 import threading
-from typing import List, Literal, Optional, Union
-import queue
+from typing import Literal, Optional, Union
+
 from .timer import Timer
 
 LOGGER = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ PROJPATH = os.path.abspath(os.path.join(OWNPATH, "..", ".."))
 """ Project top path """
 
 
-def compose_args(args: List[str]) -> List[str]:
+def compose_args(args: list[str]) -> list[str]:
     """Combine executions arguments with any prefix scripts and/or tools
     needed to run from the `testroot` environment.
     """
@@ -85,7 +86,7 @@ def compose_args(args: List[str]) -> List[str]:
     return args
 
 
-WaitStream = Union[Literal["stdout"], Literal["stderr"]]
+WaitStream = Literal["stdout", "stderr"]
 """ Name for output stream """
 
 
@@ -98,7 +99,7 @@ class CmdRunner:
     :py:func:`subprocess.Popen`
     """
 
-    def __init__(self, args: List[str], **kwargs):
+    def __init__(self, args: list[str], **kwargs):
         self._args = args
         self._kwargs = kwargs
 

--- a/mock-bpa-test/helpers/timer.py
+++ b/mock-bpa-test/helpers/timer.py
@@ -20,8 +20,8 @@
 # subcontract 1700763.
 #
 
-import logging
 import datetime
+import logging
 import time
 from typing import Optional
 

--- a/mock-bpa-test/pyproject.toml
+++ b/mock-bpa-test/pyproject.toml
@@ -3,15 +3,13 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mock-bpa-test"
+name = "bsl-mock-bpa-test"
 version = "0.0.0"
 authors = [
   { name="JHU/APL", email="dtnma-support@jhuapl.edu" },
 ]
 description = "BSL Mock BPA test fixtures"
-readme = "../README.md"
 license = "Apache-2.0"
-license-files = ["../LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -26,6 +24,9 @@ dependencies = [
   "pytest-subtests",
   "pyyaml",
 ]
+
+[tool.setuptools.packages.find]
+exclude = ["test*", "helpers", "data"]
 
 [tool.pytest.ini_options]
 norecursedirs = ["helpers"]

--- a/mock-bpa-test/pyproject.toml
+++ b/mock-bpa-test/pyproject.toml
@@ -25,6 +25,14 @@ dependencies = [
   "pyyaml",
 ]
 
+[project.optional-dependencies]
+format = [
+  "ruff ==0.16.0",
+  "ty == 0.0.65",
+  "licenseheaders ==0.8.8",
+]
+
+
 [tool.setuptools.packages.find]
 exclude = ["test*", "helpers", "data"]
 

--- a/mock-bpa-test/pyproject.toml
+++ b/mock-bpa-test/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mock-bpa-test"
+version = "0.0.0"
+authors = [
+  { name="JHU/APL", email="dtnma-support@jhuapl.edu" },
+]
+description = "BSL Mock BPA test fixtures"
+readme = "../README.md"
+license = "Apache-2.0"
+license-files = ["../LICENSE"]
+requires-python = ">=3.9"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent",
+]
+
+dependencies = [
+  "cbor2 ~= 5.6.0",
+  "cbor-diag ~= 1.1",
+  "pytest",
+  "pytest-subtests",
+  "pyyaml",
+]
+
+[tool.pytest.ini_options]
+norecursedirs = ["helpers"]
+log_level = "DEBUG"
+log_cli = true
+log_cli_level = "WARNING"
+
+[tool.ruff]
+line-length=100
+[tool.ruff.lint]
+ignore = ["FA"]

--- a/mock-bpa-test/pytest.ini
+++ b/mock-bpa-test/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-norecursedirs = helpers
-log_level = DEBUG
-
-log_cli = True
-log_cli_level = WARNING

--- a/mock-bpa-test/requirements.txt
+++ b/mock-bpa-test/requirements.txt
@@ -1,5 +1,0 @@
-cbor2 ~= 5.6
-cbor-diag ~= 1.1
-pytest
-pytest-subtests
-pyyaml

--- a/mock-bpa-test/ruff.toml
+++ b/mock-bpa-test/ruff.toml
@@ -1,1 +1,0 @@
-line-length = 100

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -28,7 +28,7 @@ import select
 import socket
 import subprocess
 import unittest
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import cbor2
 from cbor_diag import cbor2diag, diag2cbor
@@ -47,14 +47,14 @@ class TestAgent(unittest.TestCase):
     def __init__(self, methodName="runTest"):
         super().__init__(methodName)
 
+        self._agent: Optional[CmdRunner] = None
+        self._ol_sock: Optional[socket.socket] = None
+        self._ul_sock: Optional[socket.socket] = None
+
     def setUp(self):
         path = os.path.abspath(os.path.join(OWNPATH, ".."))
         os.chdir(path)
         LOGGER.info("Working in %s", path)
-
-        self._agent = None
-        self._ol_sock = None
-        self._ul_sock = None
 
     def tearDown(self):
         self._stop()
@@ -167,24 +167,26 @@ class TestAgent(unittest.TestCase):
         LOGGER.debug(f"WAIT FOR GOT: {data.hex()}")
         return data
 
-    def _single_test(self, testcase: Optional[_TestCase]):
+    def _single_test(self, testcase: _TestCase):
         # start mock BPA using specified policy config
         self._start(testcase)
+        self._agent = cast(CmdRunner, self._agent)
 
         tx_data = self._encode(testcase.input_data, testcase.input_data_format)
 
-        test_sock = (
+        test_socket = (
             self._ol_sock if testcase.bundle_dest_loc == BundleDestLoc.APPIN else self._ul_sock
         )
+        test_sock = cast(socket.socket, test_socket)
+
+        if tx_data:
+            test_sock.send(tx_data)
+            LOGGER.info("Sent data:\n%s\n", tx_data.hex())
 
         if testcase.expected_output_format == DataFormat.ERR:
-            test_sock.send(tx_data)
             LOGGER.debug("waiting")
-
             with self.assertRaises(TimeoutError):
                 self._wait_for(test_sock, timeout=0.1)
-
-            LOGGER.info("\nTransferred data:\n%s\n", tx_data.hex())
 
             LOGGER.warning("Check log output to validate expected error")
 
@@ -199,9 +201,6 @@ class TestAgent(unittest.TestCase):
         else:
             # actual data
             expected_rx = self._encode(testcase.expected_output, testcase.expected_output_format)
-
-            test_sock.send(tx_data)
-            LOGGER.info("Sent data:\n%s\n", tx_data.hex())
 
             rx_data = self._wait_for(test_sock)
             if expected_rx is not None:
@@ -219,6 +218,4 @@ class TestStartStop(TestAgent):
 
     def test_start_stop(self):
         self._start(None)
-        ret = self._agent.stop()
-        self._agent = None
-        self.assertEqual(0, ret)
+        self._stop()

--- a/mock-bpa-test/test_bpa.py
+++ b/mock-bpa-test/test_bpa.py
@@ -27,16 +27,18 @@ import os
 import select
 import socket
 import subprocess
-from typing import Any, Optional
 import unittest
-import cbor2
-from cbor_diag import diag2cbor, cbor2diag
+from typing import Any, Optional
 
+import cbor2
+from cbor_diag import cbor2diag, diag2cbor
+
+from _test_util import BundleDestLoc, DataFormat, _TestCase
 from helpers import CmdRunner, compose_args
-from _test_util import _TestCase, DataFormat, BundleDestLoc
 
 OWNPATH = os.path.dirname(os.path.abspath(__file__))
 LOGGER = logging.getLogger(__name__)
+""" Logger for this module. """
 
 
 class TestAgent(unittest.TestCase):
@@ -158,7 +160,7 @@ class TestAgent(unittest.TestCase):
 
     def _wait_for(self, sock: socket.socket, timeout: float = 1.0) -> bytes:
         LOGGER.debug("Waiting for socket data...")
-        rrd, rwr, rxp = select.select([sock], [], [], timeout)
+        rrd, _rwr, _rxp = select.select([sock], [], [], timeout)
         if not rrd:
             raise TimeoutError("Did not receive bundle in time")
         data = sock.recv(65535)

--- a/mock-bpa-test/test_ccsds.py
+++ b/mock-bpa-test/test_ccsds.py
@@ -19,34 +19,37 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-import yaml
-import cbor2
-import binascii
 import json
-from _test_util import _TestCase, DataFormat, BundleDestLoc
+import logging
+import unittest
+
+import cbor2
+import yaml
+
+from _test_util import BundleDestLoc, DataFormat, _TestCase
 from test_bpa import TestAgent
 
+LOGGER = logging.getLogger(__name__)
+""" Logger for this module. """
 
-class TestCCSDS(TestAgent):
-    pass
 
-
-def load_ccsds():
+def load_ccsds(cls: TestAgent):
+    """Add test functions based on configuration file."""
     cases = {}
 
     ccsds_test_dir = "mock-bpa-test/ccsds_json/"
     ccsds_spec_file = "mock-bpa-test/ccsds_bpsec_redbook_requirements_modified.yaml"
 
     try:
-        s = open(ccsds_spec_file)
+        with open(ccsds_spec_file) as infile:
+            requirements = yaml.safe_load(infile)["requirements"]
     except FileNotFoundError:
-        print(f"Could not find {ccsds_spec_file}")
+        LOGGER.warning(f"Could not find {ccsds_spec_file}")
         return
 
-    requirements = yaml.safe_load(s)["requirements"]
     for item in requirements:
-        if "tests" not in item.keys():
-            # print(f'CCSDS | Item {item["item"]}: Skipping item - No test(s) specified.')
+        if "tests" not in item:
+            # LOGGER.error(f'CCSDS | Item {item["item"]}: Skipping item - No test(s) specified.')
             continue
 
         for t in item["tests"]:
@@ -56,23 +59,23 @@ def load_ccsds():
             outcome = t["outcome"].split(" ")[0] == "SUCCESS."
             if outcome:
                 input = t["incoming_bundle"]["hex"][2:].replace(" ", "")[:-1]
-                b_input = binascii.unhexlify(input)
+                b_input = bytes.fromhex(input)
                 cbor_input = cbor2.loads(b_input)
                 input_format = DataFormat.BUNDLEARRAY
 
                 output = t["outgoing_bundle"]["hex"][2:].replace(" ", "")[:-1]
-                b_output = binascii.unhexlify(output)
+                b_output = bytes.fromhex(output)
                 output = cbor2.loads(b_output)
                 output_format = DataFormat.BUNDLEARRAY
             else:
                 try:
                     input = t["incoming_bundle"]["hex"][2:].replace(" ", "")[:-1]
-                    b_input = binascii.unhexlify(input)
+                    b_input = bytes.fromhex(input)
                     cbor_input = cbor2.loads(b_input)
                     input_format = DataFormat.BUNDLEARRAY
 
-                except Exception:
-                    print(f"CCSDS | Test {t['test']}: Bundle hex not specified.")
+                except KeyError:
+                    LOGGER.error(f"CCSDS | Test {t['test']}: Bundle hex not specified.")
                     continue
 
                 output_format = DataFormat.ERR
@@ -102,7 +105,7 @@ def load_ccsds():
                 #       b[i|c]b_[a|s|v]_\d_\d
                 policy_desc = r["description"].split("_")
                 if len(policy_desc) != 4:
-                    print(f"CCSDS | Test {t['test']}: Policyrule {i} misconfigured.")
+                    LOGGER.error(f"CCSDS | Test {t['test']}: Policyrule {i} misconfigured.")
                     success = False
                     break
 
@@ -125,13 +128,15 @@ def load_ccsds():
                         params.append(bib_param_key_good)
 
                 else:
-                    print(f"CCSDS | Test {t['test']}: Policyrule {i} sec ctx misconfigured.")
+                    LOGGER.error(f"CCSDS | Test {t['test']}: Policyrule {i} sec ctx misconfigured.")
                     success = False
                     break
 
                 sec_role = policy_desc[1]
                 if sec_role != "s" and sec_role != "a" and sec_role != "v":
-                    print(f"CCSDS | Test {t['test']}: Policyrule {i} sec role misconfigured.")
+                    LOGGER.error(
+                        f"CCSDS | Test {t['test']}: Policyrule {i} sec role misconfigured."
+                    )
                     success = False
                     break
 
@@ -151,14 +156,14 @@ def load_ccsds():
                         "policy_action_on_fail": "delete_bundle",
                     }
                 }
-                print(f"Appending new Policy Rule {pr}")
+                LOGGER.info(f"Appending new Policy Rule {pr}")
                 policyrules.append(pr)
 
             if not success:
                 continue
 
             final_json = json.dumps({"policyrule_set": policyrules})
-            print(f"Final rule set {final_json}")
+            LOGGER.info(f"Final rule set {final_json}")
             finame = ccsds_test_dir + f"{t['test']}.json"
             with open(finame, "w") as f:
                 f.write(final_json)
@@ -175,7 +180,7 @@ def load_ccsds():
                 input_data_format=input_format,
                 expected_output_format=output_format,
             )
-            print(f"CCSDS | Test {t['test']}: Appending case.")
+            LOGGER.info(f"CCSDS | Test {t['test']}: Appending case.")
 
     def _make_test(case):
         def _test(self):
@@ -183,8 +188,10 @@ def load_ccsds():
 
         return _test
 
-    for id, case in cases.items():
-        setattr(TestCCSDS, f"test_{id}", _make_test(case))
+    for id, test_case in cases.items():
+        setattr(cls, f"test_{id}", _make_test(test_case))
 
 
-load_ccsds()
+@load_ccsds
+class TestCCSDS(TestAgent):
+    pass

--- a/mock-bpa-test/test_ccsds.py
+++ b/mock-bpa-test/test_ccsds.py
@@ -21,7 +21,6 @@
 #
 import json
 import logging
-import unittest
 
 import cbor2
 import yaml
@@ -33,7 +32,7 @@ LOGGER = logging.getLogger(__name__)
 """ Logger for this module. """
 
 
-def load_ccsds(cls: TestAgent):
+def load_ccsds(cls: type[TestAgent]):
     """Add test functions based on configuration file."""
     cases = {}
 

--- a/mock-bpa-test/test_cose_sc.py
+++ b/mock-bpa-test/test_cose_sc.py
@@ -26,8 +26,9 @@ import json
 import logging
 import os
 import tempfile
-from typing import Any, Dict
-from _test_util import _TestCase, DataFormat, BundleDestLoc
+from typing import Any
+
+from _test_util import BundleDestLoc, DataFormat, _TestCase
 from test_bpa import TestAgent
 
 OWNPATH = os.path.dirname(os.path.abspath(__file__))
@@ -120,7 +121,7 @@ CCSDS_MAC_WITH_BIB = """\
 
 
 @contextlib.contextmanager
-def sc_config_modifier(orig: str, modify: Dict[str, Any]):
+def sc_config_modifier(orig: str, modify: dict[str, Any]):
     """A context for modifying baseline configurations"""
     with tempfile.NamedTemporaryFile("w+", suffix=".json") as polfile:
         with open(os.path.join(OWNPATH, orig), "r") as infile:

--- a/mock-bpa-test/test_json_policy.py
+++ b/mock-bpa-test/test_json_policy.py
@@ -19,7 +19,7 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from _test_util import _TestCase, DataFormat, BundleDestLoc
+from _test_util import BundleDestLoc, DataFormat, _TestCase
 from test_bpa import TestAgent
 
 # Test Cases utilizing JSON policy definitions with the Default contexts

--- a/mock-bpa-test/test_requirements.py
+++ b/mock-bpa-test/test_requirements.py
@@ -19,7 +19,7 @@
 # the prime contract 80NM0018D0004 between the Caltech and NASA under
 # subcontract 1700763.
 #
-from _test_util import _TestCase, DataFormat, BundleDestLoc
+from _test_util import BundleDestLoc, DataFormat, _TestCase
 from test_bpa import TestAgent
 
 # Test Cases specified by the Requirements Document
@@ -331,7 +331,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 expected_output=[
                     [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
                     [
@@ -353,7 +352,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x2A0",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -386,7 +384,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 expected_output=[
                     [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
                     [
@@ -417,7 +414,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x04",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -452,7 +448,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 expected_output=[
                     [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
                     [
@@ -508,7 +503,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 expected_output=[
                     [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
                     [
@@ -521,7 +515,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0xA2",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -739,7 +732,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x04",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -789,7 +781,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x04",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -1411,7 +1402,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x96",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",
@@ -1462,7 +1452,6 @@ class TestRequirements(TestAgent):
                         ),
                     ],
                 ],
-                #
                 policy_config="0x105",
                 bundle_dest_loc=BundleDestLoc.CLIN,
                 key_set="data/key_set_1.json",

--- a/resources/apply_format.sh
+++ b/resources/apply_format.sh
@@ -58,5 +58,13 @@ do
 done
 
 # Python test fixtures
-ruff check --fix mock-bpa-test/
-ruff format mock-bpa-test/
+pushd mock-bpa-test/
+ANYERR=0
+ruff format || ANYERR=$((ANYERR + 1))
+ruff check --fix || ANYERR=$((ANYERR + 1))
+ty check --fix || ANYERR=$((ANYERR + 1))
+popd
+if [[ "${ANYERR}" -ne 0 ]]
+then
+    exit ${ANYERR}
+fi

--- a/resources/apply_format.sh
+++ b/resources/apply_format.sh
@@ -62,7 +62,10 @@ pushd mock-bpa-test/
 ANYERR=0
 ruff format || ANYERR=$((ANYERR + 1))
 ruff check --fix || ANYERR=$((ANYERR + 1))
-ty check --fix || ANYERR=$((ANYERR + 1))
+if which ty
+then
+    ty check --fix || ANYERR=$((ANYERR + 1))
+fi
 popd
 if [[ "${ANYERR}" -ne 0 ]]
 then

--- a/resources/check_format.sh
+++ b/resources/check_format.sh
@@ -22,7 +22,7 @@
 ##
 set -e
 
-if [[ -z "$SELFDIR" ]];
+if [[ -z "$SELFDIR" ]]
 then
     echo "$SELFDIR not defined"
     exit 1
@@ -35,10 +35,11 @@ echo "Check format from root: $SELFDIR"
 ./resources/apply_format.sh
 ./resources/apply_license.sh
 
-if ! git diff -q; then
-  echo "Error: Files changed after formatting:"
-  git diff
-  exit 1
+if ! git diff --quiet
+then
+    echo "Error: Files changed after formatting:"
+    git diff
+    exit 1
 fi
 
 exit 0

--- a/src/bsl/cose_sc/AadScope.c
+++ b/src/bsl/cose_sc/AadScope.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025-2026 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
 #include "AadScope.h"
 
 int BSLX_CoseSc_AadScope_Encode(QCBOREncodeContext *enc, const BSLX_CoseSc_AadScope_t *scope)

--- a/src/bsl/crypto/KeyLoader.c
+++ b/src/bsl/crypto/KeyLoader.c
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025-2026 The Johns Hopkins University Applied Physics
+ * Laboratory LLC.
+ *
+ * This file is part of the Bundle Protocol Security Library (BSL).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This work was performed for the Jet Propulsion Laboratory, California
+ * Institute of Technology, sponsored by the United States Government under
+ * the prime contract 80NM0018D0004 between the Caltech and NASA under
+ * subcontract 1700763.
+ */
 #include "KeyLoader.h"
 
 #include <bsl/front/TextUtil.h>


### PR DESCRIPTION
This was broken by upstream behavior change between versions.

This change also applies ruff checks to the source.