### PR TITLE
Disallow and test option injection

### DIFF
--- a/mock-bpa-test/test_default_scs.py
+++ b/mock-bpa-test/test_default_scs.py
@@ -113,6 +113,28 @@ class TestBibHmacSha(TestAgent):
             )
         )
 
+    def test_exampleA_1_acceptor_valid_unknown_param(self):
+        input_diag = """\
+[_
+    [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
+    [11, 2, 0, 0, << [1], 1, 1, [2, [2, 1]], [[1, 7], [3, 0], [1001, h'31323334']], [[[1, h'3BDC69B3A34A2B5D3A8554368BD1E808F606219D2A10A846EAE3886AE4ECC83C4EE550FDFB1CC636B904E2F1A73E303DCD4B6CCECE003E95E8164DCC89A156E1']]] >>],
+    [1, 1, 0, 0, h'526561647920746F2067656E657261746520612033322D62797465207061796C6F6164']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
+                expected_output=EXAMPLE_A_NO_SEC,
+                sec_src_eid="ipn:1.0",
+                policy_config="data/default-scs/policy-exA.1-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/default-scs/keyset-1.json",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.CBORDIAG,
+            )
+        )
+
     def test_exampleA_1_acceptor_failure_key_mismatch(self):
         with sc_config_modifier(
             orig=os.path.join(OWNPATH, "data/default-scs/policy-exA.1-accept.json"),
@@ -203,6 +225,28 @@ class TestBcbAesGcm(TestAgent):
         self._single_test(
             _TestCase(
                 input_data=EXAMPLE_A_2_WITH_BCB,
+                expected_output=EXAMPLE_A_NO_SEC,
+                sec_src_eid="ipn:1.0",
+                policy_config="data/default-scs/policy-exA.2-accept.json",
+                bundle_dest_loc=BundleDestLoc.APPIN,
+                key_set="data/default-scs/keyset-1.json",
+                input_data_format=DataFormat.CBORDIAG,
+                expected_output_format=DataFormat.CBORDIAG,
+            )
+        )
+
+    def test_exampleA_2_acceptor_valid_unknown_param(self):
+        input_diag = """\
+[_
+    [7, 0, 0, [2, [1, 2]], [2, [2, 1]], [2, [2, 1]], [0, 40], 1000000],
+    [12, 2, 1, 0, << [1], 2, 1, [2, [2, 1]], [[1, h'5477656C7665313231323132'], [2, 1], [3, h'69C411276FECDDC4780DF42C8A2AF89296FABF34D7FAE700'], [4, 0], [1001, h'31323334']], [[[1, h'EFA4B5AC0108E3816C5606479801BC04']]] >>],
+    [1, 1, 0, 0, h'3A09C1E63FE23A7F66A59C7303837241E070B02619FC59C5214A22F08CD70795E73E9A']
+]
+"""
+
+        self._single_test(
+            _TestCase(
+                input_data=input_diag,
                 expected_output=EXAMPLE_A_NO_SEC,
                 sec_src_eid="ipn:1.0",
                 policy_config="data/default-scs/policy-exA.2-accept.json",

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -274,7 +274,7 @@ static int BSL_ExecBIBVerifierAcceptor(BSL_SecCtx_Execute_f sec_context_fn, BSL_
                 int res = Encode_ASB(lib, bundle, sec_blk.block_num, &abs_sec_block);
                 if (res != BSL_SUCCESS)
                 {
-                    retval = BSL_ERR_FAILURE;
+                    retval = res;
                 }
             }
         }

--- a/src/backend/SecurityContext.c
+++ b/src/backend/SecurityContext.c
@@ -190,77 +190,108 @@ static int BSL_ExecBIBVerifierAcceptor(BSL_SecCtx_Execute_f sec_context_fn, BSL_
     BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_ASB_DECODE_COUNT, 1);
     BSL_Data_Deinit(&btsd_copy);
 
-    CHK_PROPERTY(BSL_AbsSecBlock_IsConsistent(&abs_sec_block));
-
-    for (size_t i = 0; i < BSLB_SecParamList_size(abs_sec_block.params); i++)
+    int retval = BSL_SUCCESS;
+    if (!BSL_AbsSecBlock_IsConsistent(&abs_sec_block))
     {
-        const BSL_SecParam_t *param = BSLB_SecParamList_cget(abs_sec_block.params, i);
-        CHK_PROPERTY(BSL_SecParam_IsConsistent(param));
-        BSLB_SecParamList_push_back(sec_oper->_param_list, *param);
+        BSL_LOG_ERR("ASB is not consistent");
+        retval = BSL_ERR_SECURITY_OPERATION_FAILED;
     }
 
-    const int sec_context_result = (*sec_context_fn)(lib, bundle, sec_oper, outcome);
-    if (sec_context_result != BSL_SUCCESS) // || outcome->is_success == false)
+    if (BSL_SUCCESS == retval)
     {
-        BSL_LOG_ERR("BIB Sec Ctx processing for verifier/acceptor failed!");
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return BSL_ERR_SECURITY_OPERATION_FAILED;
+        for (size_t i = 0; i < BSLB_SecParamList_size(abs_sec_block.params); i++)
+        {
+            const BSL_SecParam_t *param = BSLB_SecParamList_cget(abs_sec_block.params, i);
+            if (!BSL_SecParam_IsConsistent(param))
+            {
+                BSL_LOG_ERR("ASB parameter is not consistent");
+                retval = BSL_ERR_SECURITY_OPERATION_FAILED;
+                break;
+            }
+            // these options cannot come from an ASB
+            if (param->param_id >= BSL_SECPARAM_TYPE_INT_STARTINDEX)
+            {
+                BSL_LOG_WARNING("Ignoring invalid ASB parameter ID: %" PRIu64, param->param_id);
+                continue;
+            }
+            BSLB_SecParamList_push_back(sec_oper->_param_list, *param);
+        }
     }
 
-    if (!BSL_SecOutcome_IsInAbsSecBlock(outcome, &abs_sec_block))
+    if (BSL_SUCCESS == retval)
     {
-        BSL_LOG_ERR("ASB Does not contain expeceted sec params and outcomes");
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return BSL_ERR_SECURITY_OPERATION_FAILED;
+        const int sec_context_result = (*sec_context_fn)(lib, bundle, sec_oper, outcome);
+        if (sec_context_result != BSL_SUCCESS) // || outcome->is_success == false)
+        {
+            BSL_LOG_ERR("BIB Sec Ctx processing for verifier/acceptor failed!");
+            retval = BSL_ERR_SECURITY_OPERATION_FAILED;
+        }
     }
 
+    if (BSL_SUCCESS == retval)
+    {
+        if (!BSL_SecOutcome_IsInAbsSecBlock(outcome, &abs_sec_block))
+        {
+            BSL_LOG_ERR("ASB Does not contain expeceted sec params and outcomes");
+            retval = BSL_ERR_SECURITY_OPERATION_FAILED;
+        }
+    }
+
+    BSL_TlmCounterIndex_e tlm_index;
     // If secop is to verify, processing is complete
     if (BSL_SecOper_IsRoleVerifier(sec_oper))
     {
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_VERIFIER_COUNT, 1);
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        return BSL_SUCCESS;
-    }
-
-    // TODO/FIXME - This logic seems to be correct, but should be refactored and simplified.
-    // There are too many branches/conditionals each with their own return statement.
-
-    // If secop is to accept, BIB must be removed from bundle
-    uint64_t target_block_num = BSL_SecOper_GetTargetBlockNum(sec_oper);
-    int      status           = BSL_AbsSecBlock_StripResults(&abs_sec_block, target_block_num);
-    if (status < 0)
-    {
-        BSL_LOG_ERR("Failure to strip ASB of results");
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return BSL_ERR_FAILURE;
-    }
-
-    if (BSL_AbsSecBlock_IsEmpty(&abs_sec_block))
-    {
-        if (BSL_BundleCtx_RemoveBlock(bundle, sec_blk.block_num) != BSL_SUCCESS)
-        {
-            BSL_LOG_ERR("Failed to remove block when ASB is empty");
-            BSL_AbsSecBlock_Deinit(&abs_sec_block);
-            BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-            return BSL_ERR_HOST_CALLBACK_FAILED;
-        }
+        tlm_index = BSL_TLM_SECOP_VERIFIER_COUNT;
     }
     else
     {
-        int res = Encode_ASB(lib, bundle, sec_blk.block_num, &abs_sec_block);
-        if (res != BSL_SUCCESS)
+        tlm_index = BSL_TLM_SECOP_ACCEPTOR_COUNT;
+
+        if (BSL_SUCCESS == retval)
         {
-            BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-            return res;
+            // If secop is to accept, BIB must be removed from bundle
+            uint64_t target_block_num = BSL_SecOper_GetTargetBlockNum(sec_oper);
+            int      status           = BSL_AbsSecBlock_StripResults(&abs_sec_block, target_block_num);
+            if (status < 0)
+            {
+                BSL_LOG_ERR("Failure to strip ASB of results");
+                retval = BSL_ERR_FAILURE;
+            }
+        }
+
+        if (BSL_SUCCESS == retval)
+        {
+            if (BSL_AbsSecBlock_IsEmpty(&abs_sec_block))
+            {
+                if (BSL_BundleCtx_RemoveBlock(bundle, sec_blk.block_num) != BSL_SUCCESS)
+                {
+                    BSL_LOG_ERR("Failed to remove block when ASB is empty");
+                    retval = BSL_ERR_HOST_CALLBACK_FAILED;
+                }
+            }
+            else
+            {
+                int res = Encode_ASB(lib, bundle, sec_blk.block_num, &abs_sec_block);
+                if (res != BSL_SUCCESS)
+                {
+                    retval = BSL_ERR_FAILURE;
+                }
+            }
         }
     }
-    BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_ACCEPTOR_COUNT, 1);
+
+    // cleanup
+    if (BSL_SUCCESS == retval)
+    {
+        BSL_TlmCounters_IncrementCounter(lib, tlm_index, 1);
+    }
+    else
+    {
+        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
+    }
     BSL_AbsSecBlock_Deinit(&abs_sec_block);
 
-    return BSL_SUCCESS;
+    return retval;
 }
 
 static int BSL_ExecBCBVerifierAcceptor(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle,
@@ -301,82 +332,118 @@ static int BSL_ExecBCBVerifierAcceptor(BSL_SecCtx_Execute_f sec_context_fn, BSL_
     BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_ASB_DECODE_COUNT, 1);
     BSL_Data_Deinit(&btsd_copy);
 
-    CHK_PROPERTY(BSL_AbsSecBlock_IsConsistent(&abs_sec_block));
-
-    for (size_t i = 0; i < BSLB_SecParamList_size(abs_sec_block.params); i++)
+    int retval = BSL_SUCCESS;
+    if (!BSL_AbsSecBlock_IsConsistent(&abs_sec_block))
     {
-        const BSL_SecParam_t *param = BSLB_SecParamList_cget(abs_sec_block.params, i);
-        CHK_PROPERTY(BSL_SecParam_IsConsistent(param));
-        BSLB_SecParamList_push_back(sec_oper->_param_list, *param);
+        BSL_LOG_ERR("ASB is not consistent");
+        retval = BSL_ERR_SECURITY_OPERATION_FAILED;
     }
 
-    const size_t   result_count = BSLB_SecResultList_size(abs_sec_block.results);
-    BSL_SecParam_t results_as_params[result_count];
-    for (size_t i = 0; i < result_count; i++)
+    if (BSL_SUCCESS == retval)
     {
-        const BSL_SecResult_t *result = BSLB_SecResultList_get(abs_sec_block.results, i);
-        if (result->target_block_num == sec_oper->target_block_num)
+        for (size_t i = 0; i < BSLB_SecParamList_size(abs_sec_block.params); i++)
         {
-            BSL_Data_t as_data;
-            BSL_SecResult_GetAsBytestr(result, &as_data);
-
-            BSL_SecParam_t *result_param = &results_as_params[i];
-            BSL_SecParam_InitBytestr(result_param, BSL_SECPARAM_TYPE_AUTH_TAG, as_data);
-            BSLB_SecParamList_push_move(sec_oper->_param_list, result_param);
+            const BSL_SecParam_t *param = BSLB_SecParamList_cget(abs_sec_block.params, i);
+            if (!BSL_SecParam_IsConsistent(param))
+            {
+                BSL_LOG_ERR("ASB parameter is not consistent");
+                retval = BSL_ERR_SECURITY_OPERATION_FAILED;
+                break;
+            }
+            // these options cannot come from an ASB
+            if (param->param_id >= BSL_SECPARAM_TYPE_INT_STARTINDEX)
+            {
+                BSL_LOG_WARNING("Ignoring invalid ASB parameter ID: %" PRIu64, param->param_id);
+                continue;
+            }
+            BSLB_SecParamList_push_back(sec_oper->_param_list, *param);
         }
     }
 
-    const int sec_context_result = (*sec_context_fn)(lib, bundle, sec_oper, outcome);
-    if (sec_context_result != BSL_SUCCESS)
+    if (BSL_SUCCESS == retval)
     {
-        BSL_LOG_ERR("BCB Sec Ctx processing for verifier/acceptor failed!");
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return BSL_ERR_SECURITY_OPERATION_FAILED;
+        const size_t   result_count = BSLB_SecResultList_size(abs_sec_block.results);
+        BSL_SecParam_t results_as_params[result_count];
+        for (size_t i = 0; i < result_count; i++)
+        {
+            const BSL_SecResult_t *result = BSLB_SecResultList_get(abs_sec_block.results, i);
+            if (result->target_block_num == sec_oper->target_block_num)
+            {
+                BSL_Data_t as_data;
+                BSL_SecResult_GetAsBytestr(result, &as_data);
+
+                BSL_SecParam_t *result_param = &results_as_params[i];
+                BSL_SecParam_InitBytestr(result_param, BSL_SECPARAM_TYPE_AUTH_TAG, as_data);
+                BSLB_SecParamList_push_move(sec_oper->_param_list, result_param);
+            }
+        }
     }
 
+    if (BSL_SUCCESS == retval)
+    {
+        const int sec_context_result = (*sec_context_fn)(lib, bundle, sec_oper, outcome);
+        if (sec_context_result != BSL_SUCCESS)
+        {
+            BSL_LOG_ERR("BCB Sec Ctx processing for verifier/acceptor failed!");
+            retval = BSL_ERR_SECURITY_OPERATION_FAILED;
+        }
+    }
+
+    BSL_TlmCounterIndex_e tlm_index;
     // If secop is to verify, processing is complete
     if (BSL_SecOper_IsRoleVerifier(sec_oper))
     {
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_VERIFIER_COUNT, 1);
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        return BSL_SUCCESS;
-    }
-
-    // If secop is to accept, BCB must be removed from bundle
-    uint64_t target_block_num = BSL_SecOper_GetTargetBlockNum(sec_oper);
-    int      status           = BSL_AbsSecBlock_StripResults(&abs_sec_block, target_block_num);
-    if (status < 0)
-    {
-        BSL_LOG_ERR("Failure to strip ASB of results");
-        BSL_AbsSecBlock_Deinit(&abs_sec_block);
-        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-        return BSL_ERR_FAILURE;
-    }
-
-    if (BSL_AbsSecBlock_IsEmpty(&abs_sec_block))
-    {
-        if (BSL_BundleCtx_RemoveBlock(bundle, sec_blk.block_num) != BSL_SUCCESS)
-        {
-            BSL_LOG_ERR("Failed to remove block when ASB is empty");
-            BSL_AbsSecBlock_Deinit(&abs_sec_block);
-            BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-            return BSL_ERR_HOST_CALLBACK_FAILED;
-        }
+        tlm_index = BSL_TLM_SECOP_VERIFIER_COUNT;
     }
     else
     {
-        int res = Encode_ASB(lib, bundle, sec_blk.block_num, &abs_sec_block);
-        if (res != BSL_SUCCESS)
+        tlm_index = BSL_TLM_SECOP_ACCEPTOR_COUNT;
+
+        if (BSL_SUCCESS == retval)
         {
-            BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
-            return res;
+            // If secop is to accept, BCB must be removed from bundle
+            uint64_t target_block_num = BSL_SecOper_GetTargetBlockNum(sec_oper);
+            int      status           = BSL_AbsSecBlock_StripResults(&abs_sec_block, target_block_num);
+            if (status < 0)
+            {
+                BSL_LOG_ERR("Failure to strip ASB of results");
+                retval = BSL_ERR_FAILURE;
+            }
+        }
+
+        if (BSL_SUCCESS == retval)
+        {
+            if (BSL_AbsSecBlock_IsEmpty(&abs_sec_block))
+            {
+                if (BSL_BundleCtx_RemoveBlock(bundle, sec_blk.block_num) != BSL_SUCCESS)
+                {
+                    BSL_LOG_ERR("Failed to remove block when ASB is empty");
+                    retval = BSL_ERR_HOST_CALLBACK_FAILED;
+                }
+            }
+            else
+            {
+                int res = Encode_ASB(lib, bundle, sec_blk.block_num, &abs_sec_block);
+                if (res != BSL_SUCCESS)
+                {
+                    retval = res;
+                }
+            }
         }
     }
-    BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_ACCEPTOR_COUNT, 1);
+
+    // cleanup
+    if (BSL_SUCCESS == retval)
+    {
+        BSL_TlmCounters_IncrementCounter(lib, tlm_index, 1);
+    }
+    else
+    {
+        BSL_TlmCounters_IncrementCounter(lib, BSL_TLM_SECOP_FAIL_COUNT, 1);
+    }
     BSL_AbsSecBlock_Deinit(&abs_sec_block);
 
-    return BSL_SUCCESS;
+    return retval;
 }
 
 static int BSL_ExecBCBSource(BSL_SecCtx_Execute_f sec_context_fn, BSL_LibCtx_t *lib, BSL_BundleRef_t *bundle,
@@ -489,9 +556,14 @@ int BSL_SecCtx_ExecutePolicyActionSet(BSL_LibCtx_t *lib, BSL_SecurityResponseSet
             int errcode = -1;
             if (BSL_SecOper_IsBIB(sec_oper))
             {
-                errcode = BSL_SecOper_IsRoleSource(sec_oper) == true
-                              ? BSL_ExecBIBSource(sec_ctx->execute, lib, bundle, sec_oper, outcome)
-                              : BSL_ExecBIBVerifierAcceptor(sec_ctx->execute, lib, bundle, sec_oper, outcome);
+                if (BSL_SecOper_IsRoleSource(sec_oper))
+                {
+                    errcode = BSL_ExecBIBSource(sec_ctx->execute, lib, bundle, sec_oper, outcome);
+                }
+                else
+                {
+                    errcode = BSL_ExecBIBVerifierAcceptor(sec_ctx->execute, lib, bundle, sec_oper, outcome);
+                }
             }
             else
             {

--- a/src/security_context/BIB_HMAC_SHA2.c
+++ b/src/security_context/BIB_HMAC_SHA2.c
@@ -118,9 +118,7 @@ int BSLX_BIB_InitFromSecOper(BSLX_BIB_t *self, const BSL_BundleRef_t *bundle, co
         if (param_id == BSL_SECPARAM_TYPE_KEY_ID)
         {
             ASSERT_PRECONDITION(!is_int);
-            const char *res;
-            BSL_SecParam_GetAsTextstr(param, &res);
-            self->key_id = res;
+            ASSERT_POSTCONDITION(BSL_SUCCESS == BSL_SecParam_GetAsTextstr(param, &self->key_id));
         }
         else if (param_id == RFC9173_BIB_PARAMID_SHA_VARIANT)
         {

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -690,7 +690,7 @@ void test_comprehensive(BSL_PolicyLocation_e policy_loc, const char *src_eid, co
                     }
                 }
 
-                TEST_ASSERT(fail_ct > 0);
+                TEST_ASSERT_GREATER_THAN(0, fail_ct);
 
                 if (policy_act == BSL_POLICYACTION_DROP_BLOCK)
                 {
@@ -789,7 +789,7 @@ void test_comprehensive(BSL_PolicyLocation_e policy_loc, const char *src_eid, co
                     }
                 }
 
-                TEST_ASSERT(fail_ct > 0);
+                TEST_ASSERT_GREATER_THAN(0, fail_ct);
 
                 if (policy_act == BSL_POLICYACTION_DROP_BLOCK)
                 {


### PR DESCRIPTION
This also performs some control flow cleanup in common verifier/acceptor handling.

Closes #302 for v1.1