### PR TITLE
Fix when BSL_Data_t resizing from a view

### DIFF
--- a/src/Data.c
+++ b/src/Data.c
@@ -154,17 +154,25 @@ int BSL_Data_Resize(BSL_Data_t *data, size_t len)
         return BSL_SUCCESS;
     }
 
+    BSL_DataConstPtr_t need_cpy = NULL;
     if (!data->owned)
     {
+        need_cpy  = data->ptr;
         data->ptr = NULL;
     }
     BSL_DataPtr_t got = BSL_realloc(data->ptr, len);
     if (UNLIKELY(!got))
     {
         bsl_data_int_reset(data);
-        BSL_LOG_ERR("Failed to realloc");
+        BSL_LOG_CRIT("Failed to realloc");
         return BSL_ERR_INSUFFICIENT_SPACE;
     }
+    if (need_cpy)
+    {
+        // copy old data only when it was a view
+        memcpy(got, need_cpy, data->len);
+    }
+
     data->owned = true;
     data->ptr   = got;
     data->len   = len;


### PR DESCRIPTION
This was not triggered by the default SCs in v1.1 but was seen for later SC work.