### PR TITLE
Default SCs enforce optional config for verifier/acceptor

### DIFF
--- a/mock-bpa-test/_test_util.py
+++ b/mock-bpa-test/_test_util.py
@@ -81,7 +81,9 @@ class _TestCase:
 
 
 @contextlib.contextmanager
-def sc_config_modifier(orig: str, modify: dict[str, Any]) -> Generator[str, None, None]:
+def sc_config_modifier(
+    orig: str, modify: Optional[dict[str, Any]] = None, role: Optional[str] = None
+) -> Generator[str, None, None]:
     """A context for modifying baseline configurations
 
     :param orig: The original file path, relative to this directory.
@@ -93,22 +95,28 @@ def sc_config_modifier(orig: str, modify: dict[str, Any]) -> Generator[str, None
         with open(orig, "r") as infile:
             poldata = json.load(infile)
 
-        params = poldata["policyrule_set"][0]["policyrule"]["spec"]["sc_parms"]
-        LOGGER.debug("Original params:\n%s", params)
-        if isinstance(params, dict):
-            params |= modify
-        elif isinstance(params, list):
-            # replace existing
-            for pair in params:
-                key = pair["id"]
-                if key in modify:
-                    pair["value"] = str(modify.pop(key))
-            # add remaining
-            for key, val in modify.items():
-                params.append({"id": key, "value": str(val)})
-        else:
-            raise TypeError(f"bad type {type(params)}")
-        LOGGER.debug("Modified params:\n%s", params)
+        rule = poldata["policyrule_set"][0]["policyrule"]
+
+        if role:
+            rule["filter"]["role"] = role
+
+        if modify:
+            params = rule["spec"]["sc_parms"]
+            LOGGER.debug("Original params:\n%s", params)
+            if isinstance(params, dict):
+                params |= modify
+            elif isinstance(params, list):
+                # replace existing
+                for pair in params:
+                    key = pair["id"]
+                    if key in modify:
+                        pair["value"] = str(modify.pop(key))
+                # add remaining
+                for key, val in modify.items():
+                    params.append({"id": key, "value": str(val)})
+            else:
+                raise TypeError(f"bad type {type(params)}")
+            LOGGER.debug("Modified params:\n%s", params)
 
         json.dump(poldata, polfile)
         polfile.flush()

--- a/mock-bpa-test/data/default-scs/policy-exA.1-accept.json
+++ b/mock-bpa-test/data/default-scs/policy-exA.1-accept.json
@@ -15,8 +15,6 @@
           "sc_id": 1,
           "sc_parms": {
             "key_name": "ExampleA.1",
-            "sha_variant": 7,
-            "scope_flags": 0,
             "key_wrap": 0
           }
         },

--- a/mock-bpa-test/data/default-scs/policy-exA.2-accept.json
+++ b/mock-bpa-test/data/default-scs/policy-exA.2-accept.json
@@ -15,8 +15,6 @@
           "sc_id": 2,
           "sc_parms": {
             "key_name": "ExampleA.2",
-            "aes_variant": 1,
-            "aad_scope": 0,
             "key_wrap": 1
           }
         },

--- a/mock-bpa-test/test_default_scs.py
+++ b/mock-bpa-test/test_default_scs.py
@@ -23,7 +23,6 @@
 
 import logging
 import os
-import unittest
 
 from _test_util import BundleDestLoc, DataFormat, _TestCase, sc_config_modifier
 from test_bpa import TestAgent
@@ -99,7 +98,7 @@ class TestBibHmacSha(TestAgent):
             )
         )
 
-    def test_exampleA_1_acceptor_valid_match(self):
+    def test_exampleA_1_acceptor_valid_loose(self):
         self._single_test(
             _TestCase(
                 input_data=EXAMPLE_A_1_WITH_BIB,
@@ -112,6 +111,42 @@ class TestBibHmacSha(TestAgent):
                 expected_output_format=DataFormat.CBORDIAG,
             )
         )
+
+    def test_exampleA_1_acceptor_valid_nulls(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.1-accept.json"),
+            modify={"sha_variant": None, "scope_flags": None},
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_1_WITH_BIB,
+                    expected_output=EXAMPLE_A_NO_SEC,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
+                )
+            )
+
+    def test_exampleA_1_acceptor_valid_match(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.1-accept.json"),
+            modify={"sha_variant": 7, "scope_flags": 0},
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_1_WITH_BIB,
+                    expected_output=EXAMPLE_A_NO_SEC,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
+                )
+            )
 
     def test_exampleA_1_acceptor_failure_key_mismatch(self):
         with sc_config_modifier(
@@ -149,8 +184,7 @@ class TestBibHmacSha(TestAgent):
                 )
             )
 
-    @unittest.skip("the operation still proceeds after mismatch")
-    def test_exampleA_1_acceptor_failure_aad_mismatch(self):
+    def test_exampleA_1_acceptor_failure_scope_mismatch(self):
         with sc_config_modifier(
             orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.1-accept.json"),
             modify={"scope_flags": 0x1},
@@ -158,13 +192,32 @@ class TestBibHmacSha(TestAgent):
             self._single_test(
                 _TestCase(
                     input_data=EXAMPLE_A_1_WITH_BIB,
-                    expected_output=".*<WARNING>.* IPPT Scope mismatch, needed 1 got 0",
+                    expected_output=".*<ERROR>.* IPPT scope mismatch, needed 1 got 0",
                     sec_src_eid="ipn:1.0",
                     policy_config=polfile_path,
                     bundle_dest_loc=BundleDestLoc.APPIN,
                     key_set="data/default-scs/keyset-1.json",
                     input_data_format=DataFormat.CBORDIAG,
                     expected_output_format=DataFormat.ERR,
+                )
+            )
+
+    def test_exampleA_1_verifier_valid_match(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.1-accept.json"),
+            modify={"sha_variant": 7, "scope_flags": 0},
+            role="v",
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_1_WITH_BIB,
+                    expected_output=EXAMPLE_A_1_WITH_BIB,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
                 )
             )
 
@@ -198,7 +251,7 @@ class TestBcbAesGcm(TestAgent):
             )
         )
 
-    def test_exampleA_2_acceptor_valid_match(self):
+    def test_exampleA_2_acceptor_valid_loose(self):
         self._single_test(
             _TestCase(
                 input_data=EXAMPLE_A_2_WITH_BCB,
@@ -211,6 +264,42 @@ class TestBcbAesGcm(TestAgent):
                 expected_output_format=DataFormat.CBORDIAG,
             )
         )
+
+    def test_exampleA_2_acceptor_valid_nulls(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.2-accept.json"),
+            modify={"aes_variant": None, "aad_scope": None},
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_2_WITH_BCB,
+                    expected_output=EXAMPLE_A_NO_SEC,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
+                )
+            )
+
+    def test_exampleA_2_acceptor_valid_match(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.2-accept.json"),
+            modify={"aes_variant": 1, "aad_scope": 0},
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_2_WITH_BCB,
+                    expected_output=EXAMPLE_A_NO_SEC,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
+                )
+            )
 
     def test_exampleA_2_acceptor_failure_key_mismatch(self):
         with sc_config_modifier(
@@ -248,8 +337,7 @@ class TestBcbAesGcm(TestAgent):
                 )
             )
 
-    @unittest.skip("the operation still proceeds after mismatch")
-    def test_exampleA_2_acceptor_failure_aad_mismatch(self):
+    def test_exampleA_2_acceptor_failure_scope_mismatch(self):
         with sc_config_modifier(
             orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.2-accept.json"),
             modify={"aad_scope": 0x1},
@@ -257,13 +345,32 @@ class TestBcbAesGcm(TestAgent):
             self._single_test(
                 _TestCase(
                     input_data=EXAMPLE_A_2_WITH_BCB,
-                    expected_output=".*<WARNING>.* AAD Scope mismatch, needed 1 got 0",
+                    expected_output=".*<ERROR>.* AAD scope mismatch, needed 1 got 0",
                     sec_src_eid="ipn:1.0",
                     policy_config=polfile_path,
                     bundle_dest_loc=BundleDestLoc.APPIN,
                     key_set="data/default-scs/keyset-1.json",
                     input_data_format=DataFormat.CBORDIAG,
                     expected_output_format=DataFormat.ERR,
+                )
+            )
+
+    def test_exampleA_2_verifier_valid_match(self):
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.2-accept.json"),
+            modify={"aes_variant": 1, "aad_scope": 0},
+            role="v",
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_2_WITH_BCB,
+                    expected_output=EXAMPLE_A_2_WITH_BCB,
+                    sec_src_eid="ipn:1.0",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/default-scs/keyset-1.json",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
                 )
             )
 

--- a/src/bsl/default_sc/BCB_AES_GCM.c
+++ b/src/bsl/default_sc/BCB_AES_GCM.c
@@ -399,11 +399,17 @@ int BSLX_BCB_GetOptions(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, 
     param = BSL_SecOper_FindOption(sec_oper, BSLX_BCB_OPT_AES_VARIANT);
     if (param)
     {
-        res = BSL_Variant_GetAsInt64(param, &bcb_context->aes_variant);
+        int64_t as_int;
+        res = BSL_Variant_GetAsInt64(param, &as_int);
         if (BSL_SUCCESS != res)
         {
             BSL_LOG_ERR("Invalid AES variant value");
             bcb_context->err_count++;
+        }
+        else
+        {
+            bcb_context->aes_variant     = as_int;
+            bcb_context->opt_aes_variant = true;
         }
         // later validation checks the actual int values
     }
@@ -450,17 +456,36 @@ int BSLX_BCB_GetOptions(const BSL_BundleRef_t *bundle, BSLX_BCB_t *bcb_context, 
     param = BSL_SecOper_FindOption(sec_oper, BSLX_BCB_OPT_USE_KEY_WRAP);
     if (param)
     {
-        res = BSL_Variant_GetAsInt64(param, &bcb_context->keywrap);
+        int64_t as_int;
+        res = BSL_Variant_GetAsInt64(param, &as_int);
         if (BSL_SUCCESS != res)
         {
             BSL_LOG_ERR("Invalid use key wrap value");
             bcb_context->err_count++;
         }
+        else
+        {
+            bcb_context->keywrap     = (as_int != 0);
+            bcb_context->opt_keywrap = true;
+        }
     }
 
-    if (bcb_context->keywrap < 0)
+    if (bcb_context->is_source)
     {
-        BSL_LOG_WARNING("BCB USE KEYWRAP param required.");
+        if (!bcb_context->opt_aes_variant)
+        {
+            BSL_LOG_ERR("BCB AES variant option is required");
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
+        if (!bcb_context->opt_aad_scope)
+        {
+            BSL_LOG_ERR("BCB AAD scope option is required");
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
+    }
+    if (!bcb_context->opt_keywrap)
+    {
+        BSL_LOG_ERR("BCB use keywrap option is required");
         return BSL_ERR_PROPERTY_CHECK_FAILED;
     }
 
@@ -567,41 +592,56 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib _U_, BSL_BundleRef_t *bundle, BSL_SecOper
             }
         }
 
+        int64_t aes_variant = -1;
+        // actual parameter or default
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BCB_SECPARAM_AESVARIANT);
         if (param)
         {
-            int64_t got;
-            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &got))
+            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &aes_variant))
             {
                 BSL_LOG_ERR("AES variant parameter is not valid");
                 bcb_context.err_count++;
             }
-            else if (got != bcb_context.aes_variant)
-            {
-                BSL_LOG_ERR("AES variant mismatch, needed %d got %d", bcb_context.aes_variant, got);
-                bcb_context.err_count++;
-            }
         }
+        else
+        {
+            // Default from RFC 9173
+            aes_variant = RFC9173_BCB_AES_VARIANT_A256GCM;
+        }
+        if (bcb_context.opt_aes_variant && (aes_variant != bcb_context.aes_variant))
+        {
+            BSL_LOG_ERR("AES variant mismatch, needed %d got %d", bcb_context.aes_variant, aes_variant);
+            bcb_context.err_count++;
+        }
+        BSL_LOG_DEBUG("using AES variant %" PRId64, aes_variant);
+        bcb_context.aes_variant = aes_variant;
 
+        int64_t aad_scope = -1;
+        // actual parameter or default
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BCB_SECPARAM_AADSCOPE);
         if (param)
         {
-            int64_t got;
-            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &got))
+            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &aad_scope))
             {
                 BSL_LOG_ERR("AAD scope parameter is not valid");
                 bcb_context.err_count++;
             }
-            else
-            {
-                if (bcb_context.opt_aad_scope && (got != bcb_context.aad_scope))
-                {
-                    BSL_LOG_WARNING("AAD Scope mismatch, needed %d got %d", bcb_context.aad_scope, got);
-                }
-                bcb_context.aad_scope = got;
-            }
         }
+        else
+        {
+            // Default from RFC 9173
+            aad_scope = 0x07;
+        }
+        if (bcb_context.opt_aad_scope && (aad_scope != bcb_context.aad_scope))
+        {
+            BSL_LOG_ERR("AAD scope mismatch, needed %d got %d", bcb_context.aad_scope, aad_scope);
+            bcb_context.err_count++;
+        }
+        BSL_LOG_DEBUG("using AAD scope %" PRId64, aad_scope);
+        bcb_context.aad_scope = aad_scope;
 
+        bool has_keywrap = false;
+        // actual parameter determines unwrapping
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BCB_SECPARAM_WRAPPEDKEY);
         if (param)
         {
@@ -612,7 +652,14 @@ int BSLX_BCB_Execute(BSL_LibCtx_t *lib _U_, BSL_BundleRef_t *bundle, BSL_SecOper
                 bcb_context.err_count++;
             }
             BSL_LOG_DEBUG("Wrapped key parameter used");
+            has_keywrap = true;
         }
+        if (bcb_context.opt_keywrap && (has_keywrap != bcb_context.keywrap))
+        {
+            BSL_LOG_ERR("keywrap mismatch, needed %d got %d", bcb_context.keywrap, has_keywrap);
+            bcb_context.err_count++;
+        }
+        bcb_context.keywrap = has_keywrap;
 
         param = BSL_SecOper_FindResult(sec_oper, RFC9173_BCB_RESULTID_AUTHTAG);
         if (param)

--- a/src/bsl/default_sc/BIB_HMAC_SHA2.c
+++ b/src/bsl/default_sc/BIB_HMAC_SHA2.c
@@ -94,7 +94,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
     self->err_count       = 0;
     self->opt_sha_variant = false;
     self->opt_ippt_scope  = false;
-    self->keywrap         = -1;
+    self->opt_keywrap     = false;
     BSL_Data_Init(&self->wrapped_key);
     BSL_Data_Init(&self->hmac_result_val);
 
@@ -119,7 +119,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
         int64_t as_int;
         if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &as_int))
         {
-            BSL_LOG_ERR("Invalid SHA Varriant value");
+            BSL_LOG_ERR("Invalid SHA Variant value");
             self->err_count++;
         }
         else
@@ -134,7 +134,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
         int64_t as_int;
         if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &as_int))
         {
-            BSL_LOG_ERR("Invalid SHA Varriant value");
+            BSL_LOG_ERR("Invalid SHA Variant value");
             self->err_count++;
         }
         else
@@ -156,43 +156,49 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
     param = BSL_SecOper_FindOption(sec_oper, BSLX_BIB_OPT_USE_KEY_WRAP);
     if (param)
     {
-        if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &self->keywrap))
+        int64_t as_int;
+        if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &as_int))
         {
             BSL_LOG_ERR("Invalid Key Wrap value");
             self->err_count++;
         }
         else
         {
-            BSL_LOG_DEBUG("Param[%" PRIu64 "]: USE_WRAPPED_KEY value = %" PRIu64, BSLX_BIB_OPT_USE_KEY_WRAP,
-                          self->keywrap);
+            self->keywrap     = (as_int != 0);
+            self->opt_keywrap = true;
         }
     }
 
-    if (self->keywrap < 0)
+    if (self->is_source)
     {
-        BSL_LOG_WARNING("BIB USE KEYWRAP option is required.");
-        return BSL_ERR_PROPERTY_CHECK_FAILED;
+        if (!self->opt_sha_variant)
+        {
+            BSL_LOG_ERR("BIB sha variant option is required");
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
+        if (!self->opt_ippt_scope)
+        {
+            BSL_LOG_ERR("BIB IPPT scope option is required");
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
+        if (!self->opt_keywrap)
+        {
+            BSL_LOG_ERR("BIB use keywrap option is required");
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
     }
 
-    if (!self->opt_sha_variant)
+    // validate early
+    if (self->opt_sha_variant)
     {
-        // Default is SHA384: https://www.rfc-editor.org/rfc/rfc9173.html#name-block-integrity-block
-        BSL_LOG_DEBUG("No SHA Variant set, defaulting to SHA_HMAC384");
-        self->sha_variant = RFC9173_BIB_SHA_HMAC384;
-    }
-    self->crypto_sha_variant = map_rfc9173_sha_variant_to_crypto(self->sha_variant);
-    if (self->crypto_sha_variant < 0)
-    {
-        BSL_LOG_WARNING("BIB SHA varient required.");
-        return BSL_ERR_PROPERTY_CHECK_FAILED;
+        self->crypto_sha_variant = map_rfc9173_sha_variant_to_crypto(self->sha_variant);
+        if (self->crypto_sha_variant < 0)
+        {
+            BSL_LOG_WARNING("BIB SHA variant invalid %" PRId64, self->sha_variant);
+            return BSL_ERR_PROPERTY_CHECK_FAILED;
+        }
     }
 
-    if (!self->opt_ippt_scope)
-    {
-        // If none given, assume they must all be true per spec.
-        BSL_LOG_DEBUG("No scope flag set, defaulting to everything (0x07)");
-        self->ippt_scope = 0x07;
-    }
     return BSL_SUCCESS;
 }
 
@@ -423,44 +429,61 @@ int BSLX_BIB_Execute(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, BSL_SecOper_t *
         // find the existing parameters and results
         const BSL_Variant_t *param;
 
+        int64_t sha_variant = -1;
+        // actual parameter or default
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BIB_PARAMID_SHA_VARIANT);
         if (param)
         {
-            int64_t got;
-            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &got))
+            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &sha_variant))
             {
                 BSL_LOG_ERR("SHA variant parameter is not valid");
                 bib_context.err_count++;
             }
-            else if (bib_context.opt_sha_variant && (got != bib_context.sha_variant))
-            {
-                BSL_LOG_ERR("SHA variant mismatch, needed %d got %d", bib_context.sha_variant, got);
-                bib_context.err_count++;
-            }
-            else
-            {
-                bib_context.sha_variant = got;
-            }
         }
+        else
+        {
+            // Default is SHA384: https://www.rfc-editor.org/rfc/rfc9173.html#name-block-integrity-block
+            BSL_LOG_DEBUG("No SHA Variant set, defaulting to SHA_HMAC384");
+            sha_variant = RFC9173_BIB_SHA_HMAC384;
+        }
+        bib_context.crypto_sha_variant = map_rfc9173_sha_variant_to_crypto(sha_variant);
+        if (bib_context.crypto_sha_variant < 0)
+        {
+            BSL_LOG_ERR("BIB SHA variant invalid %" PRId64, sha_variant);
+            bib_context.err_count++;
+        }
+        if (bib_context.opt_sha_variant && (sha_variant != bib_context.sha_variant))
+        {
+            BSL_LOG_ERR("SHA variant mismatch, needed %" PRIu64 " got %" PRIu64, bib_context.sha_variant, sha_variant);
+            bib_context.err_count++;
+        }
+        BSL_LOG_DEBUG("using SHA variant %" PRId64, sha_variant);
+        bib_context.sha_variant = sha_variant;
 
+        int64_t ippt_scope = -1;
+        // actual parameter or default
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BIB_PARAMID_INTEG_SCOPE_FLAG);
         if (param)
         {
-            int64_t got;
-            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &got))
+            if (BSL_SUCCESS != BSL_Variant_GetAsInt64(param, &ippt_scope))
             {
                 BSL_LOG_ERR("IPPT Scope parameter is not valid");
                 bib_context.err_count++;
             }
-            else
-            {
-                if (bib_context.opt_ippt_scope && (got != bib_context.ippt_scope))
-                {
-                    BSL_LOG_WARNING("IPPT Scope mismatch, needed %d got %d", bib_context.ippt_scope, got);
-                }
-                bib_context.ippt_scope = got;
-            }
         }
+        else
+        {
+            // If none given, assume they must all be true per spec.
+            BSL_LOG_DEBUG("No scope flag set, defaulting to everything (0x07)");
+            ippt_scope = 0x07;
+        }
+        if (bib_context.opt_ippt_scope && (ippt_scope != bib_context.ippt_scope))
+        {
+            BSL_LOG_ERR("IPPT scope mismatch, needed %" PRIu64 " got %" PRIu64, bib_context.ippt_scope, ippt_scope);
+            bib_context.err_count++;
+        }
+        BSL_LOG_DEBUG("using IPPT scope %" PRId64, ippt_scope);
+        bib_context.ippt_scope = ippt_scope;
 
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BIB_PARAMID_WRAPPED_KEY);
         if (param)

--- a/src/bsl/default_sc/BIB_HMAC_SHA2.c
+++ b/src/bsl/default_sc/BIB_HMAC_SHA2.c
@@ -173,7 +173,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
     {
         if (!self->opt_sha_variant)
         {
-            BSL_LOG_ERR("BIB sha variant option is required");
+            BSL_LOG_ERR("BIB SHA variant option is required");
             return BSL_ERR_PROPERTY_CHECK_FAILED;
         }
         if (!self->opt_ippt_scope)
@@ -181,11 +181,11 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
             BSL_LOG_ERR("BIB IPPT scope option is required");
             return BSL_ERR_PROPERTY_CHECK_FAILED;
         }
-        if (!self->opt_keywrap)
-        {
-            BSL_LOG_ERR("BIB use keywrap option is required");
-            return BSL_ERR_PROPERTY_CHECK_FAILED;
-        }
+    }
+    if (!self->opt_keywrap)
+    {
+        BSL_LOG_ERR("BIB use keywrap option is required");
+        return BSL_ERR_PROPERTY_CHECK_FAILED;
     }
 
     // validate early
@@ -485,6 +485,8 @@ int BSLX_BIB_Execute(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, BSL_SecOper_t *
         BSL_LOG_DEBUG("using IPPT scope %" PRId64, ippt_scope);
         bib_context.ippt_scope = ippt_scope;
 
+        bool has_keywrap = false;
+        // actual parameter determines unwrapping
         param = BSL_SecOper_FindParam(sec_oper, RFC9173_BIB_PARAMID_WRAPPED_KEY);
         if (param)
         {
@@ -494,7 +496,14 @@ int BSLX_BIB_Execute(BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle, BSL_SecOper_t *
                 bib_context.err_count++;
             }
             BSL_LOG_DEBUG("Wrapped key parameter used");
+            has_keywrap = true;
         }
+        if (bib_context.opt_keywrap && (has_keywrap != bib_context.keywrap))
+        {
+            BSL_LOG_ERR("keywrap mismatch, needed %d got %d", bib_context.keywrap, has_keywrap);
+            bib_context.err_count++;
+        }
+        bib_context.keywrap = has_keywrap;
     }
     if (bib_context.err_count)
     {

--- a/src/bsl/default_sc/DefaultSecContext_Private.h
+++ b/src/bsl/default_sc/DefaultSecContext_Private.h
@@ -71,6 +71,7 @@ typedef struct BSLX_BIB_s
     BSL_PrimaryBlock_t   primary_block;
     BSL_CanonicalBlock_t target_block;
     BSL_CanonicalBlock_t sec_block;
+
     /// True if #ippt_scope came from an option
     bool opt_ippt_scope;
     /// Required IPPT scope
@@ -81,7 +82,6 @@ typedef struct BSLX_BIB_s
     int64_t sha_variant;
     /// Converted #sha_variant into enum value
     BSL_Crypto_SHAVariant_e crypto_sha_variant;
-
     /// True if key wrap is enabled
     bool keywrap;
     /// True if #keywrap came from an option
@@ -123,6 +123,8 @@ typedef struct BSLX_BCB_s
     BSL_CipherMode_e crypto_mode;
     /// Required AES variant (external code point)
     int64_t aes_variant;
+    /// True if #aes_variant came from an option
+    bool opt_aes_variant;
     /// Internal enumeration for #aes_variant
     BSL_Crypto_AESVariant_e bsl_aes;
     /// Required key size for #aes_variant
@@ -132,14 +134,17 @@ typedef struct BSLX_BCB_s
     bool opt_aad_scope;
     /// Required AAD scope
     int64_t aad_scope;
+    /// True if key wrap is enabled
+    bool keywrap;
+    /// True if #keywrap came from an option
+    bool opt_keywrap;
 
     // Metadata about bundles and blocks
     BSL_PrimaryBlock_t   primary_block;
     BSL_CanonicalBlock_t sec_block;
     BSL_CanonicalBlock_t target_block;
 
-    int64_t keywrap;
-    bool    success;
+    bool success;
     /// True if this is a source or acceptor role and target BTSD is replaced
     bool overwrite_btsd;
 } BSLX_BCB_t;

--- a/src/bsl/default_sc/DefaultSecContext_Private.h
+++ b/src/bsl/default_sc/DefaultSecContext_Private.h
@@ -82,8 +82,12 @@ typedef struct BSLX_BIB_s
     /// Converted #sha_variant into enum value
     BSL_Crypto_SHAVariant_e crypto_sha_variant;
 
+    /// True if key wrap is enabled
+    bool keywrap;
+    /// True if #keywrap came from an option
+    bool opt_keywrap;
+
     BSL_Data_t wrapped_key;
-    int64_t    keywrap;
     BSL_Data_t hmac_result_val;
 } BSLX_BIB_t;
 

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -127,6 +127,26 @@ static int BSLP_GetBoolean(const json_t *value, bool *as_bool)
     }
 }
 
+/** Add an option variant if a value is non-null or erase it if the value is null.
+ *
+ * @param[in] options The map to modify.
+ * @param key The option ID.
+ * @param value The config value.
+ * @return Non-NULL if value is to be set or NULL.
+ */
+static BSL_Variant_t *BSLP_OptionAddOrErase(BSLB_VariantPtrMap_t options, int64_t key, const json_t *value)
+{
+    if (json_is_null(value))
+    {
+        BSLB_VariantPtrMap_erase(options, key);
+        return NULL;
+    }
+    else
+    {
+        return BSLB_VariantPtrMap_add(options, key);
+    }
+}
+
 /// Type for individual option handling according to each SC
 typedef int (*BSLP_OptionHandler_f)(BSLB_VariantPtrMap_t options, const char *id_str, json_t *value);
 
@@ -137,41 +157,50 @@ static int BSLP_PolicyOptions_SC1(BSLB_VariantPtrMap_t options, const char *id_s
 {
     if (0 == strcmp(id_str, "key_name"))
     {
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BIB_OPT_KEY_ID);
-        BSL_Variant_SetTextstr(opt, json_string_value(value));
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BIB_OPT_KEY_ID, value);
+        if (opt)
+        {
+            BSL_Variant_SetTextstr(opt, json_string_value(value));
+        }
     }
     else if (0 == strcmp(id_str, "sha_variant"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BIB_OPT_SHA_VARIANT, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BIB_OPT_SHA_VARIANT);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcmp(id_str, "scope_flags"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BIB_OPT_SCOPE, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BIB_OPT_SCOPE);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcmp(id_str, "key_wrap"))
     {
-        bool as_bool;
-        if (BSLP_GetBoolean(value, &as_bool))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BIB_OPT_USE_KEY_WRAP, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            bool as_bool;
+            if (BSLP_GetBoolean(value, &as_bool))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, (int64_t)as_bool);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BIB_OPT_USE_KEY_WRAP);
-        BSL_Variant_SetInt64(opt, (int64_t)as_bool);
     }
     else
     {
@@ -188,41 +217,50 @@ static int BSLP_PolicyOptions_SC2(BSLB_VariantPtrMap_t options, const char *id_s
 {
     if (0 == strcmp(id_str, "key_name"))
     {
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BCB_OPT_KEY_ID);
-        BSL_Variant_SetTextstr(opt, json_string_value(value));
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BCB_OPT_KEY_ID, value);
+        if (opt)
+        {
+            BSL_Variant_SetTextstr(opt, json_string_value(value));
+        }
     }
     else if (0 == strcmp(id_str, "aes_variant"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BCB_OPT_AES_VARIANT, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BCB_OPT_AES_VARIANT);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcmp(id_str, "aad_scope"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BCB_OPT_SCOPE, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BCB_OPT_SCOPE);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcmp(id_str, "key_wrap"))
     {
-        bool as_bool;
-        if (BSLP_GetBoolean(value, &as_bool))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_BCB_OPT_USE_KEY_WRAP, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            bool as_bool;
+            if (BSLP_GetBoolean(value, &as_bool))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, (int64_t)as_bool);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_BCB_OPT_USE_KEY_WRAP);
-        BSL_Variant_SetInt64(opt, (int64_t)as_bool);
     }
     else
     {
@@ -239,123 +277,140 @@ static int BSLP_PolicyOptions_SC3(BSLB_VariantPtrMap_t options, const char *id_s
 {
     if (0 == strcmp(id_str, "key_id"))
     {
-        const char *val_str = json_string_value(value);
-        if (!val_str)
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_KEY_ID, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            const char *val_str = json_string_value(value);
+            if (!val_str)
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Data_t as_bytes = BSL_DATA_INIT_VIEW_CSTR(val_str);
+            BSL_Variant_SetBytestr(opt, as_bytes);
         }
-        BSL_Data_t as_bytes = BSL_DATA_INIT_VIEW_CSTR(val_str);
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_KEY_ID);
-        BSL_Variant_SetBytestr(opt, as_bytes);
     }
     else if (0 == strcasecmp(id_str, "target_alg"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_TGT_ALG, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_TGT_ALG);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcasecmp(id_str, "aad_scope"))
     {
-        void *val_it = json_object_iter(value);
-        if (!val_it)
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_AAD_SCOPE, value);
+        if (opt)
         {
-            BSL_LOG_ERR("AAD Scope is not an object");
-            return BSL_ERR_POLICY_CONFIG;
-        }
-
-        const size_t                 scope_count = json_object_size(value);
-        BSLX_CoseSc_AadScope_Item_t *scope       = BSL_calloc(scope_count, sizeof(BSLX_CoseSc_AadScope_Item_t));
-        for (size_t item_ix = 0; val_it; ++item_ix)
-        {
-            int64_t blk_num;
-            if (BSLP_GetTextAsInt(&blk_num, json_object_iter_key(val_it), json_object_iter_key_len(val_it)))
+            void *val_it = json_object_iter(value);
+            if (!val_it)
             {
-                BSL_LOG_ERR("AAD Scope invalid map key");
-                BSL_free(scope);
-                return BSL_ERR_POLICY_CONFIG;
-            }
-            int64_t aad_flags;
-            if (BSLP_GetNumberInt(json_object_iter_value(val_it), &aad_flags))
-            {
-                BSL_LOG_ERR("AAD Scope invalid map value");
-                BSL_free(scope);
+                BSL_LOG_ERR("AAD Scope is not an object");
                 return BSL_ERR_POLICY_CONFIG;
             }
 
-            BSL_LOG_DEBUG("AAD Scope for block %" PRId64 " has flags 0x%" PRIx64, blk_num, aad_flags);
-            scope[item_ix] = (BSLX_CoseSc_AadScope_Item_t) { .key = blk_num, .flags = aad_flags };
+            const size_t                 scope_count = json_object_size(value);
+            BSLX_CoseSc_AadScope_Item_t *scope       = BSL_calloc(scope_count, sizeof(BSLX_CoseSc_AadScope_Item_t));
+            for (size_t item_ix = 0; val_it; ++item_ix)
+            {
+                int64_t blk_num;
+                if (BSLP_GetTextAsInt(&blk_num, json_object_iter_key(val_it), json_object_iter_key_len(val_it)))
+                {
+                    BSL_LOG_ERR("AAD Scope invalid map key");
+                    BSL_free(scope);
+                    return BSL_ERR_POLICY_CONFIG;
+                }
+                int64_t aad_flags;
+                if (BSLP_GetNumberInt(json_object_iter_value(val_it), &aad_flags))
+                {
+                    BSL_LOG_ERR("AAD Scope invalid map value");
+                    BSL_free(scope);
+                    return BSL_ERR_POLICY_CONFIG;
+                }
 
-            val_it = json_object_iter_next(value, val_it);
+                BSL_LOG_DEBUG("AAD Scope for block %" PRId64 " has flags 0x%" PRIx64, blk_num, aad_flags);
+                scope[item_ix] = (BSLX_CoseSc_AadScope_Item_t) { .key = blk_num, .flags = aad_flags };
+
+                val_it = json_object_iter_next(value, val_it);
+            }
+
+            BSLX_CoseSc_SetAadScope(opt, scope, scope_count);
+            BSL_free(scope);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_AAD_SCOPE);
-        BSLX_CoseSc_SetAadScope(opt, scope, scope_count);
-        BSL_free(scope);
     }
     else if (0 == strcasecmp(id_str, "iv_base"))
     {
-        BSL_Data_t as_bytes;
-        BSL_Data_Init(&as_bytes);
-        if (BSLP_GetBytesHex(value, &as_bytes))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_IV_BASE, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            BSL_Data_t as_bytes;
+            BSL_Data_Init(&as_bytes);
+            if (BSLP_GetBytesHex(value, &as_bytes))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetBytestr(opt, as_bytes);
+            BSL_Data_Deinit(&as_bytes);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_IV_BASE);
-        BSL_Variant_SetBytestr(opt, as_bytes);
-        BSL_Data_Deinit(&as_bytes);
     }
     else if (0 == strcasecmp(id_str, "iv_counter_offset"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_IV_COUNTER_OFFSET, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_IV_COUNTER_OFFSET);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcasecmp(id_str, "salt_length"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_SALT_LENGTH, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_SALT_LENGTH);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else if (0 == strcasecmp(id_str, "salt_base"))
     {
-        BSL_Data_t as_bytes;
-        BSL_Data_Init(&as_bytes);
-        if (BSLP_GetBytesHex(value, &as_bytes))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_SALT_BASE, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            BSL_Data_t as_bytes;
+            BSL_Data_Init(&as_bytes);
+            if (BSLP_GetBytesHex(value, &as_bytes))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetBytestr(opt, as_bytes);
+            BSL_Data_Deinit(&as_bytes);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_SALT_BASE);
-        BSL_Variant_SetBytestr(opt, as_bytes);
-        BSL_Data_Deinit(&as_bytes);
     }
     else if (0 == strcasecmp(id_str, "salt_counter_offset"))
     {
-        int64_t as_int;
-        if (BSLP_GetNumberInt(value, &as_int))
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_SALT_COUNTER_OFFSET, value);
+        if (opt)
         {
-            return BSL_ERR_POLICY_CONFIG;
+            int64_t as_int;
+            if (BSLP_GetNumberInt(value, &as_int))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetInt64(opt, as_int);
         }
-
-        BSL_Variant_t *opt = BSLB_VariantPtrMap_add(options, BSLX_COSESC_OPTION_SALT_COUNTER_OFFSET);
-        BSL_Variant_SetInt64(opt, as_int);
     }
     else
     {

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -124,6 +124,7 @@ void _setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_USE_KEY_WRAP), 1);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32a, &predicate_bsl_32a);
 
     BSLP_PolicyPredicate_t predicate_bsl_32b;
@@ -135,6 +136,7 @@ void _setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_USE_KEY_WRAP), 1);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32b, &predicate_bsl_32b);
 }
 

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -230,6 +230,7 @@ void setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_14, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_14, BSLX_BCB_OPT_USE_KEY_WRAP), 1);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_14, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_14, &predicate_14);
 
     // test bib & bcb sourcing with good key
@@ -256,6 +257,7 @@ void setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_15b, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A256GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_15b, BSLX_BCB_OPT_USE_KEY_WRAP), 0);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_15b, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_15b, &predicate_15b);
 
     // test bib verif with good key, bad key (drop bundle), bad key (drop block), bad key (nothing)
@@ -412,6 +414,7 @@ void setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_USE_KEY_WRAP), 1);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32a, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32a, &predicate_bsl_32a);
 
     BSLP_PolicyPredicate_t predicate_bsl_32b;
@@ -423,6 +426,7 @@ void setUp(void)
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_AES_VARIANT),
                          RFC9173_BCB_AES_VARIANT_A128GCM);
     BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_USE_KEY_WRAP), 1);
+    BSL_Variant_SetInt64(BSLP_PolicyRule_AddOption(&rule_bsl_32b, BSLX_BCB_OPT_SCOPE), 0x7);
     BSLP_PolicyProvider_AddRule(policy, &rule_bsl_32b, &predicate_bsl_32b);
     BSL_Data_Deinit(&wrapkey_data);
 }


### PR DESCRIPTION
This draws a strong separation between local policy options and received parameters. Default values apply to received parameters, not to local options. This will be explained in user guide updates for https://github.com/NASA-AMMOS/BSL-docs/issues/37.

Closes #283 