### PR TITLE
Guard uses of IV and salt parameters

### DIFF
--- a/mock-bpa-test/test_cose_sc.py
+++ b/mock-bpa-test/test_cose_sc.py
@@ -73,15 +73,6 @@ EXAMPLE_A_4_WITH_BCB = """\
 """
 """ Bundle with BCB over target #1, adjusted sec block to #2 with flags 0x1"""
 
-EXAMPLE_A_4_WITH_BCB_ADDL_UHDR = """\
-[_
-    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
-    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[4, <<{4: 'ExampleA.4'}>>], [5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {6: h'484A'}, null] >>]]] >>],
-    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
-]
-"""
-""" Adapted to use additional unprotected headers parameter"""
-
 EXAMPLE_A_5_WITH_BCB = """\
 [_
     [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
@@ -422,9 +413,17 @@ class TestCoseScEncrypt0(TestAgent):
         )
 
     def test_exampleA_4_acceptor_valid_addl_uhdr(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[4, <<{4: 'ExampleA.4'}>>], [5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {6: h'484A'}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+        
         self._single_test(
             _TestCase(
-                input_data=EXAMPLE_A_4_WITH_BCB_ADDL_UHDR,
+                input_data=input_diag,
                 expected_output=EXAMPLE_A_NO_SEC,
                 sec_src_eid="dtn://dst/",
                 policy_config="data/cose-sc/policy-any-bcb-accept.json",
@@ -488,6 +487,94 @@ class TestCoseScEncrypt0(TestAgent):
                     expected_output_format=DataFormat.CBORDIAG,
                 )
             )
+
+    def test_exampleA_4_acceptor_valid_fulliv(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4', 5: h'6f3093eba5d85143c3dc484a'}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+        
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=EXAMPLE_A_NO_SEC,
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.CBORDIAG,
+            )
+        )
+
+    def test_exampleA_4_acceptor_valid_padded_partialiv(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4', 6: h'00000000000000000000484A'}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+        
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=EXAMPLE_A_NO_SEC,
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.CBORDIAG,
+            )
+        )
+
+    def test_exampleA_4_acceptor_invalid_missing_iv(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4'}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+        
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=".*<ERROR>.* No full or parital IV header present",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
+            )
+        )
+
+    def test_exampleA_4_acceptor_invalid_excessive_iv(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4', 6: h'0000000000000000000000484A'}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+        
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=r".*<ERROR>.* Invalid Partial IV length, no more than 12 got 13",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
+            )
+        )
 
 
 class TestCoseScEncrypt(TestAgent):

--- a/mock-bpa-test/test_cose_sc.py
+++ b/mock-bpa-test/test_cose_sc.py
@@ -576,6 +576,50 @@ class TestCoseScEncrypt0(TestAgent):
             )
         )
 
+    def test_exampleA_4_acceptor_invalid_fulliv_type(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4', 5: 42}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=r".*<ERROR>.* Invalid IV header",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
+            )
+        )
+
+    def test_exampleA_4_acceptor_invalid_partialiv_type(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[16, << [<< {1: 3} >>, {4: 'ExampleA.4', 6: 42}, null] >>]]] >>],
+    [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=r".*<ERROR>.* Invalid IV header",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
+            )
+        )
+
 
 class TestCoseScEncrypt(TestAgent):
     def test_exampleA_5_source(self):
@@ -648,6 +692,28 @@ class TestCoseScEncrypt(TestAgent):
             _TestCase(
                 input_data=input_diag,
                 expected_output=".*<ERROR>.* Missing required salt header",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
+            )
+        )
+
+    def test_exampleA_6_acceptor_invalid_salt_type(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[96, << [<< {1: 3} >>, {5: h'6F3093EBA5D85143C3DC484A'}, null, [[<< {1: -11} >>, {4: 'ExampleA.6', -20: 42}, '']]] >>]]] >>],
+    [1, 1, 0, 2, h'6D0664951176F40600518B5C32A2A2137871F1F045AD', h'D7042DE5']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=".*<ERROR>.* Invalid salt header",
                 sec_src_eid="dtn://dst/",
                 policy_config="data/cose-sc/policy-any-bcb-accept.json",
                 bundle_dest_loc=BundleDestLoc.APPIN,

--- a/mock-bpa-test/test_cose_sc.py
+++ b/mock-bpa-test/test_cose_sc.py
@@ -420,7 +420,7 @@ class TestCoseScEncrypt0(TestAgent):
     [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
 ]
 """
-        
+
         self._single_test(
             _TestCase(
                 input_data=input_diag,
@@ -496,7 +496,7 @@ class TestCoseScEncrypt0(TestAgent):
     [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
 ]
 """
-        
+
         self._single_test(
             _TestCase(
                 input_data=input_diag,
@@ -518,7 +518,7 @@ class TestCoseScEncrypt0(TestAgent):
     [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
 ]
 """
-        
+
         self._single_test(
             _TestCase(
                 input_data=input_diag,
@@ -540,7 +540,7 @@ class TestCoseScEncrypt0(TestAgent):
     [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
 ]
 """
-        
+
         self._single_test(
             _TestCase(
                 input_data=input_diag,
@@ -562,7 +562,7 @@ class TestCoseScEncrypt0(TestAgent):
     [1, 1, 0, 2, h'1FD25F64A2EEE2FF1A1AB29812BA221874380974C13B', h'2086C017']
 ]
 """
-        
+
         self._single_test(
             _TestCase(
                 input_data=input_diag,
@@ -632,6 +632,28 @@ class TestCoseScEncrypt(TestAgent):
                 key_set="data/cose-sc/keyset-1.cbordiag",
                 input_data_format=DataFormat.CBORDIAG,
                 expected_output_format=DataFormat.CBORDIAG,
+            )
+        )
+
+    def test_exampleA_6_acceptor_invalid_missing_salt(self):
+        input_diag = """\
+[_
+    [7, 0, 2, [1, "//dst/svc"], [1, "//src/svc"], [1, "//src/"], [813110400000, 0], 1000000, h'82A081C9'],
+    [12, 2, 1, 0, << [1], 3, 1, [1, "//src/"], [[5, {0: 1, -1: 1}]], [[[96, << [<< {1: 3} >>, {5: h'6F3093EBA5D85143C3DC484A'}, null, [[<< {1: -11} >>, {4: 'ExampleA.6'}, '']]] >>]]] >>],
+    [1, 1, 0, 2, h'6D0664951176F40600518B5C32A2A2137871F1F045AD', h'D7042DE5']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=".*<ERROR>.* Missing required salt header",
+                sec_src_eid="dtn://dst/",
+                policy_config="data/cose-sc/policy-any-bcb-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/cose-sc/keyset-1.cbordiag",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.ERR,
             )
         )
 

--- a/src/bsl/cose_sc/CoseContext.c
+++ b/src/bsl/cose_sc/CoseContext.c
@@ -2067,6 +2067,7 @@ static void BSLX_CoseSc_GenerateIV(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Headers_t *h
         {
             BSL_LOG_ERR("Invalid Base IV value");
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
         else
         {
@@ -2079,22 +2080,21 @@ static void BSLX_CoseSc_GenerateIV(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Headers_t *h
         BSL_Data_InitView(&baseiv_view, ctx->iv_base.len, ctx->iv_base.ptr);
     }
 
-    if ((BSL_SUCCESS == ctx->status) && (baseiv_view.len > 0) && (BSLX_COSEMSG_AESGCM_IV_LEN != baseiv_view.len))
+    if ((baseiv_view.len > 0) && (BSLX_COSEMSG_AESGCM_IV_LEN != baseiv_view.len))
     {
         BSL_LOG_ERR("Invalid Base IV length, need %zu got %zu", BSLX_COSEMSG_AESGCM_IV_LEN, baseiv_view.len);
         ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+        return;
     }
 
-    if (BSL_SUCCESS == ctx->status)
+    int res =
+        BSLX_CoseSc_GenerateNonce(ctx->keyhandle, &ctx->full_iv, keyparam ? &ctx->partial_iv : NULL, &baseiv_view,
+                                  ctx->opt_iv_offset, ctx->iv_offset, BSLX_COSEMSG_AESGCM_IV_LEN);
+    if (BSL_SUCCESS != res)
     {
-        int res =
-            BSLX_CoseSc_GenerateNonce(ctx->keyhandle, &ctx->full_iv, keyparam ? &ctx->partial_iv : NULL, &baseiv_view,
-                                      ctx->opt_iv_offset, ctx->iv_offset, BSLX_COSEMSG_AESGCM_IV_LEN);
-        if (BSL_SUCCESS != res)
-        {
-            BSL_LOG_ERR("Failed to generate IV");
-            ctx->status = res;
-        }
+        BSL_LOG_ERR("Failed to generate IV");
+        ctx->status = res;
+        return;
     }
 
     // prefer partial when defined
@@ -2131,14 +2131,20 @@ static void BSLX_CoseSc_ExtractIV(BSLX_CoseSc_t *ctx, const BSLX_CoseMsg_Headers
         {
             BSL_LOG_ERR("Invalid IV header");
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
         else if (BSLX_COSEMSG_AESGCM_IV_LEN != ctx->full_iv.len)
         {
             BSL_LOG_ERR("Invalid IV length, need %zu got %zu", BSLX_COSEMSG_AESGCM_IV_LEN, ctx->full_iv.len);
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
+        // got the full IV here
+        return;
     }
-    else if ((head_iv = BSLX_CoseMsg_Headers_Get(headers, BSLX_COSEMSG_HDR_PARTIALIV, false)))
+
+    head_iv = BSLX_CoseMsg_Headers_Get(headers, BSLX_COSEMSG_HDR_PARTIALIV, false);
+    if (head_iv)
     {
         BSL_Data_Resize(&ctx->full_iv, BSLX_COSEMSG_AESGCM_IV_LEN);
 
@@ -2147,11 +2153,13 @@ static void BSLX_CoseSc_ExtractIV(BSLX_CoseSc_t *ctx, const BSLX_CoseMsg_Headers
         {
             BSL_LOG_ERR("Invalid IV header");
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
         else if (partialiv_val.len > ctx->full_iv.len)
         {
             BSL_LOG_ERR("Invalid Partial IV length, no more than %zu got %zu", ctx->full_iv.len, partialiv_val.len);
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
 
         BSL_Data_t baseiv_val;
@@ -2161,30 +2169,36 @@ static void BSLX_CoseSc_ExtractIV(BSLX_CoseSc_t *ctx, const BSLX_CoseMsg_Headers
         {
             BSL_LOG_ERR("Key is missing Base IV");
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
         else if (BSL_SUCCESS != BSL_Variant_GetAsBytestr(keyparam, &baseiv_val))
         {
             BSL_LOG_ERR("Invalid Base IV value");
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
         else if (ctx->full_iv.len != baseiv_val.len)
         {
             BSL_LOG_ERR("Invalid Base IV length, need %zu got %zu", ctx->full_iv.len, baseiv_val.len);
             ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+            return;
         }
-        else
-        {
-            // right-align the partial IV first
-            const size_t pad = ctx->full_iv.len - partialiv_val.len;
-            memset(ctx->full_iv.ptr, 0, pad);
-            memcpy(ctx->full_iv.ptr + pad, partialiv_val.ptr, partialiv_val.len);
 
-            for (size_t ix = 0; ix < ctx->full_iv.len; ++ix)
-            {
-                ctx->full_iv.ptr[ix] ^= baseiv_val.ptr[ix];
-            }
+        // right-align the partial IV first
+        const size_t pad = ctx->full_iv.len - partialiv_val.len;
+        memset(ctx->full_iv.ptr, 0, pad);
+        memcpy(ctx->full_iv.ptr + pad, partialiv_val.ptr, partialiv_val.len);
+
+        for (size_t ix = 0; ix < ctx->full_iv.len; ++ix)
+        {
+            ctx->full_iv.ptr[ix] ^= baseiv_val.ptr[ix];
         }
+        // computed the full IV here
+        return;
     }
+
+    BSL_LOG_ERR("No full or parital IV header present");
+    ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
 }
 
 /** Internal processing to source a COSE_Encrypt0 message.

--- a/src/bsl/cose_sc/CoseContext.c
+++ b/src/bsl/cose_sc/CoseContext.c
@@ -1545,6 +1545,7 @@ static void BSLX_CoseSc_HkdfContentKey(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Recipien
     }
 
     BSL_Data_t salt;
+    BSL_Data_Init(&salt);
     if (ctx->is_source)
     {
         // override algorithm default length
@@ -1553,7 +1554,6 @@ static void BSLX_CoseSc_HkdfContentKey(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Recipien
             salt_len = ctx->salt_length;
         }
 
-        BSL_Data_Init(&salt);
         res = BSLX_CoseSc_GenerateNonce(ctx->keyhandle, &salt, NULL, &ctx->salt_base, ctx->opt_salt_offset,
                                         ctx->salt_offset, salt_len);
         if (BSL_SUCCESS != res)
@@ -1609,10 +1609,16 @@ static void BSLX_CoseSc_HkdfContentKey(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Recipien
         // GCOV_EXCL_STOP
     }
 
-    if (BSL_SUCCESS != BSL_Crypto_KDF(ctx->keyhandle, bsl_kdf, &salt, &kdf_ctx_enc, ctx->tgt_keylen, &ctx->cekhandle))
+    if (BSL_SUCCESS == ctx->status)
     {
-        BSL_LOG_ERR("Failed to derive content key");
-        ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+        res = BSL_Crypto_KDF(ctx->keyhandle, bsl_kdf, &salt, &kdf_ctx_enc, ctx->tgt_keylen, &ctx->cekhandle);
+        // GCOV_EXCL_START
+        if (BSL_SUCCESS != res)
+        {
+            BSL_LOG_ERR("Failed to derive content key");
+            ctx->status = BSL_ERR_SECURITY_CONTEXT_CRYPTO_FAILED;
+        }
+        // GCOV_EXCL_STOP
     }
 
     BSL_Data_Deinit(&kdf_ctx_enc);
@@ -2087,9 +2093,8 @@ static void BSLX_CoseSc_GenerateIV(BSLX_CoseSc_t *ctx, BSLX_CoseMsg_Headers_t *h
         return;
     }
 
-    int res =
-        BSLX_CoseSc_GenerateNonce(ctx->keyhandle, &ctx->full_iv, keyparam ? &ctx->partial_iv : NULL, &baseiv_view,
-                                  ctx->opt_iv_offset, ctx->iv_offset, BSLX_COSEMSG_AESGCM_IV_LEN);
+    int res = BSLX_CoseSc_GenerateNonce(ctx->keyhandle, &ctx->full_iv, keyparam ? &ctx->partial_iv : NULL, &baseiv_view,
+                                        ctx->opt_iv_offset, ctx->iv_offset, BSLX_COSEMSG_AESGCM_IV_LEN);
     if (BSL_SUCCESS != res)
     {
         BSL_LOG_ERR("Failed to generate IV");


### PR DESCRIPTION
This adds specific failure test cases, does not add general fuzzing with secop processing.

Closes #305 