### PR TITLE
Add Sample PP config schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,7 @@ if(BUILD_LIB)
     install(
         FILES ${PC_FILES}
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        COMPONENT devel
     )
 
     # cmakeConfig for BSL targets

--- a/bsl.spec
+++ b/bsl.spec
@@ -115,6 +115,7 @@ install -m644 -D testroot/usr/lib/pkgconfig/m-lib.pc %{buildroot}%{_datadir}/pkg
 %{_libdir}/libbsl_sample_pp.so.*
 %{_libdir}/libbsl_default_sc.so.*
 %{_libdir}/libbsl_cose_sc.so.*
+%{_datadir}/bsl/sample_pp/config-schema.json
 
 %files devel
 %license LICENSE

--- a/docs/api/01-bsl-sis.md
+++ b/docs/api/01-bsl-sis.md
@@ -30,24 +30,21 @@ Bundle Protocol Security Library (BPSec Lib) Software Interface Specification (S
 **Change Log**
 | Revision | Submission Date | Affection Sections or Pages | Change Summary            |
 |----------|-----------------|-----------------------------|---------------------------|
-| Initial  | 10/2/2024       | All                         | Initial issue of document |
-| A        | 7/29/2026       | All                         | Updating copyright year and instances of "example policy provider" |
-
+| Initial  | 2 Oct. 2024     | All                         | Initial issue of document |
+| A        | 29 Jul. 2026    | All                         | Updating copyright year and instances of "example policy provider" |
+| B        | TBD 2026        | Secs. 1.1, 1.4, 2.3, 3.2, 3.3 | Updates for BSLv2.0, phrasing of "sample policy provider," and for the new COSE Context |
 
 
 # 1: Document Overview
 
 ## 1.1: Identification
 
-
-
-
 | Property                        | Value                               |
 |---------------------------------|-------------------------------------|
 | Configuration ID (CI)           | 681.2                               |
 | Element                         | Multi-Mission Control System (MMCS) |
 | Program Set                     | Bundle Protocol Security (BPSec)    |
-| Version                         | 1.0                                 |
+| Version                         | 2.0                                 |
 
 ## 1.2: Purpose
 
@@ -97,14 +94,15 @@ Finally, the BSL is open-source software whose design and implementation should 
 **Table 3: Other Applicable Documents**:
 | Title                                                            | Document Number                                               |
 |------------------------------------------------------------------|---------------------------------------------------------------|
-| Bundle Protocol Version 7                                        | IETF RFC 9171                                                 |
-| Bundle Protocol Security (BPSec)                                 | IETF RFC 9172                                                 |
-| Default Security Contexts for Bundle Protocol Security (BPSec)   | IETF RFC 9173                                                 |
+| Bundle Protocol Version 7                                        | [IETF RFC 9171](https://www.rfc-editor.org/info/rfc9171) |
+| Bundle Protocol Security (BPSec)                                 | [IETF RFC 9172](https://www.rfc-editor.org/info/rfc9172) |
+| Default Security Contexts for Bundle Protocol Security (BPSec)   | [IETF RFC 9173](https://www.rfc-editor.org/info/rfc9173) |
+| Bundle Protocol Security (BPSec) COSE Context                    | [draft-ietf-dtn-bpsec-cose](https://datatracker.ietf.org/doc/draft-ietf-dtn-bpsec-cose/) |
 | BSL GitHub Repository                                            | https://github.com/NASA-AMMOS/BSL-private                     |
 | BSL Online Documentation                                         | https://github.com/NASA-AMMOS/BSL-private/tree/main/docs      |
-| ISO C99 Specification                                            | https://www.iso.org/standard/74528.html                       |
-| POSIX 2008 Specification                                         | https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/ |
-| NIST FIPS 140 Specification                                      | https://csrc.nist.gov/pubs/fips/140-3/final                   |
+| ISO C99 Specification                                            | [ISO/IEC 9899:2018](https://www.iso.org/standard/74528.html) |
+| POSIX 2008 Specification                                         | [IEEE Std 1003.1-2008](https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/) |
+| NIST Security Requirements for Cryptographic Modules             | [NIST FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final) |
 | SE Linux Overview                                                | https://www.redhat.com/en/topics/linux/what-is-selinux        |
 
 # 2: Environment
@@ -154,29 +152,33 @@ Backends may be swapped out with another implementation that implements the fron
 
 ## 3.2: Instructions for Building Documentation
 
-The most up-to-date documentation will be found in the BSL’s GitHub page, and the details of any API function or data-structure will likewise be found in the documentation generated from annotations inside the source code (using doxygen). As such, this document will generally avoid API specifics since it these may become obsolete as BSL evolves in response to operational needs.
+The most up-to-date documentation will be found in the BSL’s GitHub page, and the details of any API function or data-structure will likewise be found in the documentation generated from annotations inside the source code (using doxygen).
+As such, this document will generally avoid API specifics since it these may become obsolete as BSL evolves in response to operational needs.
 
-Instructions to build the documentation using doxygen as HTML (and/or PDF, among other formats) may be found in the README.md file. Assuming a RHEL9 platform, the Linux tool xdg-open may be used to open the index.html found under build/default/docs/doxygen/html/index.html.
+Instructions to build the documentation using doxygen as HTML (and/or PDF, among other formats) may be found in the README.md file.
+Assuming a RHEL9 platform, the Linux tool @c xdg-open may be used to open the @c index.html found under @c build/default/docs/doxygen/html/index.html.
 
-The menu on the left-hand side includes this overview, as well as links to the top-level modules in the repository. These include the Frontend API, Dynamic Backend, the default security context, the Sample Security Policy Provider, and a “mock” BPA required to exercise the Frontend. Delving further into each of these shows the relevant files, functions, and data structures.
+The menu on the left-hand side includes this overview, as well as links to the top-level modules in the repository.
+These include the Frontend API, Dynamic Backend, the built-in example Security Contexts, the Sample Policy Provider, and a “mock” BPA required to exercise the Frontend. Delving further into each of these shows the relevant files, functions, and data structures.
 
 Links will be found in Table 3 above.
 
 
 ## 3.3: BSL Modules and Data Structures
 
-As indicated in the prior section, the BSL has four main components. The principal two are the Frontend API and the Dynamic backend. There are two others, being the security policy provider, and the security context.
+As indicated in the prior section, the BSL has the following main components.
+The principal two are the Frontend API and the Dynamic backend. There are two others, being the security policy provider, and the security context.
 
  * The **Frontend API** defines the software interface between host Bundle Protocol Agents and the underlying security operations implemented in a Dynamic Backend. The API remains an invariant regardless of which backend is selected.
  * The **Dynamic Backend** is an implementation of the BPSec security operations that adheres to the Frontend API. The BSL’s design and implementation facilitate “swapping” backend implementations tailored for mission-specific constraints. The BSL ships with a default backend, which may not be suitable for all operational environments.
- * The **Sample Security Policy Provider** is a library used internally by the BSL to query which security operations need to be applied to a given Bundle, and what those security parameters are (such as key, hash type, etc). The BSL provides a sample security provider exercising the policy provider interface.
- * The **Example Default Security Contexts** perform the actual cryptographic functionality. The Default Security Context is detailed in RFC 9173. The BSL implements this via the security context interface, and uses OpenSSL as the underlying cryptographic software.
+ * The **Sample Policy Provider** is a library used internally by the BSL to query which security operations need to be applied to a given Bundle, and what those security parameters are (such as key, hash type, etc). The BSL provides a sample security provider exercising the policy provider interface.
+ * The **Example Security Contexts** perform the actual cryptographic functionality. The Default Security Contexts are specified in RFC 9173 and the COSE Context in an internet draft. The BSL can register these via the security context callback interface (see @ref sc-callback-api), and uses OpenSSL as the underlying cryptographic software.
 
 ## 3.4: BSL Context Initialization
 
 The BSL requires the existence of a Security Policy Provider (commonly referred to as the “Policy Provider” throughout subsequent documentation), which governs what security actions should be performed upon a particular bundle, and a Security Context, which handles all cryptographic material and safely performs the cryptographic functionality.
 
-A sample Policy Provider is included in the repository, as well as an implementation of the Default Security Context (as specified in RFC 9173).
+A sample Policy Provider is included in the repository, as well as an implementation of the Default Security Contexts (as specified in RFC 9173).
 
 Refer to the doxygen-generated documentation in the repository for the relevant BSL initialization functions, that provision the library with the appropriate policy provider and security context.
 
@@ -191,12 +193,12 @@ The BPA then iterates through this list calling the relevant BSL functions to pe
 
 The BSL strives to avoid excessive reliance on third-party libraries and a long software supply chain. A few third-party libraries are required, however, to: provide dynamic data structures for this C codebase; provide a unit-test driver; provide a CODEC for CBOR-encoded Bundle blocks; and provide implementations of cryptographic algorithms. At the time of the Critical Design Review, these third-party open-source libraries respectively are MLib, Unity, QCBOR, and OpenSSL. 
 
-Note that specific library versions are detailed in Release Description Documents (RDD), which is produced with each release of BSL.
+Note that specific library versions are detailed in each Release Description Document (RDD) which accompanies a formal release of BSL.
 
 | Library Name | Repository Link                            |
 |--------------|--------------------------------------------|
-| MLIB         | MLib https://github.com/P-p-H-d/mlib       |
-| Unity        |  https://github.com/ThrowTheSwitch/Unity   |
-| QCBOR        | https://github.com/laurencelundblade/QCBOR |
+| Jansson      | https://github.com/akheron/jansson         |
+| MLIB         | https://github.com/P-p-H-d/mlib            |
 | OpenSSL      | https://github.com/openssl/openssl         |
-
+| QCBOR        | https://github.com/laurencelundblade/QCBOR |
+| Unity        | https://github.com/ThrowTheSwitch/Unity    |

--- a/docs/api/02-bpa-integrators.md
+++ b/docs/api/02-bpa-integrators.md
@@ -1,4 +1,4 @@
-@page bpa-integrators BPA Integrator Topics
+@page bpa-integrators BPA Integrators
 <!--
 Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.

--- a/docs/api/03-policy-providers.md
+++ b/docs/api/03-policy-providers.md
@@ -1,4 +1,4 @@
-@page policy-providers Policy Provider Topics
+@page policy-providers Policy Provider Authors
 <!--
 Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.

--- a/docs/api/03-security-contexts.md
+++ b/docs/api/03-security-contexts.md
@@ -1,4 +1,4 @@
-@page security-contexts Security Context Topics
+@page security-contexts Security Context Authors
 <!--
 Copyright (c) 2026 The Johns Hopkins University Applied Physics
 Laboratory LLC.

--- a/docs/api/04-examples-and-mocks.md
+++ b/docs/api/04-examples-and-mocks.md
@@ -43,7 +43,7 @@ A more full-featured draft PP maintained as part of the BSL source is based on t
 This PP parses an ION-Like JSON structure to configure policy rules within a running Mock BPA. See the _BSL User Guide_ @cite bsl_user_guide for details on specific JSON structure and attributes.
 This PP is registered and used by the @ref mock-bpa for many BSL testing cases.
 
-Sources related to this provider are associated with the @ref sample_pp group.
+Sources related to this provider are associated with the @ref sample_pp group, and a JSON Schema definition for the policy input is included in the file tree as the @c src/bsl/sample_pp/config-schema.json file.
 
 # Example Security Contexts {#example-scs}
 

--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -37,6 +37,7 @@ BPv
 bsl
 BSL
 BSLs
+BSLv
 BSLX
 bstr
 BTSD
@@ -127,6 +128,7 @@ IPN
 IPPT
 IsInt
 isspace
+Jansson
 JHU
 Josefsson
 JPL
@@ -209,6 +211,7 @@ structs
 Structs
 SWaP
 syslog
+TBD
 Todo
 TODO
 tstr

--- a/docs/api/dictionary.txt
+++ b/docs/api/dictionary.txt
@@ -122,6 +122,7 @@ IETF
 init
 Init
 initializer
+Integrators
 invariants
 ipn
 IPN

--- a/mock-bpa-test/data/cose-sc/policy-exA.1-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-exA.1-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.1",
+            "key_name": "ExampleA.1",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/data/cose-sc/policy-exA.11-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-exA.11-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.1",
+            "key_name": "ExampleA.1",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/data/cose-sc/policy-exA.4-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-exA.4-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.4",
+            "key_name": "ExampleA.4",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/data/cose-sc/policy-exA.5-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-exA.5-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.5",
+            "key_name": "ExampleA.5",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/data/cose-sc/policy-exA.6-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-exA.6-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.6",
+            "key_name": "ExampleA.6",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/data/cose-sc/policy-interop-A.1-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-interop-A.1-source.json
@@ -13,23 +13,14 @@
         "spec": {
           "svc": "bib-integrity",
           "sc_id": 3,
-          "sc_parms": [
-            {
-              "id": "key_id",
-              "value": "ExampleA.1"
-            },
-            {
-              "id": "target_alg",
-              "value": 6
-            },
-            {
-              "id": "aad_scope",
-              "value": {
-                "0": 1,
-                "-1": 1
-              }
+          "sc_parms": {
+            "key_name": "ExampleA.1",
+            "target_alg": 6,
+            "aad_scope": {
+              "0": 1,
+              "-1": 1
             }
-          ]
+          }
         },
         "policy_action_on_fail": "delete_bundle"
       }

--- a/mock-bpa-test/data/cose-sc/policy-interop-A.5-source.json
+++ b/mock-bpa-test/data/cose-sc/policy-interop-A.5-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.5",
+            "key_name": "ExampleA.5",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/mock-bpa-test/pyproject.toml
+++ b/mock-bpa-test/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 format = [
+  "check-jsonschema ~=0.38.0","
   "ruff ==0.16.0",
   "ty == 0.0.65",
   "licenseheaders ==0.8.8",

--- a/mock-bpa-test/pyproject.toml
+++ b/mock-bpa-test/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 format = [
-  "check-jsonschema ~=0.38.0","
+  "check-jsonschema ~=0.38.0",
   "ruff ==0.16.0",
   "ty == 0.0.65",
   "licenseheaders ==0.8.8",

--- a/mock-bpa-test/test_cose_sc.py
+++ b/mock-bpa-test/test_cose_sc.py
@@ -167,6 +167,25 @@ class TestCoseScMac0(TestAgent):
             )
         )
 
+    def test_exampleA_1_source_with_keyid(self):
+        # use key_id (bytes) option instead of key_name (text)
+        with sc_config_modifier(
+            orig=os.path.join(OWNPATH, "data/cose-sc/policy-exA.1-source.json"),
+            modify={"key_name": None, "key_id": b"ExampleA.1".hex()},
+        ) as polfile_path:
+            self._single_test(
+                _TestCase(
+                    input_data=EXAMPLE_A_NO_SEC,
+                    expected_output=EXAMPLE_A_1_WITH_BIB,
+                    sec_src_eid="dtn://src/",
+                    policy_config=polfile_path,
+                    bundle_dest_loc=BundleDestLoc.APPIN,
+                    key_set="data/cose-sc/keyset-1.cbordiag",
+                    input_data_format=DataFormat.CBORDIAG,
+                    expected_output_format=DataFormat.CBORDIAG,
+                )
+            )
+
     def test_exampleA_1_acceptor_valid_loose(self):
         self._single_test(
             _TestCase(
@@ -234,7 +253,7 @@ class TestCoseScMac0(TestAgent):
     def test_exampleA_1_acceptor_failure_key_disallow(self):
         with sc_config_modifier(
             orig=os.path.join(OWNPATH, "data/cose-sc/policy-any-bib-accept.json"),
-            modify={"key_id": "ExampleA.5"},
+            modify={"key_name": "ExampleA.5"},
         ) as polfile_path:
             self._single_test(
                 _TestCase(
@@ -419,7 +438,7 @@ class TestCoseScEncrypt0(TestAgent):
     def test_exampleA_4_acceptor_valid_strict_key_id(self):
         with sc_config_modifier(
             orig=os.path.join(OWNPATH, "data/cose-sc/policy-any-bcb-accept.json"),
-            modify={"key_id": "ExampleA.4"},
+            modify={"key_name": "ExampleA.4"},
         ) as polfile_path:
             self._single_test(
                 _TestCase(

--- a/resources/apply_format.sh
+++ b/resources/apply_format.sh
@@ -56,13 +56,20 @@ do
         exit $ERR
     fi
 done
+if which check-jsonschema >/dev/null
+then
+    check-jsonschema \
+        --schemafile src/bsl/sample_pp/config-schema.json -vv \
+        test/test_PolicyParser-data/*.json \
+        $(find . -name 'policy*.json')
+fi
 
 # Python test fixtures
 pushd mock-bpa-test/
 ANYERR=0
 ruff format || ANYERR=$((ANYERR + 1))
 ruff check --fix || ANYERR=$((ANYERR + 1))
-if which ty
+if which ty >/dev/null
 then
     ty check --fix || ANYERR=$((ANYERR + 1))
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,6 +171,11 @@ target_link_libraries(bsl_sample_pp PUBLIC bsl_dynamic)
 target_link_libraries(bsl_sample_pp PRIVATE bsl_default_sc bsl_cose_sc)
 target_link_libraries(bsl_sample_pp PUBLIC MLIB::mlib)
 target_link_libraries(bsl_sample_pp PRIVATE Jansson::Jansson)
+install(
+    FILES bsl/sample_pp/config-schema.json
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/sample_pp/
+    COMPONENT devel
+)
 
 # Dynamic backend library
 add_library(bsl_dynamic)

--- a/src/bsl/front/Data.h
+++ b/src/bsl/front/Data.h
@@ -74,6 +74,7 @@ typedef struct BSL_Data_s
     }
 
 /** Static initializer for a view on a static text string.
+ * @note The view does not include any null terminator.
  * @sa BSL_Data_InitView() BSL_Data_SetViewCstr()
  */
 #define BSL_DATA_INIT_VIEW_CSTR(cstr)                                                    \

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -276,7 +276,7 @@ static int BSLP_PolicyOptions_SC2(BSLB_VariantPtrMap_t options, const char *id_s
  */
 static int BSLP_PolicyOptions_SC3(BSLB_VariantPtrMap_t options, const char *id_str, json_t *value) // NOSONAR
 {
-    if (0 == strcmp(id_str, "key_id"))
+    if (0 == strcmp(id_str, "key_name"))
     {
         BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_KEY_ID, value);
         if (opt)
@@ -286,8 +286,24 @@ static int BSLP_PolicyOptions_SC3(BSLB_VariantPtrMap_t options, const char *id_s
             {
                 return BSL_ERR_POLICY_CONFIG;
             }
+            // Key ID as UTF-8 bytes excluding null terminator
             BSL_Data_t as_bytes = BSL_DATA_INIT_VIEW_CSTR(val_str);
             BSL_Variant_SetBytestr(opt, as_bytes);
+        }
+    }
+    else if (0 == strcasecmp(id_str, "key_id"))
+    {
+        BSL_Variant_t *opt = BSLP_OptionAddOrErase(options, BSLX_COSESC_OPTION_KEY_ID, value);
+        if (opt)
+        {
+            BSL_Data_t as_bytes;
+            BSL_Data_Init(&as_bytes);
+            if (BSLP_GetBytesHex(value, &as_bytes))
+            {
+                return BSL_ERR_POLICY_CONFIG;
+            }
+            BSL_Variant_SetBytestr(opt, as_bytes);
+            BSL_Data_Deinit(&as_bytes);
         }
     }
     else if (0 == strcasecmp(id_str, "target_alg"))

--- a/src/bsl/sample_pp/PolicyParser.c
+++ b/src/bsl/sample_pp/PolicyParser.c
@@ -496,15 +496,15 @@ static int BSLP_PolicyParser_ReadOneRule(BSLP_PolicyProvider_t *policy, const js
         BSL_LOG_DEBUG("     role   : %s", role_str);
 
         // check for valid sec role
-        if (0 == strcmp(role_str, "s"))
+        if ((0 == strcmp(role_str, "s")) || (0 == strcmp(role_str, "source")))
         {
             sec_role = BSL_SECROLE_SOURCE;
         }
-        else if (0 == strcmp(role_str, "v"))
+        else if ((0 == strcmp(role_str, "v")) || (0 == strcmp(role_str, "verifier")))
         {
             sec_role = BSL_SECROLE_VERIFIER;
         }
-        else if (0 == strcmp(role_str, "a"))
+        else if ((0 == strcmp(role_str, "a")) || (0 == strcmp(role_str, "acceptor")))
         {
             sec_role = BSL_SECROLE_ACCEPTOR;
         }

--- a/src/bsl/sample_pp/config-schema.json
+++ b/src/bsl/sample_pp/config-schema.json
@@ -1,0 +1,364 @@
+{
+  "$id": "https://nasa-ammos.github.io/BSL/config-schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "This is the BSL Sample Policy Provider configuration syntax.",
+  "$defs": {
+    "PolicyRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "desc": {
+          "description": "A human description of the rule.",
+          "type": "string"
+        },
+        "filter": {
+          "description": "Filter options to match a specific bundle and target block at one of the BSL interaction points.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "rule_id": {
+              "description": "The unique ID number this rule.",
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "role": {
+              "description": "The role for the possible security operation. The values are the first letter of either: source, verifier, or acceptor.",
+              "type": "string",
+              "enum": [
+                "s",
+                "v",
+                "a"
+              ]
+            },
+            "loc": {
+              "description": "The interaction point location to match at.",
+              "type": "string",
+              "enum": [
+                "appin",
+                "appout",
+                "clin",
+                "clout"
+              ]
+            },
+            "src": {
+              "description": "An EID Pattern to match the Source Node ID of the bundle primary block. The default will match any source.",
+              "$ref": "#/$defs/BundleEidPattern",
+              "default": "*:**"
+            },
+            "dest": {
+              "description": "An EID Pattern to match the Destiantion EID of the bundle primary block. The default will match any destination.",
+              "$ref": "#/$defs/BundleEidPattern",
+              "default": "*:**"
+            },
+            "sec_src": {
+              "description": "When the role is verifier or acceptor, an EID Pattern to match the Security Source of an existing operation. The default will match any source of an existing operation.",
+              "$ref": "#/$defs/BundleEidPattern",
+              "default": "*:**"
+            },
+            "tgt": {
+              "description": "The target block _type_ to match on, which should be unique in the bundle, not the specific block _number_.",
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "sc_id": {
+              "description": "Formerly used to require an existing security operation for this Context ID.",
+              "deprecated": true,
+              "$ref": "#/$defs/IntegerOrText"
+            }
+          },
+          "required": [
+            "rule_id",
+            "loc",
+            "role",
+            "tgt"
+          ]
+        },
+        "spec": {
+          "description": "Specification of how to form a security operation for the target block when the filter matches.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "svc": {
+              "description": "The security service needing to be present. This matches only on text prefix of bib or bcb. For source role this will create the operation, for verifier or acceptor this will require the operation to exist and process it.",
+              "type": "string",
+              "pattern": "(bib|bcb)-?.*"
+            },
+            "sc_id": {
+              "description": "The security Context ID of the operation needing to be present. For source role this will create the operation, for verifier or acceptor this will require an operation with the context and process it.",
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "sc_parms": {
+              "description": "Options specific to the sibling sc_id value, encoded with a common structure of ID-value pairs.",
+              "$ref": "#/$defs/GenericOptions"
+            }
+          },
+          "required": [
+            "svc",
+            "sc_id",
+            "sc_parms"
+          ],
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "sc_id": {
+                    "const": 1
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "sc_parms": {
+                    "$ref": "#/$defs/SC1Options"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "sc_id": {
+                    "const": 2
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "sc_parms": {
+                    "$ref": "#/$defs/SC2Options"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "sc_id": {
+                    "const": 3
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "sc_parms": {
+                    "$ref": "#/$defs/SC3Options"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "policy_action_on_fail": {
+          "type": "string",
+          "enum": [
+            "delete_bundle"
+          ]
+        }
+      }
+    },
+    "IntegerOrText": {
+      "description": "A direct integer value or a text value which can be converted to integer as either base 10 or base 16.",
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string",
+          "pattern": "^-?([0-9]+|0x[0-9a-fA-F]+)$"
+        }
+      ]
+    },
+    "BooleanOrText": {
+      "description": "A true/false boolean value or an integer or text value interpreted as one. Value zero or text 0 is false and all others are true.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "BytesAsHex": {
+      "description": "A byte string represented as hexadecimal encoding of each byte in sequence. The prefix marker 0x is optional and recommended.",
+      "type": "string",
+      "pattern": "(0x)?([0-9a-fA-F]{2})*"
+    },
+    "BundleEidPattern": {
+      "description": "An EID Pattern in text form which is not restricted by this schema.",
+      "type": "string"
+    },
+    "GenericOptions": {
+      "description": "The set of security operation options, which use option IDs specific to a each Context ID.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OptionsArray"
+        },
+        {
+          "description": "A more compact object encoding of ID-value pairs as properties. The valid ID names are context-specific.",
+          "type": "object"
+        }
+      ]
+    },
+    "OptionsArray": {
+      "description": "An array of explicit ID-value pairs, where the ID must be unique across the array.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "The valid ID names are context-specific.",
+            "type": "string"
+          },
+          "value": {
+            "description": "The corresponding value types are context-specific."
+          }
+        },
+        "required": [
+          "id",
+          "value"
+        ]
+      }
+    },
+    "SC1Options": {
+      "description": "Named options for Context ID 1 (BIB-HMAC-SHA2).",
+      "anyOf": [
+        {
+          "description": "Fall-back to non-overloaded array.",
+          "$ref": "#/$defs/OptionsArray"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key_name": {
+              "type": "string"
+            },
+            "key_wrap": {
+              "$ref": "#/$defs/BooleanOrText"
+            },
+            "sha_variant": {
+              "$ref": "#/$defs/IntegerOrText",
+              "minimum": 5,
+              "maximum": 7
+            },
+            "scope_flags": {
+              "$ref": "#/$defs/IntegerOrText",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "key_name",
+            "key_wrap"
+          ]
+        }
+      ]
+    },
+    "SC2Options": {
+      "description": "Named options for Context ID 2 (BCB-AES-GCM).",
+      "anyOf": [
+        {
+          "description": "Fall-back to non-overloaded array.",
+          "$ref": "#/$defs/OptionsArray"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key_name": {
+              "description": "Arbitrary name for the key to use with the operation. This must match one of the keys in the key store for the operation to succeed.",
+              "type": "string"
+            },
+            "key_wrap": {
+              "description": "True if the key must be used to wrap a content key. For source role this is required and controls the operation, for verifier or acceptor this is optional and constrains valid operations.",
+              "$ref": "#/$defs/BooleanOrText"
+            },
+            "aes_variant": {
+              "$ref": "#/$defs/IntegerOrText",
+              "minimum": 1,
+              "maximum": 3
+            },
+            "aad_scope": {
+              "$ref": "#/$defs/IntegerOrText",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "key_name",
+            "key_wrap"
+          ]
+        }
+      ]
+    },
+    "SC3Options": {
+      "description": "Named options for Context ID 3 (COSE).",
+      "anyOf": [
+        {
+          "description": "Fall-back to non-overloaded array.",
+          "$ref": "#/$defs/OptionsArray"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key_name": {
+              "type": "string"
+            },
+            "key_id": {
+              "$ref": "#/$defs/BytesAsHex"
+            },
+            "target_alg": {
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "aad_scope": {
+              "description": "An encoding of the native AAD Scope parameter with keys in integer-as-text form.",
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^-?[0-9]+$": {
+                  "type": "integer"
+                }
+              }
+            },
+            "iv_counter_offset": {
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "iv_base": {
+              "$ref": "#/$defs/BytesAsHex"
+            },
+            "salt_length": {
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "salt_counter_offset": {
+              "$ref": "#/$defs/IntegerOrText"
+            },
+            "salt_base": {
+              "$ref": "#/$defs/BytesAsHex"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "policyrule_set": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "policyrule": {
+            "$ref": "#/$defs/PolicyRule"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "policyrule_set"
+  ]
+}

--- a/src/bsl/sample_pp/config-schema.json
+++ b/src/bsl/sample_pp/config-schema.json
@@ -4,6 +4,9 @@
   "description": "This is the BSL Sample Policy Provider configuration syntax. Some parts of the structure are legacy and marked as deprecated in this schema.",
   "type": "object",
   "additionalProperties": true,
+  "required": [
+    "policyrule_set"
+  ],
   "properties": {
     "policyrule_set": {
       "description": "Policy rules are assertions about what security operations must be present on specific filtered-in traffic.",
@@ -11,27 +14,29 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "policyrule"
+        ],
         "properties": {
           "policyrule": {
             "$ref": "#/$defs/PolicyRule"
           }
-        },
-        "required": [
-          "policyrule"
-        ]
+        }
       }
     },
     "event_set": {
       "deprecated": true
     }
   },
-  "required": [
-    "policyrule_set"
-  ],
   "$defs": {
     "PolicyRule": {
       "type": "object",
       "additionalProperties": false,
+      "required": [
+        "filter",
+        "spec",
+        "policy_action_on_fail"
+      ],
       "properties": {
         "desc": {
           "description": "A human description of the rule.",
@@ -41,6 +46,12 @@
           "description": "Filter options to match a specific bundle and target block at one of the BSL interaction points.",
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "rule_id",
+            "loc",
+            "role",
+            "tgt"
+          ],
           "properties": {
             "rule_id": {
               "description": "The unique ID number for this rule.",
@@ -92,18 +103,17 @@
               "deprecated": true,
               "$ref": "#/$defs/IntegerOrText"
             }
-          },
-          "required": [
-            "rule_id",
-            "loc",
-            "role",
-            "tgt"
-          ]
+          }
         },
         "spec": {
           "description": "Specification of how to form a security operation for the target block when the filter matches.",
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "svc",
+            "sc_id",
+            "sc_parms"
+          ],
           "properties": {
             "svc": {
               "description": "The security service needing to be present. This matches only on text prefix of bib or bcb.",
@@ -119,11 +129,6 @@
               "$ref": "#/$defs/GenericOptions"
             }
           },
-          "required": [
-            "svc",
-            "sc_id",
-            "sc_parms"
-          ],
           "allOf": [
             {
               "if": {
@@ -180,7 +185,7 @@
           "enum": [
             "delete_bundle",
             "drop_block",
-            "do_nothing"
+            "nothing"
           ]
         }
       }
@@ -238,6 +243,10 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
+        "required": [
+          "id",
+          "value"
+        ],
         "properties": {
           "id": {
             "description": "The valid ID names are context-specific and not refined here.",
@@ -246,11 +255,7 @@
           "value": {
             "description": "The corresponding value types are context-specific and not refined here."
           }
-        },
-        "required": [
-          "id",
-          "value"
-        ]
+        }
       }
     },
     "SC1Options": {
@@ -263,6 +268,10 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "key_name",
+            "key_wrap"
+          ],
           "properties": {
             "key_name": {
               "type": "string"
@@ -279,11 +288,7 @@
               "$ref": "#/$defs/IntegerOrText",
               "minimum": 0
             }
-          },
-          "required": [
-            "key_name",
-            "key_wrap"
-          ]
+          }
         }
       ]
     },
@@ -297,6 +302,10 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "key_name",
+            "key_wrap"
+          ],
           "properties": {
             "key_name": {
               "type": "string"
@@ -316,11 +325,7 @@
             "iv": {
               "deprecated": true
             }
-          },
-          "required": [
-            "key_name",
-            "key_wrap"
-          ]
+          }
         }
       ]
     },
@@ -345,12 +350,12 @@
               "$ref": "#/$defs/IntegerOrText"
             },
             "aad_scope": {
-              "description": "An encoding of the native AAD Scope parameter with keys in integer-as-text form.",
+              "description": "A JSON encoding of the AAD Scope parameter with keys in integer-as-text decimal-only form.",
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
                 "^-?[0-9]+$": {
-                  "type": "integer"
+                  "$ref": "#/$defs/IntegerOrText"
                 }
               }
             },

--- a/src/bsl/sample_pp/config-schema.json
+++ b/src/bsl/sample_pp/config-schema.json
@@ -1,7 +1,33 @@
 {
   "$id": "https://nasa-ammos.github.io/BSL/config-schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "This is the BSL Sample Policy Provider configuration syntax.",
+  "description": "This is the BSL Sample Policy Provider configuration syntax. Some parts of the structure are legacy and marked as deprecated in this schema.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "policyrule_set": {
+      "description": "Policy rules are assertions about what security operations must be present on specific filtered-in traffic.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "policyrule": {
+            "$ref": "#/$defs/PolicyRule"
+          }
+        },
+        "required": [
+          "policyrule"
+        ]
+      }
+    },
+    "event_set": {
+      "deprecated": true
+    }
+  },
+  "required": [
+    "policyrule_set"
+  ],
   "$defs": {
     "PolicyRule": {
       "type": "object",
@@ -149,7 +175,9 @@
         "policy_action_on_fail": {
           "type": "string",
           "enum": [
-            "delete_bundle"
+            "delete_bundle",
+            "drop_block",
+            "do_nothing"
           ]
         }
       }
@@ -283,6 +311,9 @@
             "aad_scope": {
               "$ref": "#/$defs/IntegerOrText",
               "minimum": 0
+            },
+            "iv": {
+              "deprecated": true
             }
           },
           "required": [
@@ -341,24 +372,5 @@
         }
       ]
     }
-  },
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "policyrule_set": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "policyrule": {
-            "$ref": "#/$defs/PolicyRule"
-          }
-        }
-      }
-    }
-  },
-  "required": [
-    "policyrule_set"
-  ]
+  }
 }

--- a/src/bsl/sample_pp/config-schema.json
+++ b/src/bsl/sample_pp/config-schema.json
@@ -43,15 +43,18 @@
           "additionalProperties": false,
           "properties": {
             "rule_id": {
-              "description": "The unique ID number this rule.",
+              "description": "The unique ID number for this rule.",
               "$ref": "#/$defs/IntegerOrText"
             },
             "role": {
-              "description": "The role for the possible security operation. The values are the first letter of either: source, verifier, or acceptor.",
+              "description": "The role for the possible security operation. The single-letter values are the first letter of the full words.",
               "type": "string",
               "enum": [
+                "source",
                 "s",
+                "verifier",
                 "v",
+                "acceptor",
                 "a"
               ]
             },
@@ -103,16 +106,16 @@
           "additionalProperties": false,
           "properties": {
             "svc": {
-              "description": "The security service needing to be present. This matches only on text prefix of bib or bcb. For source role this will create the operation, for verifier or acceptor this will require the operation to exist and process it.",
+              "description": "The security service needing to be present. This matches only on text prefix of bib or bcb.",
               "type": "string",
               "pattern": "(bib|bcb)-?.*"
             },
             "sc_id": {
-              "description": "The security Context ID of the operation needing to be present. For source role this will create the operation, for verifier or acceptor this will require an operation with the context and process it.",
+              "description": "The security Context ID of the operation needing to be present.",
               "$ref": "#/$defs/IntegerOrText"
             },
             "sc_parms": {
-              "description": "Options specific to the sibling sc_id value, encoded with a common structure of ID-value pairs.",
+              "description": "Options specific to the sibling sc_id value. Options use a logical structure of ID-value pairs. This generic structure is overridden by context-specific options in the allOf below.",
               "$ref": "#/$defs/GenericOptions"
             }
           },
@@ -230,18 +233,18 @@
       ]
     },
     "OptionsArray": {
-      "description": "An array of explicit ID-value pairs, where the ID must be unique across the array.",
+      "description": "An array of explicit ID-value pairs, where the ID must be unique across the array. This kind of structure is not easily refined using JSON schema so no attempt is made in this file.",
       "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "id": {
-            "description": "The valid ID names are context-specific.",
+            "description": "The valid ID names are context-specific and not refined here.",
             "type": "string"
           },
           "value": {
-            "description": "The corresponding value types are context-specific."
+            "description": "The corresponding value types are context-specific and not refined here."
           }
         },
         "required": [
@@ -254,7 +257,7 @@
       "description": "Named options for Context ID 1 (BIB-HMAC-SHA2).",
       "anyOf": [
         {
-          "description": "Fall-back to non-overloaded array.",
+          "description": "Allow array encoding but without JSON schema type constraints. See the object type below for option IDs and types.",
           "$ref": "#/$defs/OptionsArray"
         },
         {
@@ -288,7 +291,7 @@
       "description": "Named options for Context ID 2 (BCB-AES-GCM).",
       "anyOf": [
         {
-          "description": "Fall-back to non-overloaded array.",
+          "description": "Allow array encoding but without JSON schema type constraints. See the object type below for option IDs and types.",
           "$ref": "#/$defs/OptionsArray"
         },
         {
@@ -296,11 +299,9 @@
           "additionalProperties": false,
           "properties": {
             "key_name": {
-              "description": "Arbitrary name for the key to use with the operation. This must match one of the keys in the key store for the operation to succeed.",
               "type": "string"
             },
             "key_wrap": {
-              "description": "True if the key must be used to wrap a content key. For source role this is required and controls the operation, for verifier or acceptor this is optional and constrains valid operations.",
               "$ref": "#/$defs/BooleanOrText"
             },
             "aes_variant": {
@@ -327,7 +328,7 @@
       "description": "Named options for Context ID 3 (COSE).",
       "anyOf": [
         {
-          "description": "Fall-back to non-overloaded array.",
+          "description": "Allow array encoding but without JSON schema type constraints. See the object type below for option IDs and types.",
           "$ref": "#/$defs/OptionsArray"
         },
         {

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.1-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.1-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.1",
+            "key_name": "ExampleA.1",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.11-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.11-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.1",
+            "key_name": "ExampleA.1",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.4-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.4-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.4",
+            "key_name": "ExampleA.4",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.5-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.5-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.5",
+            "key_name": "ExampleA.5",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.6-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-exA.6-source.json
@@ -14,7 +14,7 @@
           "svc": "bcb",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.6",
+            "key_name": "ExampleA.6",
             "target_alg": 3,
             "aad_scope": {
               "0": 1,

--- a/test/fuzz_PolicyParser_LoadFd-corpus/policy-interop-A.5-source.json
+++ b/test/fuzz_PolicyParser_LoadFd-corpus/policy-interop-A.5-source.json
@@ -14,7 +14,7 @@
           "svc": "bib-integrity",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.5",
+            "key_name": "ExampleA.5",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,

--- a/test/test_PolicyParser-data/validSC3-parms-long.json
+++ b/test/test_PolicyParser-data/validSC3-parms-long.json
@@ -15,7 +15,7 @@
           "sc_id": 3,
           "sc_parms": [
             {
-              "id": "key_id",
+              "id": "key_name",
               "value": "ExampleA.1"
             },
             {

--- a/test/test_PolicyParser-data/validSC3-parms-short.json
+++ b/test/test_PolicyParser-data/validSC3-parms-short.json
@@ -14,7 +14,7 @@
           "svc": "bcb-confidentiality",
           "sc_id": 3,
           "sc_parms": {
-            "key_id": "ExampleA.1",
+            "key_name": "ExampleA.1",
             "target_alg": 6,
             "aad_scope": {
               "0": 1,


### PR DESCRIPTION
This is not used in operations, it is documentation only for now.

This testing did uncover a discrepancy between legacy policy option "key_name" and COSE key identifiers. Updating COSE config for consistency and for option of raw "key_id" bytes.

Closes #288 