### PR TITLE
Guard policy config with rwlock instead of mutex

### DIFF
--- a/lib-user-test/CMakeLists.txt
+++ b/lib-user-test/CMakeLists.txt
@@ -23,6 +23,10 @@ cmake_minimum_required(VERSION 3.23)
 
 project(lib-user-test VERSION 0.0.0 LANGUAGES C)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
 set(PKG_CONFIG_ARGN "--define-prefix")
 find_package(PkgConfig REQUIRED)
 include(CMakePrintHelpers)

--- a/lib-user-test/configure.ac
+++ b/lib-user-test/configure.ac
@@ -10,7 +10,7 @@ AM_SILENT_RULES([yes]) # less verbose make output
 AC_CONFIG_SRCDIR([main.c])
 
 AC_LANG([C]) # Use C not C++
-
+AC_USE_SYSTEM_EXTENSIONS # Use POSIX
 AC_PROG_CC # check for compiler
 AX_CHECK_COMPILE_FLAG([-std=c99], [CFLAGS="$CFLAGS -std=c99"])
 AC_PROG_INSTALL

--- a/lib-user-test/configure.ac
+++ b/lib-user-test/configure.ac
@@ -10,7 +10,7 @@ AM_SILENT_RULES([yes]) # less verbose make output
 AC_CONFIG_SRCDIR([main.c])
 
 AC_LANG([C]) # Use C not C++
-AC_USE_SYSTEM_EXTENSIONS # Use POSIX
+
 AC_PROG_CC # check for compiler
 AX_CHECK_COMPILE_FLAG([-std=c99], [CFLAGS="$CFLAGS -std=c99"])
 AC_PROG_INSTALL

--- a/src/bsl/BPSecLib_Public.h
+++ b/src/bsl/BPSecLib_Public.h
@@ -289,6 +289,7 @@ typedef struct BSL_CanonicalBlock_s
  *
  * These are meant to be used as part of ::BSL_HostDescriptors_t for
  * registering host callbacks.
+ * @since v1.1.0
  */
 typedef struct
 {

--- a/src/bsl/crypto/KeyStore.h
+++ b/src/bsl/crypto/KeyStore.h
@@ -71,6 +71,7 @@ typedef struct
 /** The set of callback function pointers which actually implement
  * a key store.
  * When registering, all of the functions need to be non-NULL.
+ * @since v2.0.0
  */
 typedef struct
 {

--- a/src/bsl/mock_bpa/agent.c
+++ b/src/bsl/mock_bpa/agent.c
@@ -550,7 +550,7 @@ int MockBPA_Agent_Init(MockBPA_Agent_t *agent, BSLP_PolicyProvider_t **policy)
         }
     }
 
-    *policy              = BSLP_PolicyProvider_Init(1);
+    *policy              = BSLP_PolicyProvider_New(1);
     agent->appin.policy  = *policy;
     agent->appout.policy = *policy;
     agent->clin.policy   = *policy;

--- a/src/bsl/sample_pp/SamplePolicyProvider.c
+++ b/src/bsl/sample_pp/SamplePolicyProvider.c
@@ -181,7 +181,7 @@ int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set
     BSLP_SecOperPtrList_t secops;
     BSLP_SecOperPtrList_init(secops);
 
-    pthread_mutex_lock(&self->mutex);
+    pthread_rwlock_rdlock(&self->mutex);
     BSLP_PolicyRuleList_it_t      rule_it;
     BSLP_PolicyPredicateList_it_t pred_it;
     for (BSLP_PolicyRuleList_it(rule_it, self->rules), BSLP_PolicyPredicateList_it(pred_it, self->predicates);
@@ -288,7 +288,7 @@ int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set
         }
         BSL_LOG_INFO("Created sec operation for rule `%s`", m_string_get_cstr(rule->description));
     }
-    pthread_mutex_unlock(&self->mutex);
+    pthread_rwlock_unlock(&self->mutex);
 
     BSL_PrimaryBlock_deinit(&primary_block);
 
@@ -318,9 +318,9 @@ int BSLP_FinalizePolicy(void *user_data _U_, const BSL_SecurityActionSet_t *outp
     {
         const BSL_SecurityAction_t *action = BSL_SecurityActionSet_GetActionAtIndex(output_action_set, i);
 
-        pthread_mutex_lock(&self->mutex);
+        pthread_rwlock_rdlock(&self->mutex);
         uint64_t pp_id = self->pp_id;
-        pthread_mutex_unlock(&self->mutex);
+        pthread_rwlock_unlock(&self->mutex);
 
         if (BSL_SecurityAction_GetPPID(action) != pp_id)
         {
@@ -382,7 +382,7 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
     pp->pp_id = pp_id;
     BSLP_PolicyRuleList_init(pp->rules);
     BSLP_PolicyPredicateList_init(pp->predicates);
-    pthread_mutex_init(&pp->mutex, NULL);
+    pthread_rwlock_init(&pp->mutex, NULL);
 
     return pp;
 }
@@ -400,22 +400,22 @@ int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *
     BSLP_PolicyPredicatePtr_t *pred_ptr = BSLP_PolicyPredicatePtr_new();
     BSLP_PolicyPredicate_Move(BSLP_PolicyPredicatePtr_ref(pred_ptr), predicate);
 
-    pthread_mutex_lock(&self->mutex);
+    pthread_rwlock_wrlock(&self->mutex);
     BSLP_PolicyRuleList_push_move(self->rules, &rule_ptr);
     BSLP_PolicyPredicateList_push_move(self->predicates, &pred_ptr);
-    pthread_mutex_unlock(&self->mutex);
+    pthread_rwlock_unlock(&self->mutex);
 
     return BSL_SUCCESS;
 }
 
 void BSLP_PolicyProvider_Destroy(BSLP_PolicyProvider_t *self)
 {
-    pthread_mutex_lock(&self->mutex);
+    pthread_rwlock_wrlock(&self->mutex);
     BSLP_PolicyRuleList_clear(self->rules);
     BSLP_PolicyPredicateList_clear(self->predicates);
-    pthread_mutex_unlock(&self->mutex);
+    pthread_rwlock_unlock(&self->mutex);
 
-    pthread_mutex_destroy(&self->mutex);
+    pthread_rwlock_destroy(&self->mutex);
     BSL_free(self);
 }
 

--- a/src/bsl/sample_pp/SamplePolicyProvider.c
+++ b/src/bsl/sample_pp/SamplePolicyProvider.c
@@ -31,11 +31,19 @@
 #include "bsl/dynamic/MLibConfig.h"
 
 #include <m-array.h>
+#include <m-dict.h>
+#include <m-shared-ptr.h>
 
+#include <pthread.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+
+void BSLP_Deinit(void *user_data)
+{
+    (void)user_data;
+}
 
 /** @struct BSLP_SecOperPtrList_t
  * Defines a basic list of ::BSL_SecOper_s pointers.
@@ -44,6 +52,47 @@
 // NOLINTBEGIN
 // GCOV_EXCL_START
 M_ARRAY_DEF(BSLP_SecOperPtrList, BSL_SecOper_t *, M_PTR_OPLIST)
+// GCOV_EXCL_STOP
+// NOLINTEND
+/// @endcond
+
+/** @struct BSLP_PolicyPredicatePtr_t
+ * Thread-unsafe shared pointer to ::BSLP_PolicyPredicate_t.
+ */
+/** @struct BSLP_PolicyPredicateList_t
+ * Defines list of policy predicates (::BSLP_PolicyPredicate_t)
+ */
+/// @cond Doxygen_Suppress
+// NOLINTBEGIN
+// GCOV_EXCL_START
+M_SHARED_WEAK_PTR_DEF(BSLP_PolicyPredicatePtr, BSLP_PolicyPredicate_t, M_OPL_BSLP_PolicyPredicate_t())
+#define M_OPL_BSLP_PolicyPredicatePtr_t() M_SHARED_PTR_OPLIST(BSLP_PolicyPredicatePtr, M_OPL_BSLP_PolicyPredicate_t())
+M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicatePtr_t *, M_OPL_BSLP_PolicyPredicatePtr_t())
+// GCOV_EXCL_STOP
+// NOLINTEND
+/// @endcond
+
+/** @struct BSLP_PolicyRulePtr_t
+ * A thread-unsafe shared pointer to a single ::BSLP_PolicyRule_t instance.
+ */
+/** @struct BSLP_PolicyRuleList_t
+ * Defines list of policy rules (::BSLP_PolicyRule_t)
+ */
+/// @cond Doxygen_Suppress
+// NOLINTBEGIN
+// GCOV_EXCL_START
+M_SHARED_WEAK_PTR_DEF(BSLP_PolicyRulePtr, BSLP_PolicyRule_t, M_OPL_BSLP_PolicyRule_t())
+#define M_OPL_BSLP_PolicyRulePtr_t() M_SHARED_PTR_OPLIST(BSLP_PolicyRulePtr, M_OPL_BSLP_PolicyRule_t())
+M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRulePtr_t *, M_OPL_BSLP_PolicyRulePtr_t())
+// GCOV_EXCL_STOP
+// NOLINTEND
+/// @endcond
+
+/// @cond Doxygen_Suppress
+// NOLINTBEGIN
+// GCOV_EXCL_START
+M_DICT_DEF2(BSLP_PolicyNoRuleActionMap, BSL_PolicyLocation_e, M_BASIC_OPLIST, BSL_PolicyAction_e,
+            M_ENUM_OPLIST(BSL_PolicyAction_e, BSL_POLICYACTION_UNDEFINED))
 // GCOV_EXCL_STOP
 // NOLINTEND
 /// @endcond
@@ -158,9 +207,20 @@ static uint64_t get_target_block_id(const BSL_BundleRef_t *bundle, uint64_t targ
     return target_block_num;
 }
 
-/**
- * Note that criticality is HIGH
- */
+struct BSLP_PolicyProvider_s
+{
+    /// Variable-length list of policy rules
+    BSLP_PolicyRuleList_t rules;
+    /// Variable-length list of policy predicates
+    BSLP_PolicyPredicateList_t predicates;
+    /// Action when no rules match at an interaction point
+    BSLP_PolicyNoRuleActionMap_t norule_action;
+    /// ID of policy provider
+    uint64_t pp_id;
+    /// Mutex for all other shared data in this struct
+    pthread_rwlock_t mutex;
+};
+
 int BSLP_QueryPolicy(void *user_data, BSL_SecurityActionSet_t *output_action_set, const BSL_BundleRef_t *bundle,
                      BSL_PolicyLocation_e location)
 {
@@ -385,12 +445,7 @@ int BSLP_FinalizePolicy(void *user_data _U_, const BSL_SecurityActionSet_t *outp
     return error_ret;
 }
 
-void BSLP_Deinit(void *user_data)
-{
-    (void)user_data;
-}
-
-BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
+BSLP_PolicyProvider_t *BSLP_PolicyProvider_New(uint64_t pp_id)
 {
     ASSERT_ARG_EXPR(pp_id > 0);
 
@@ -408,6 +463,7 @@ BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id)
 
 int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule, BSLP_PolicyPredicate_t *predicate)
 {
+    ASSERT_ARG_NONNULL(self);
     if (!BSLP_PolicyRule_IsConsistent(rule) || !BSLP_PolicyPredicate_IsConsistent(predicate))
     {
         return BSL_ERR_ARG_INVALID;
@@ -425,6 +481,17 @@ int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *
     pthread_rwlock_unlock(&self->mutex);
 
     return BSL_SUCCESS;
+}
+
+size_t BSLP_PolicyProvider_RuleCount(BSLP_PolicyProvider_t *self)
+{
+    ASSERT_ARG_NONNULL(self);
+
+    pthread_rwlock_rdlock(&self->mutex);
+    size_t count = BSLP_PolicyRuleList_size(self->rules);
+    pthread_rwlock_unlock(&self->mutex);
+
+    return count;
 }
 
 void BSLP_PolicyProvider_SetNoRuleAction(BSLP_PolicyProvider_t *self, BSL_PolicyLocation_e loc,

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -235,7 +235,7 @@ typedef struct BSLP_PolicyProvider_s
     /// ID of policy provider
     uint64_t pp_id;
     /// Mutex for all other shared data in this struct
-    pthread_mutex_t mutex;
+    pthread_rwlock_t mutex;
 } BSLP_PolicyProvider_t;
 
 /** Initialize policy provider data

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -32,12 +32,8 @@
 #include "bsl/dynamic/MLibConfig.h"
 #include "bsl/dynamic/Variant.h"
 
-#include <m-array.h>
-#include <m-dict.h>
-#include <m-shared-ptr.h>
 #include <m-string.h>
 
-#include <pthread.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -102,19 +98,6 @@ void BSLP_PolicyPredicate_Move(BSLP_PolicyPredicate_t *self, BSLP_PolicyPredicat
 #define M_OPL_BSLP_PolicyPredicate_t()                                                                    \
     (INIT(API_2(BSLP_PolicyPredicate_Init)), INIT_SET(0), SET(0), MOVE(API_6(BSLP_PolicyPredicate_Move)), \
      CLEAR(API_2(BSLP_PolicyPredicate_Deinit)))
-
-/** @struct BSLP_PolicyPredicateList_t
- * Defines list of policy predicates (::BSLP_PolicyPredicate_t)
- */
-/// @cond Doxygen_Suppress
-// NOLINTBEGIN
-// GCOV_EXCL_START
-M_SHARED_WEAK_PTR_DEF(BSLP_PolicyPredicatePtr, BSLP_PolicyPredicate_t, M_OPL_BSLP_PolicyPredicate_t())
-#define M_OPL_BSLP_PolicyPredicatePtr_t() M_SHARED_PTR_OPLIST(BSLP_PolicyPredicatePtr, M_OPL_BSLP_PolicyPredicate_t())
-M_ARRAY_DEF(BSLP_PolicyPredicateList, BSLP_PolicyPredicatePtr_t *, M_OPL_BSLP_PolicyPredicatePtr_t())
-// GCOV_EXCL_STOP
-// NOLINTEND
-/// @endcond
 
 /**
  * @brief Returns true if the given predicate matches the arguments
@@ -201,31 +184,6 @@ void BSLP_PolicyRule_Move(BSLP_PolicyRule_t *self, BSLP_PolicyRule_t *src);
     (INIT(API_2(BSLP_PolicyRule_Init)), INIT_SET(0), SET(0), MOVE(API_6(BSLP_PolicyRule_Move)), \
      CLEAR(API_2(BSLP_PolicyRule_Deinit)))
 
-/** @struct BSLP_PolicyRulePtr_t
- * A thread-unsafe shared pointer to a single ::BSLP_PolicyRule_t instance.
- */
-/** @struct BSLP_PolicyRuleList_t
- * Defines list of policy rules (::BSLP_PolicyRule_t)
- */
-/// @cond Doxygen_Suppress
-// NOLINTBEGIN
-// GCOV_EXCL_START
-M_SHARED_WEAK_PTR_DEF(BSLP_PolicyRulePtr, BSLP_PolicyRule_t, M_OPL_BSLP_PolicyRule_t())
-#define M_OPL_BSLP_PolicyRulePtr_t() M_SHARED_PTR_OPLIST(BSLP_PolicyRulePtr, M_OPL_BSLP_PolicyRule_t())
-M_ARRAY_DEF(BSLP_PolicyRuleList, BSLP_PolicyRulePtr_t *, M_OPL_BSLP_PolicyRulePtr_t())
-// GCOV_EXCL_STOP
-// NOLINTEND
-/// @endcond
-
-/// @cond Doxygen_Suppress
-// NOLINTBEGIN
-// GCOV_EXCL_START
-M_DICT_DEF2(BSLP_PolicyNoRuleActionMap, BSL_PolicyLocation_e, M_BASIC_OPLIST, BSL_PolicyAction_e,
-            M_ENUM_OPLIST(BSL_PolicyAction_e, BSL_POLICYACTION_UNDEFINED))
-// GCOV_EXCL_STOP
-// NOLINTEND
-/// @endcond
-
 /**
  * @brief Include a BPSec option on this rule.
  *
@@ -235,35 +193,32 @@ M_DICT_DEF2(BSLP_PolicyNoRuleActionMap, BSL_PolicyLocation_e, M_BASIC_OPLIST, BS
  */
 BSL_Variant_t *BSLP_PolicyRule_AddOption(BSLP_PolicyRule_t *self, int64_t opt_id);
 
-/// @brief Policy provider data. References shared among individual providers in BSL context
-typedef struct BSLP_PolicyProvider_s
-{
-    /// Variable-length list of policy rules
-    BSLP_PolicyRuleList_t rules;
-    /// Variable-length list of policy predicates
-    BSLP_PolicyPredicateList_t predicates;
-    /// Action when no rules match at an interaction point
-    BSLP_PolicyNoRuleActionMap_t norule_action;
-    /// ID of policy provider
-    uint64_t pp_id;
-    /// Mutex for all other shared data in this struct
-    pthread_rwlock_t mutex;
-} BSLP_PolicyProvider_t;
+/** @brief Policy provider data.
+ * References are shared among individual providers in BSL context.
+ */
+typedef struct BSLP_PolicyProvider_s BSLP_PolicyProvider_t;
 
-/** Initialize policy provider data
+/** Allocate and initialize policy provider data
  * Data owned by BPA, reference should be provided to BSL library context(s)
  * @param pp_id policy provider id (must be > 0)
  * @return valid pointer to dynamically allocated policy provider
  */
-BSLP_PolicyProvider_t *BSLP_PolicyProvider_Init(uint64_t pp_id);
+BSLP_PolicyProvider_t *BSLP_PolicyProvider_New(uint64_t pp_id);
 
 /** Add rule and corresponding predicate to policy provider
- * @param self policy provider
- * @param rule policy rule to add
- * @param predicate predicate to be associated with policy rule
+ * @param[in] self policy provider
+ * @param[in] rule policy rule to add and move from.
+ * @param[in] predicate predicate to be associated with policy rule to move from.
  */
 int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *rule,
                                 BSLP_PolicyPredicate_t *predicate);
+
+/** Get the number of rules in a provider state.
+ *
+ * @param[in] self policy provider
+ * @return The number of rules present.
+ */
+size_t BSLP_PolicyProvider_RuleCount(BSLP_PolicyProvider_t *self);
 
 /** Set the action to perform when no rules match a bundle.
  *

--- a/src/bsl/sample_pp/SamplePolicyProvider.h
+++ b/src/bsl/sample_pp/SamplePolicyProvider.h
@@ -202,6 +202,7 @@ typedef struct BSLP_PolicyProvider_s BSLP_PolicyProvider_t;
  * Data owned by BPA, reference should be provided to BSL library context(s)
  * @param pp_id policy provider id (must be > 0)
  * @return valid pointer to dynamically allocated policy provider
+ * @since v2.0.0 renamed from _Init() for consistency
  */
 BSLP_PolicyProvider_t *BSLP_PolicyProvider_New(uint64_t pp_id);
 
@@ -217,6 +218,7 @@ int BSLP_PolicyProvider_AddRule(BSLP_PolicyProvider_t *self, BSLP_PolicyRule_t *
  *
  * @param[in] self policy provider
  * @return The number of rules present.
+ * @since v2.0.0
  */
 size_t BSLP_PolicyProvider_RuleCount(BSLP_PolicyProvider_t *self);
 

--- a/test/fuzz_PolicyParser_LoadFd.cpp
+++ b/test/fuzz_PolicyParser_LoadFd.cpp
@@ -62,7 +62,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     if (!retval)
     {
-        BSLP_PolicyProvider_t *policy = BSLP_PolicyProvider_Init(1);
+        BSLP_PolicyProvider_t *policy = BSLP_PolicyProvider_New(1);
 
         int infd = fileno(tmp);
         if (BSL_SUCCESS != BSLP_PolicyParser_LoadFd(infd, policy))

--- a/test/test_BackendPolicyProvider.c
+++ b/test/test_BackendPolicyProvider.c
@@ -60,7 +60,7 @@ void setUp(void)
     setenv("BSL_TEST_LOCAL_IPN_EID", "ipn:2.1", 1);
     TEST_ASSERT_EQUAL(0, BSL_TestContext_Init(&LocalTestCtx));
 
-    policy_provider = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID);
+    policy_provider = BSLP_PolicyProvider_New(BSL_SAMPLE_PP_ID);
 
     BSL_PolicyDesc_t policy_desc = {
         .user_data   = policy_provider,
@@ -173,7 +173,7 @@ void test_PolicyProvider_Inspect_RFC9173_BIB(void)
  */
 void test_MultiplePolicyProviders(void)
 {
-    BSLP_PolicyProvider_t *policy_provider2 = BSLP_PolicyProvider_Init(BSL_SAMPLE_PP_ID_2);
+    BSLP_PolicyProvider_t *policy_provider2 = BSLP_PolicyProvider_New(BSL_SAMPLE_PP_ID_2);
 
     BSL_PolicyDesc_t policy_desc_2 = {
         .user_data   = policy_provider2,

--- a/test/test_DynamicMemCbs.c
+++ b/test/test_DynamicMemCbs.c
@@ -100,7 +100,7 @@ void _setUp(void)
 
     BSL_SecurityActionSet_Init(&action_set);
 
-    policy_provider = BSLP_PolicyProvider_Init(1);
+    policy_provider = BSLP_PolicyProvider_New(1);
 
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = {

--- a/test/test_PolicyParser.c
+++ b/test/test_PolicyParser.c
@@ -53,7 +53,7 @@ void setUp(void)
 {
     setenv("BSL_TEST_LOCAL_IPN_EID", "ipn:2.1", 1);
     TEST_ASSERT_EQUAL(0, BSL_TestContext_Init(&LocalTestCtx));
-    policy = BSLP_PolicyProvider_Init(1);
+    policy = BSLP_PolicyProvider_New(1);
     TEST_ASSERT_NOT_NULL(policy);
 }
 
@@ -64,35 +64,19 @@ void tearDown(void)
     TEST_ASSERT_EQUAL(0, BSL_TestContext_Deinit(&LocalTestCtx));
 }
 
-void test_PolicyParser_ReadConfigEmpty(void)
-{
-    int infd = open("test_PolicyParser-data/empty.json", O_RDONLY);
-    TEST_ASSERT_GREATER_OR_EQUAL_INT(0, infd);
-    TEST_ASSERT_EQUAL_INT(BSL_SUCCESS, BSLP_PolicyParser_LoadFd(infd, policy));
-    TEST_ASSERT_EQUAL_INT(0, close(infd));
-
-    TEST_ASSERT_EQUAL_size_t(0, BSLP_PolicyRuleList_size(policy->rules));
-    TEST_ASSERT_EQUAL_size_t(0, BSLP_PolicyPredicateList_size(policy->predicates));
-}
-
+TEST_CASE("test_PolicyParser-data/empty.json", 0)
 TEST_CASE("test_PolicyParser-data/validSC1.json", 1)
-TEST_CASE("test_PolicyParser-data/validSC2.json", 2)
-TEST_CASE("test_PolicyParser-data/validSC3-parms-long.json", 3)
-TEST_CASE("test_PolicyParser-data/validSC3-parms-short.json", 3)
-/** Read a valid configuration for a single context.
- */
-void test_PolicyParser_ReadConfigValid(const char *filename, int context_id)
+TEST_CASE("test_PolicyParser-data/validSC2.json", 1)
+TEST_CASE("test_PolicyParser-data/validSC3-parms-long.json", 1)
+TEST_CASE("test_PolicyParser-data/validSC3-parms-short.json", 1)
+void test_PolicyParser_ReadConfigValid(const char *filename, int rule_count)
 {
     int infd = open(filename, O_RDONLY);
     TEST_ASSERT_GREATER_OR_EQUAL_INT(0, infd);
     TEST_ASSERT_EQUAL_INT(BSL_SUCCESS, BSLP_PolicyParser_LoadFd(infd, policy));
     TEST_ASSERT_EQUAL_INT(0, close(infd));
 
-    TEST_ASSERT_EQUAL_size_t(1, BSLP_PolicyRuleList_size(policy->rules));
-    TEST_ASSERT_EQUAL_size_t(1, BSLP_PolicyPredicateList_size(policy->predicates));
-
-    const BSLP_PolicyRule_t *rule = BSLP_PolicyRulePtr_cref(*BSLP_PolicyRuleList_front(policy->rules));
-    TEST_ASSERT_EQUAL_INT(context_id, rule->context_id);
+    TEST_ASSERT_EQUAL_size_t(rule_count, BSLP_PolicyProvider_RuleCount(policy));
 }
 
 TEST_CASE("test_PolicyParser-data/unknownSC-99.json")
@@ -103,6 +87,5 @@ void test_PolicyParser_ReadConfigInvalid(const char *filename)
     TEST_ASSERT_NOT_EQUAL_INT(BSL_SUCCESS, BSLP_PolicyParser_LoadFd(infd, policy));
     TEST_ASSERT_EQUAL_INT(0, close(infd));
 
-    TEST_ASSERT_EQUAL_size_t(0, BSLP_PolicyRuleList_size(policy->rules));
-    TEST_ASSERT_EQUAL_size_t(0, BSLP_PolicyPredicateList_size(policy->predicates));
+    TEST_ASSERT_EQUAL_size_t(0, BSLP_PolicyProvider_RuleCount(policy));
 }

--- a/test/test_PublicInterfaceImpl.c
+++ b/test/test_PublicInterfaceImpl.c
@@ -59,7 +59,7 @@ void setUp(void)
     TEST_ASSERT_EQUAL(0, BSL_TestContext_Init(&LocalTestCtx));
     BSL_TestUtils_SetupDefaultSecurityContext(&LocalTestCtx.bsl);
     BSL_SecurityActionSet_Init(&action_set);
-    policy_provider = BSLP_PolicyProvider_Init(1);
+    policy_provider = BSLP_PolicyProvider_New(1);
 
     /// Register the policy provider with some rules
     BSL_PolicyDesc_t policy_desc = {


### PR DESCRIPTION
This moves struct implementation detail out of the public header for compatibility.

Closes #315